### PR TITLE
Copy sdf2table to target directory only once

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/util/WithGrammar.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/util/WithGrammar.java
@@ -2,7 +2,6 @@ package org.spoofax.jsglr2.util;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -49,11 +48,13 @@ public interface WithGrammar extends WithParseTable {
 		
         String pathInTargetDir = targetPath + "/native/" + NativeBundle.getSdf2TableName();
         
-        // Copy the sdf2table executable to the target/native directory
-        Files.copy(Sdf2Table.getNativeInputStream(), Paths.get(pathInTargetDir), StandardCopyOption.REPLACE_EXISTING);
-        
-        // Make it executable
-        new File(pathInTargetDir).setExecutable(true);
+        if (!new File(pathInTargetDir).exists()) { // Only copy sdf2table to the target directory once
+        		// Copy the sdf2table executable to the target/native directory
+	        Files.copy(Sdf2Table.getNativeInputStream(), Paths.get(pathInTargetDir), StandardCopyOption.REPLACE_EXISTING);
+	        
+	        // Make it executable
+	        new File(pathInTargetDir).setExecutable(true);
+        }
         
         return pathInTargetDir;
 	}


### PR DESCRIPTION
The [build still failed](http://buildfarm.metaborg.org/job/metaborg/job/spoofax-releng/job/master/422/console) after #7. This PR makes sure the native `sdf2table` is only copied once to the target directory.