### PR TITLE
Depend on sdf2table from org.metaborg.spoofax.nativebundle for JSGLR2 tests

### DIFF
--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/BaseBenchmark.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/BaseBenchmark.java
@@ -90,9 +90,9 @@ public abstract class BaseBenchmark implements WithGrammar {
         new File(basePath + "/grammars").mkdirs();
         
         InputStream defResourceInJar = getClass().getResourceAsStream("/grammars/" + grammarName + ".def");
-        String destinationInJarDir = basePath + "/grammars/" + grammarName + ".def";
+        String destinationInTargetDir = basePath + "/grammars/" + grammarName + ".def";
         
-        Files.copy(defResourceInJar, Paths.get(destinationInJarDir), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(defResourceInJar, Paths.get(destinationInTargetDir), StandardCopyOption.REPLACE_EXISTING);
     }
 
     protected String getFileAsString(String filename) throws IOException {

--- a/org.spoofax.jsglr2/pom.xml
+++ b/org.spoofax.jsglr2/pom.xml
@@ -27,6 +27,12 @@
 			<artifactId>org.spoofax.jsglr</artifactId>
 			<version>${metaborg-version}</version>
 		</dependency>
+		
+	    <dependency>
+	      <groupId>org.metaborg</groupId>
+	      <artifactId>org.metaborg.spoofax.nativebundle</artifactId>
+	      <version>${metaborg-version}</version>
+	    </dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/util/Sdf2Table.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/util/Sdf2Table.java
@@ -1,0 +1,35 @@
+package org.spoofax.jsglr2.util;
+
+import java.io.InputStream;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.metaborg.spoofax.nativebundle.NativeBundle;
+
+public class Sdf2Table {
+	
+	public static InputStream getNativeInputStream() {
+		return getResourceAsStream(getNativeDirectory() + NativeBundle.getSdf2TableName());
+	}
+
+	public static String getNativeDirectory() {
+        if(SystemUtils.IS_OS_WINDOWS) {
+            return "native/cygwin/";
+        } else if(SystemUtils.IS_OS_MAC_OSX) {
+            return "native/macosx/";
+        } else if(SystemUtils.IS_OS_LINUX) {
+            return "native/linux/";
+        } else {
+            throw new UnsupportedOperationException("Unsupported platform " + SystemUtils.OS_NAME);
+        }
+    }
+	
+	private static InputStream getResourceAsStream(String name) {
+        final InputStream inputStream = NativeBundle.class.getResourceAsStream(name);
+        
+        if(inputStream == null)
+            throw new IllegalStateException("Resource " + name + " cannot be found in the native bundle");
+
+        return inputStream;
+    }
+	
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/util/WithGrammar.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/util/WithGrammar.java
@@ -1,7 +1,14 @@
 package org.spoofax.jsglr2.util;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
+import org.metaborg.spoofax.nativebundle.NativeBundle;
 import org.spoofax.jsglr.client.InvalidParseTableException;
 import org.spoofax.jsglr2.parsetable.ParseTableReadException;
 import org.spoofax.terms.ParseError;
@@ -15,13 +22,15 @@ public interface WithGrammar extends WithParseTable {
         return path;
     }
 	
-	default void setupParseTableFromDefFile(String grammarName) throws InterruptedException, IOException, ParseError, ParseTableReadException, InvalidParseTableException {
+	default void setupParseTableFromDefFile(String grammarName) throws InterruptedException, IOException, ParseError, ParseTableReadException, InvalidParseTableException, URISyntaxException {
 	    setupDefFile(grammarName);
 	    
         String grammarDefPath     = grammarsPath() + "/" + grammarName + ".def",
                parseTableTermPath = grammarsPath() + "/" + grammarName + ".tbl";
         
-        String command = "sdf2table -i " + grammarDefPath + " -o " + parseTableTermPath + " -m " + grammarName + " -t";
+        String sdf2tablePath = setupSdf2Table();
+        
+        String command = sdf2tablePath + " -i " + grammarDefPath + " -o " + parseTableTermPath + " -m " + grammarName + " -t";
         
         Process sdf2tableProcess = Runtime.getRuntime().exec(command);
         int sdf2tableExitCode = sdf2tableProcess.waitFor();
@@ -31,6 +40,23 @@ public interface WithGrammar extends WithParseTable {
         
         setupParseTableByFilename("grammars/" + grammarName + ".tbl");
     }
+	
+	default String setupSdf2Table() throws URISyntaxException, IOException {
+		String targetPath = new File(WithGrammar.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath()).getParent(); // Path of the target directory
+        
+		// Create a separate directory for the native sdf2table file
+        new File(targetPath + "/native").mkdirs();
+		
+        String pathInTargetDir = targetPath + "/native/" + NativeBundle.getSdf2TableName();
+        
+        // Copy the sdf2table executable to the target/native directory
+        Files.copy(Sdf2Table.getNativeInputStream(), Paths.get(pathInTargetDir), StandardCopyOption.REPLACE_EXISTING);
+        
+        // Make it executable
+        new File(pathInTargetDir).setExecutable(true);
+        
+        return pathInTargetDir;
+	}
     
     default void setupDefFile(String grammarName) throws IOException {}
 	

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/grammars/SumAmbiguousTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/grammars/SumAmbiguousTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.grammars;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -11,7 +12,7 @@ import org.spoofax.terms.ParseError;
 
 public class SumAmbiguousTest extends BaseTestWithJSGLR1 implements WithGrammar {
 	
-	public SumAmbiguousTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public SumAmbiguousTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 		setupParseTableFromDefFile("sum-ambiguous");
 	}
 

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/grammars/SumNonAmbiguousTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/grammars/SumNonAmbiguousTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.grammars;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -11,7 +12,7 @@ import org.spoofax.terms.ParseError;
 
 public class SumNonAmbiguousTest extends BaseTestWithJSGLR1 implements WithGrammar {
 	
-	public SumNonAmbiguousTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public SumNonAmbiguousTest() throws ParseError, InterruptedException, IOException, ParseTableReadException, InvalidParseTableException, URISyntaxException {
 		setupParseTableFromDefFile("sum-nonambiguous");
 	}
 

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/parser/CommentsTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/parser/CommentsTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.parser;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -11,7 +12,7 @@ import org.spoofax.terms.ParseError;
 
 public class CommentsTest extends BaseTest implements WithGrammar {
 	
-	public CommentsTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public CommentsTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 	    setupParseTableFromDefFile("comments");
 	}
     

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/parser/IntersectionTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/parser/IntersectionTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.parser;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.spoofax.jsglr.client.InvalidParseTableException;
 import org.spoofax.jsglr2.parsetable.ParseTableReadException;
@@ -10,7 +11,7 @@ import org.spoofax.terms.ParseError;
 
 public class IntersectionTest extends BaseTest implements WithGrammar {
 	
-	public IntersectionTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public IntersectionTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 	    setupParseTableFromDefFile("intersection");
 	}
 	

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/parser/LookaheadTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/parser/LookaheadTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.parser;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -11,7 +12,7 @@ import org.spoofax.terms.ParseError;
 
 public class LookaheadTest extends BaseTest implements WithGrammar {
 	
-	public LookaheadTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public LookaheadTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 	    setupParseTableFromDefFile("lookahead");
 	}
     

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/KernelTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/KernelTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.sdf;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -11,7 +12,7 @@ import org.spoofax.terms.ParseError;
 
 public class KernelTest extends BaseTestWithJSGLR1 implements WithGrammar {
 	
-	public KernelTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public KernelTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 	    setupParseTableFromDefFile("kernel");
 	}
     

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/LexicalTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/LexicalTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.sdf;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -12,7 +13,7 @@ import org.spoofax.terms.ParseError;
 
 public class LexicalTest extends BaseTest implements WithJSGLR1, WithGrammar {
 	
-	public LexicalTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public LexicalTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 		setupParseTableFromDefFile("lexical-id");
 	}
 

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/ListsTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/ListsTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.sdf;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -12,7 +13,7 @@ import org.spoofax.terms.ParseError;
 
 public class ListsTest extends BaseTest implements WithJSGLR1, WithGrammar {
 	
-	public ListsTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public ListsTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 		setupParseTableFromDefFile("lists");
 	}
 

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/LiteralsTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/LiteralsTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.sdf;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -12,7 +13,7 @@ import org.spoofax.terms.ParseError;
 
 public class LiteralsTest extends BaseTest implements WithJSGLR1, WithGrammar {
 	
-	public LiteralsTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public LiteralsTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 		setupParseTableFromDefFile("literals");
 	}
 

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/OptionalsTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/OptionalsTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.sdf;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -12,7 +13,7 @@ import org.spoofax.terms.ParseError;
 
 public class OptionalsTest extends BaseTest implements WithGrammar {
 	
-	public OptionalsTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public OptionalsTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 		setupParseTableFromDefFile("optionals");
 	}
 

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/PreferAvoidTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/PreferAvoidTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.sdf;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -11,7 +12,7 @@ import org.spoofax.terms.ParseError;
 
 public class PreferAvoidTest extends BaseTestWithJSGLR1 implements WithGrammar {
 	
-	public PreferAvoidTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public PreferAvoidTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 		setupParseTableFromDefFile("prefer-avoid");
 	}
 

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/SdfSyntaxTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/tests/sdf/SdfSyntaxTest.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tests.sdf;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.spoofax.jsglr.client.InvalidParseTableException;
@@ -12,7 +13,7 @@ import org.spoofax.terms.ParseError;
 
 public class SdfSyntaxTest extends BaseTest implements WithJSGLR1, WithGrammar {
 	
-	public SdfSyntaxTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException {
+	public SdfSyntaxTest() throws ParseError, ParseTableReadException, IOException, InvalidParseTableException, InterruptedException, URISyntaxException {
 		setupParseTableFromDefFile("sdf-syntax");
 	}
 


### PR DESCRIPTION
After merging JSGLR2 [the build failed](http://buildfarm.metaborg.org/job/metaborg/job/spoofax-releng/job/master/421/console) because it depended on `sdf2table` on the path. This PR copies the native `sdf2table` from `org.metaborg.spoofax.nativebundle` to the target directory of `org.metaborg.jsglr2` and sets it as executable. This `sdf2table` is then used for parse table generation for the tests instead of the local one. Fixed the problem for me after reproducing it locally by removing `sdf2table` from my path.