### PR TITLE
Add JSGLR2 primitive

### DIFF
--- a/org.spoofax.interpreter.library.jsglr/pom.xml
+++ b/org.spoofax.interpreter.library.jsglr/pom.xml
@@ -22,6 +22,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.metaborg</groupId>
+			<artifactId>org.spoofax.jsglr2</artifactId>
+			<version>${metaborg-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.metaborg</groupId>
 			<artifactId>org.spoofax.interpreter.core</artifactId>
 			<version>${metaborg-version}</version>
 		</dependency>

--- a/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/STRSGLR2_parse_implode_stream_pt.java
+++ b/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/STRSGLR2_parse_implode_stream_pt.java
@@ -1,0 +1,75 @@
+package org.spoofax.interpreter.library.jsglr;
+
+import org.metaborg.parsetable.IParseTable;
+import org.spoofax.interpreter.core.IContext;
+import org.spoofax.interpreter.core.InterpreterException;
+import org.spoofax.interpreter.core.Tools;
+import org.spoofax.interpreter.library.ssl.SSLLibrary;
+import org.spoofax.interpreter.stratego.Strategy;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.jsglr2.JSGLR2;
+import org.spoofax.jsglr2.parseforest.hybrid.HybridParseForest;
+import org.spoofax.jsglr2.parsetable.ParseTableReadException;
+
+import java.io.IOException;
+
+/**
+ * @author Jeff Smits <j.smits-1@tudelft.nl>
+ */
+public class STRSGLR2_parse_implode_stream_pt extends JSGLRPrimitive {
+	private final static String NAME = "STRSGLR2_parse_implode_stream_pt";
+
+	STRSGLR2_parse_implode_stream_pt() {
+		super(NAME, 0, 4);
+	}
+	
+	/**
+	 * tvars: [input, table, startsymbol, path]
+	 */
+	@Override
+	public boolean call(IContext env, Strategy[] svars, IStrategoTerm[] tvars)
+			throws InterpreterException {
+
+		if (!Tools.isTermString(tvars[0]))
+			return false;
+		if (!Tools.isTermInt(tvars[1]))
+			return false;
+		if(!Tools.isTermString(tvars[3]))
+			return false;
+
+		String startSymbol = STRSGLR_parse_string_pt.computeStartSymbol(tvars[2]);
+		//noinspection StringEquality
+		if(startSymbol == STRSGLR_parse_string_pt.INVALID)
+			return false;
+
+		String input;
+		try {
+			input = STRSGLR_parse_stream_pt.readFile(SSLLibrary.instance(env).getIOAgent(), Tools.asJavaInt(tvars[0]));
+		} catch (IOException e) {
+			IStrategoTerm errorTerm = env.getFactory().makeString(e.getMessage());
+			env.setCurrent(errorTerm);
+			return svars[0].evaluate(env);
+		}
+
+		IParseTable table = getLibrary(env).getV2ParseTable(Tools.asJavaInt(tvars[1]));
+		String lastPath = Tools.asJavaString(tvars[3]);
+
+		IStrategoTerm result = doParse(input, startSymbol, table, lastPath);
+		if (result == null) {
+			return false;
+		}
+
+		env.setCurrent(result);
+		return true;
+	}
+
+	private static IStrategoTerm doParse(String input, String startSymbol, IParseTable pt, String path) {
+		try {
+			JSGLR2<HybridParseForest, IStrategoTerm> parser = JSGLR2.standard(pt);
+			return parser.parse(input, path, startSymbol);
+		} catch (ParseTableReadException e) {
+			return null;
+		}
+	}
+
+}

--- a/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/STRSGLR2_parse_implode_stream_pt.java
+++ b/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/STRSGLR2_parse_implode_stream_pt.java
@@ -30,7 +30,7 @@ public class STRSGLR2_parse_implode_stream_pt extends JSGLRPrimitive {
 	public boolean call(IContext env, Strategy[] svars, IStrategoTerm[] tvars)
 			throws InterpreterException {
 
-		if (!Tools.isTermString(tvars[0]))
+		if (!Tools.isTermInt(tvars[0]))
 			return false;
 		if (!Tools.isTermInt(tvars[1]))
 			return false;

--- a/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/STRSGLR_open_parse_table.java
+++ b/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/STRSGLR_open_parse_table.java
@@ -5,15 +5,15 @@
  */
 package org.spoofax.interpreter.library.jsglr;
 
-import java.util.Map;
-
 import org.spoofax.interpreter.core.IContext;
 import org.spoofax.interpreter.core.InterpreterException;
 import org.spoofax.interpreter.stratego.Strategy;
 import org.spoofax.interpreter.terms.IStrategoInt;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.InvalidParseTableException;
-import org.spoofax.jsglr.client.ParseTable;
+import org.spoofax.jsglr2.parsetable.ParseTableReadException;
+
+import java.util.Map;
 
 public class STRSGLR_open_parse_table extends JSGLRPrimitive {
 
@@ -28,23 +28,23 @@ public class STRSGLR_open_parse_table extends JSGLRPrimitive {
 		Map<IStrategoTerm, IStrategoInt> cache = getLibrary(env).getParseTableCache();
 
 		IStrategoInt cached = cache.get(tvars[0]);
-	    if (cached != null) {
-	        env.setCurrent(cached);
-	        if(!cache.containsValue(cached))
-	        	throw new IllegalStateException("Inconsistent context: wrong JSGLR library instance");
-	        return true;
-	    }
+		if (cached != null) {
+			env.setCurrent(cached);
+			if(!cache.containsValue(cached))
+				throw new IllegalStateException("Inconsistent context: wrong JSGLR library instance");
+			return true;
+		}
 
-	    IStrategoTerm tableTerm = tvars[0];
+		IStrategoTerm tableTerm = tvars[0];
 
 		JSGLRLibrary lib = getLibrary(env);
 		try {
-			ParseTable pt = lib.getParseTableManager(env.getFactory()).loadFromTerm(tableTerm);
-			IStrategoInt result = env.getFactory().makeInt(lib.addParseTable(pt));
+			int ptPos = lib.addParseTable(env.getFactory(), tableTerm);
+			IStrategoInt result = env.getFactory().makeInt(ptPos);
 
 			env.setCurrent(result);
 			cache.put(tvars[0], result);
-		} catch (InvalidParseTableException e) {
+		} catch (ParseTableReadException | InvalidParseTableException e) {
 			e.printStackTrace();
 			return false;
 		}

--- a/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/STRSGLR_parse_stream_pt.java
+++ b/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/STRSGLR_parse_stream_pt.java
@@ -80,7 +80,7 @@ public class STRSGLR_parse_stream_pt extends JSGLRPrimitive {
 		return new Asfix2TreeBuilder(env.getFactory());
 	}
 
-	private String readFile(IOAgent io, int fd) throws IOException {
+	static String readFile(IOAgent io, int fd) throws IOException {
 		BufferedReader br = new BufferedReader(io.getReader(fd));
 		StringBuilder sb = new StringBuilder();
 		do {

--- a/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/STRSGLR_parse_string_pt.java
+++ b/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/STRSGLR_parse_string_pt.java
@@ -29,7 +29,7 @@ public class STRSGLR_parse_string_pt extends JSGLRPrimitive {
 
 	public final static String NAME = "STRSGLR_parse_string_pt";
 
-	private final static String INVALID = "";
+	final static String INVALID = "";
 
 	private SGLRException lastException;
 


### PR DESCRIPTION
The idea is that the stratego compiler can try to use this new primitive and fall back on JSGLR1 with its error recovery on parse fail. See also the [use-jsglr2 branch in strategoxt](https://github.com/metaborg/strategoxt/commit/ac0275a7b1e37ad82de95f63e0f1da8bce147e85). 