### PR TITLE
Fix error behaviour of the parser.

### DIFF
--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/SGLRParseResult.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/SGLRParseResult.java
@@ -1,13 +1,9 @@
 package org.spoofax.jsglr.client;
 
-
 public class SGLRParseResult {
-    public final CompletionStateSet completionStates;
     public final Object output;
 
-
-    public SGLRParseResult(CompletionStateSet resultCompletionStates, Object output) {
-        this.completionStates = resultCompletionStates;
+    public SGLRParseResult(Object output) {
         this.output = output;
     }
 }


### PR DESCRIPTION
The parser used to return a `SGLRParseResult` with old completion states even in case of failures.
The completion states are no longer used and bad error handling in the JSGLRI made it ignore parse errors.
Therefore we simplified the behaviour of the parser:

If parsing failed and we may try to recover, we do so.
If recovery fails, we throw a fatal exception.
If recovery succeeds, but the caller is not interested in the AST, we throw a fatal exception (after all, normal parsing failed).
If recovery claims to have succeeded, but the Disambiguator rejected the recovery, we throw a fatal exception.
We do this because normal parsing failed, and a rejected AST is a null value, so recovery actually didn't really succeed, it just claimed to.

Therefore, the result of parsing is either a fatal exception that is thrown, or a non-null `SGLRParseResult`.
The AST of the `SGLRParseResult` may only be null if a `NullTreeBuilder` was used (i.e., when the caller indicated not to want an AST).