### PR TITLE
Refactor ParseForest node classes

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentReduceManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentReduceManager.java
@@ -11,6 +11,7 @@ import org.metaborg.sdf2table.grammar.IProduction;
 import org.metaborg.sdf2table.grammar.Symbol;
 import org.metaborg.sdf2table.parsetable.ParseTableProduction;
 import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
@@ -20,8 +21,12 @@ import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.StackManager;
 import org.spoofax.jsglr2.stack.paths.StackPath;
 
-public class DataDependentReduceManager<ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation, StackNode extends AbstractStackNode<ParseForest>>
-    extends ReduceManager<ParseForest, ParseNode, Derivation, StackNode> {
+public class DataDependentReduceManager<
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>,
+        StackNode extends AbstractStackNode<ParseForest>
+        > extends ReduceManager<ParseForest, ParseNode, Derivation, StackNode> {
    
 
     public DataDependentReduceManager(IParseTable parseTable, StackManager<ParseForest, StackNode> stackManager,

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentRuleNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentRuleNode.java
@@ -77,6 +77,10 @@ public class DataDependentRuleNode extends BasicParseForest implements IDerivati
         return production;
     }
 
+    public ProductionType productionType() {
+        return productionType;
+    }
+
     public BasicParseForest[] parseForests() {
         return parseForests;
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentSymbolNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentSymbolNode.java
@@ -4,76 +4,29 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.metaborg.parsetable.IProduction;
+import org.spoofax.jsglr2.parseforest.basic.IBasicSymbolNode;
 import org.spoofax.jsglr2.parseforest.basic.BasicParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.Position;
 
-public class DataDependentSymbolNode extends BasicParseForest {
+public class DataDependentSymbolNode extends BasicParseForest implements IBasicSymbolNode<BasicParseForest, DataDependentRuleNode> {
 
-	public final IProduction production;
-	private final List<DataDependentRuleNode> derivations;
-	
-	public DataDependentSymbolNode(int nodeNumber, AbstractParse<?, ?> parse, Position startPosition, Position endPosition, IProduction production) {
-		super(nodeNumber, parse, startPosition, endPosition);
-		this.production = production;
-		this.derivations = new ArrayList<DataDependentRuleNode>();
-	}
-	
-	public void addDerivation(DataDependentRuleNode derivation) {
-		this.derivations.add(derivation);
-	}
-	
-	public List<DataDependentRuleNode> getDerivations() {
-		return derivations;
-	}
-    
-    public List<DataDependentRuleNode> getPreferredAvoidedDerivations() {
-        if (derivations.size() <= 1)
-            return derivations;
-        else {
-            List<DataDependentRuleNode> preferred = null, avoided = null, other = null;
-            
-            for (DataDependentRuleNode derivation : derivations) {
-                switch (derivation.productionType) {
-                    case PREFER:
-                        if (preferred == null)
-                            preferred = new ArrayList<DataDependentRuleNode>();
-                        
-                        preferred.add(derivation);
-                        break;
-                    case AVOID:
-                        if (avoided == null)
-                            avoided = new ArrayList<DataDependentRuleNode>();
-                        
-                        avoided.add(derivation);
-                        break;
-                    default:
-                        if (other == null)
-                            other = new ArrayList<DataDependentRuleNode>();
-                        
-                        other.add(derivation);
-                }
-            }
-            
-            if (preferred != null && !preferred.isEmpty())
-                return preferred;
-            else if (other != null && !other.isEmpty())
-                return other;
-            else
-                return avoided;
-        }
+    public final IProduction production;
+    private final List<DataDependentRuleNode> derivations = new ArrayList<>();
+
+    public DataDependentSymbolNode(int nodeNumber, AbstractParse<?, ?> parse, Position startPosition, Position endPosition,
+                                   IProduction production) {
+        super(nodeNumber, parse, startPosition, endPosition);
+        this.production = production;
     }
-	
-	public DataDependentRuleNode getOnlyDerivation() {
-		return derivations.get(0);
-	}
-	
-	public boolean isAmbiguous() {
-		return derivations.size() > 1;
-	}
-	
-	public String descriptor() {
-		return production.descriptor();
-	}
-	
+
+    @Override
+    public String descriptor() {
+        return production.descriptor();
+    }
+
+    @Override
+    public List<DataDependentRuleNode> getDerivations() {
+        return derivations;
+    }
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/ElkhoundParser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/ElkhoundParser.java
@@ -8,17 +8,22 @@ import org.metaborg.parsetable.actions.IAction;
 import org.metaborg.parsetable.actions.IReduce;
 import org.metaborg.parsetable.actions.IShift;
 import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Parse;
 import org.spoofax.jsglr2.parser.ParseFactory;
 import org.spoofax.jsglr2.parser.Parser;
 import org.spoofax.jsglr2.stack.StackManager;
 import org.spoofax.jsglr2.stack.collections.IActiveStacksFactory;
 import org.spoofax.jsglr2.stack.collections.IForActorStacksFactory;
 
-public class ElkhoundParser<ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation, ElkhoundStackNode extends AbstractElkhoundStackNode<ParseForest>, Parse extends AbstractParse<ParseForest, ElkhoundStackNode>>
-    extends Parser<ParseForest, ParseNode, Derivation, ElkhoundStackNode, Parse> {
+public class ElkhoundParser<
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>,
+        ElkhoundStackNode extends AbstractElkhoundStackNode<ParseForest>,
+        Parse extends AbstractParse<ParseForest, ElkhoundStackNode>
+        > extends Parser<ParseForest, ParseNode, Derivation, ElkhoundStackNode, Parse> {
 
     public ElkhoundParser(ParseFactory<ParseForest, ElkhoundStackNode, Parse> parseFactory, IParseTable parseTable,
         IActiveStacksFactory activeStacksFactory, IForActorStacksFactory forActorStacksFactory,

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/ElkhoundReduceManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/ElkhoundReduceManager.java
@@ -4,6 +4,7 @@ import org.metaborg.parsetable.IParseTable;
 import org.metaborg.parsetable.IState;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
@@ -11,8 +12,12 @@ import org.spoofax.jsglr2.reducing.ReduceManager;
 import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.paths.StackPath;
 
-public class ElkhoundReduceManager<ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation, ElkhoundStackNode extends AbstractElkhoundStackNode<ParseForest>>
-    extends ReduceManager<ParseForest, ParseNode, Derivation, ElkhoundStackNode> {
+public class ElkhoundReduceManager<
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>,
+        ElkhoundStackNode extends AbstractElkhoundStackNode<ParseForest>
+        > extends ReduceManager<ParseForest, ParseNode, Derivation, ElkhoundStackNode> {
 
     protected final AbstractElkhoundStackManager<ParseForest, ElkhoundStackNode> stackManager;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
@@ -6,6 +6,7 @@ import org.metaborg.parsetable.actions.IReduce;
 import org.metaborg.sdf2table.grammar.LayoutConstraintAttribute;
 import org.metaborg.sdf2table.parsetable.ParseTableProduction;
 import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
@@ -15,8 +16,12 @@ import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.StackManager;
 import org.spoofax.jsglr2.stack.paths.StackPath;
 
-public class LayoutSensitiveReduceManager<ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation, StackNode extends AbstractStackNode<ParseForest>>
-    extends ReduceManager<ParseForest, ParseNode, Derivation, StackNode> {
+public class LayoutSensitiveReduceManager<
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>,
+        StackNode extends AbstractStackNode<ParseForest>
+        > extends ReduceManager<ParseForest, ParseNode, Derivation, StackNode> {
 
     LayoutConstraintEvaluator<ParseForest> lce = new LayoutConstraintEvaluator<>();
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveSymbolNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveSymbolNode.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.metaborg.parsetable.IProduction;
+import org.spoofax.jsglr2.parseforest.basic.IBasicSymbolNode;
 import org.spoofax.jsglr2.parseforest.basic.BasicParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.Position;
@@ -11,7 +12,7 @@ import org.spoofax.jsglr2.parser.PositionInterval;
 
 import com.google.common.collect.Lists;
 
-public class LayoutSensitiveSymbolNode extends BasicParseForest {
+public class LayoutSensitiveSymbolNode extends BasicParseForest implements IBasicSymbolNode<BasicParseForest, LayoutSensitiveRuleNode> {
 
     public final IProduction production; // left hand side non-terminal
     private final List<LayoutSensitiveRuleNode> derivations;
@@ -25,10 +26,6 @@ public class LayoutSensitiveSymbolNode extends BasicParseForest {
         this.derivations = new ArrayList<LayoutSensitiveRuleNode>();
     }
 
-    public void addDerivation(LayoutSensitiveRuleNode derivation) {
-        this.derivations.add(derivation);
-    }
-
     public IProduction getProduction() {
         return production;
     }
@@ -37,52 +34,8 @@ public class LayoutSensitiveSymbolNode extends BasicParseForest {
         return derivations;
     }
 
-    public List<LayoutSensitiveRuleNode> getPreferredAvoidedDerivations() {
-        if(derivations.size() <= 1)
-            return derivations;
-        else {
-            List<LayoutSensitiveRuleNode> preferred = null, avoided = null, other = null;
-
-            for(LayoutSensitiveRuleNode derivation : derivations) {
-                switch(derivation.productionType) {
-                    case PREFER:
-                        if(preferred == null)
-                            preferred = new ArrayList<LayoutSensitiveRuleNode>();
-
-                        preferred.add(derivation);
-                        break;
-                    case AVOID:
-                        if(avoided == null)
-                            avoided = new ArrayList<LayoutSensitiveRuleNode>();
-
-                        avoided.add(derivation);
-                        break;
-                    default:
-                        if(other == null)
-                            other = new ArrayList<LayoutSensitiveRuleNode>();
-
-                        other.add(derivation);
-                }
-            }
-
-            if(preferred != null && !preferred.isEmpty())
-                return preferred;
-            else if(other != null && !other.isEmpty())
-                return other;
-            else
-                return avoided;
-        }
-    }
-
-    public LayoutSensitiveRuleNode getOnlyDerivation() {
-        return derivations.get(0);
-    }
-
-    public boolean isAmbiguous() {
-        return derivations.size() > 1;
-    }
-
-    @Override public String descriptor() {
+    @Override
+    public String descriptor() {
         return production.descriptor();
     }
 
@@ -134,10 +87,10 @@ public class LayoutSensitiveSymbolNode extends BasicParseForest {
              derivations.clear();
              derivations.add(longestDerivation);
          }
-         
+
          longestMatchPos = longestMatchNodes.get(currentLongestDerivation);
     }
-    
+
     private Boolean expandsLonger(PositionInterval pos1, PositionInterval pos2) {
         assert (pos1.getStart().equals(pos2.getStart()));
 
@@ -160,7 +113,7 @@ public class LayoutSensitiveSymbolNode extends BasicParseForest {
         } else {
             return longestMatchPos;
         }
-        
+
     }
 
     // @Override public String toString() {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/IDerivation.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/IDerivation.java
@@ -1,10 +1,13 @@
 package org.spoofax.jsglr2.parseforest;
 
 import org.metaborg.parsetable.IProduction;
+import org.metaborg.parsetable.ProductionType;
 
-public interface IDerivation<ParseForest> {
+public interface IDerivation<ParseForest extends AbstractParseForest> {
 
     IProduction production();
+
+    ProductionType productionType();
 
     ParseForest[] parseForests();
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ISymbolNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ISymbolNode.java
@@ -1,0 +1,53 @@
+package org.spoofax.jsglr2.parseforest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public interface ISymbolNode<ParseForest extends AbstractParseForest, Derivation extends IDerivation<ParseForest>> {
+
+    void addDerivation(Derivation derivation);
+
+    Iterable<Derivation> getDerivations();
+
+    default List<Derivation> getPreferredAvoidedDerivations() {
+        if (!isAmbiguous())
+            return Collections.singletonList(getOnlyDerivation());
+        else {
+            List<Derivation> preferred = null, avoided = null, other = null;
+
+            for (Derivation derivation : getDerivations()) {
+                switch (derivation.productionType()) {
+                    case PREFER:
+                        if (preferred == null)
+                            preferred = new ArrayList<>();
+
+                        preferred.add(derivation);
+                        break;
+                    case AVOID:
+                        if (avoided == null)
+                            avoided = new ArrayList<>();
+
+                        avoided.add(derivation);
+                        break;
+                    default:
+                        if (other == null)
+                            other = new ArrayList<>();
+
+                        other.add(derivation);
+                }
+            }
+
+            if (preferred != null && !preferred.isEmpty())
+                return preferred;
+            else if (other != null && !other.isEmpty())
+                return other;
+            else
+                return avoided;
+        }
+    }
+
+    Derivation getOnlyDerivation();
+
+    boolean isAmbiguous();
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ParseForestManager.java
@@ -5,7 +5,10 @@ import org.metaborg.parsetable.ProductionType;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.Position;
 
-public abstract class ParseForestManager<ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation> {
+public abstract class ParseForestManager<
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>> {
 
     abstract public ParseNode createParseNode(AbstractParse<ParseForest, ?> parse, Position beginPosition,
         IProduction production, Derivation firstDerivation);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/IBasicSymbolNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/IBasicSymbolNode.java
@@ -1,0 +1,31 @@
+package org.spoofax.jsglr2.parseforest.basic;
+
+import java.util.List;
+
+import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
+import org.spoofax.jsglr2.parseforest.ISymbolNode;
+
+public interface IBasicSymbolNode<
+        ParseForest extends AbstractParseForest,
+        Derivation extends IDerivation<ParseForest>
+        > extends ISymbolNode<ParseForest, Derivation> {
+
+    @Override
+    default void addDerivation(Derivation derivation) {
+        this.getDerivations().add(derivation);
+    }
+
+    @Override
+    List<Derivation> getDerivations();
+
+    @Override
+    default Derivation getOnlyDerivation() {
+        return getDerivations().get(0);
+    }
+
+    @Override
+    default boolean isAmbiguous() {
+        return getDerivations().size() > 1;
+    }
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/RuleNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/RuleNode.java
@@ -31,6 +31,11 @@ public class RuleNode extends BasicParseForest implements IDerivation<BasicParse
     }
 
     @Override
+    public ProductionType productionType() {
+        return productionType;
+    }
+
+    @Override
     public BasicParseForest[] parseForests() {
         return parseForests;
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/SymbolNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/SymbolNode.java
@@ -7,69 +7,15 @@ import org.metaborg.parsetable.IProduction;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.Position;
 
-public class SymbolNode extends BasicParseForest {
+public class SymbolNode extends BasicParseForest implements IBasicSymbolNode<BasicParseForest, RuleNode> {
 
     public final IProduction production;
-    private final List<RuleNode> derivations;
+    private final List<RuleNode> derivations = new ArrayList<>();
 
     public SymbolNode(int nodeNumber, AbstractParse<?, ?> parse, Position startPosition, Position endPosition,
-        IProduction production) {
+                      IProduction production) {
         super(nodeNumber, parse, startPosition, endPosition);
         this.production = production;
-        this.derivations = new ArrayList<RuleNode>();
-    }
-
-    public void addDerivation(RuleNode derivation) {
-        this.derivations.add(derivation);
-    }
-
-    public List<RuleNode> getDerivations() {
-        return derivations;
-    }
-
-    public List<RuleNode> getPreferredAvoidedDerivations() {
-        if(derivations.size() <= 1)
-            return derivations;
-        else {
-            List<RuleNode> preferred = null, avoided = null, other = null;
-
-            for(RuleNode derivation : derivations) {
-                switch(derivation.productionType) {
-                    case PREFER:
-                        if(preferred == null)
-                            preferred = new ArrayList<RuleNode>();
-
-                        preferred.add(derivation);
-                        break;
-                    case AVOID:
-                        if(avoided == null)
-                            avoided = new ArrayList<RuleNode>();
-
-                        avoided.add(derivation);
-                        break;
-                    default:
-                        if(other == null)
-                            other = new ArrayList<RuleNode>();
-
-                        other.add(derivation);
-                }
-            }
-
-            if(preferred != null && !preferred.isEmpty())
-                return preferred;
-            else if(other != null && !other.isEmpty())
-                return other;
-            else
-                return avoided;
-        }
-    }
-
-    public RuleNode getOnlyDerivation() {
-        return derivations.get(0);
-    }
-
-    public boolean isAmbiguous() {
-        return derivations.size() > 1;
     }
 
     @Override
@@ -77,4 +23,8 @@ public class SymbolNode extends BasicParseForest {
         return production.descriptor();
     }
 
+    @Override
+    public List<RuleNode> getDerivations() {
+        return derivations;
+    }
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/hybrid/Derivation.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/hybrid/Derivation.java
@@ -23,6 +23,11 @@ public class Derivation implements IDerivation<HybridParseForest> {
     }
 
     @Override
+    public ProductionType productionType() {
+        return productionType;
+    }
+
+    @Override
     public HybridParseForest[] parseForests() {
         return parseForests;
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/hybrid/ParseNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/hybrid/ParseNode.java
@@ -1,17 +1,17 @@
 package org.spoofax.jsglr2.parseforest.hybrid;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.metaborg.parsetable.IProduction;
+import org.spoofax.jsglr2.parseforest.ISymbolNode;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.util.TreePrettyPrinter;
 import org.spoofax.jsglr2.util.iterators.SingleElementWithListIterable;
 
-public class ParseNode extends HybridParseForest {
+public class ParseNode extends HybridParseForest implements ISymbolNode<HybridParseForest, Derivation> {
 
     public final IProduction production;
     private final Derivation firstDerivation;
@@ -40,43 +40,6 @@ public class ParseNode extends HybridParseForest {
         }
     }
 
-    public List<Derivation> getPreferredAvoidedDerivations() {
-        if(!isAmbiguous())
-            return Arrays.asList(firstDerivation);
-        else {
-            List<Derivation> preferred = null, avoided = null, other = null;
-
-            for(Derivation derivation : getDerivations()) {
-                switch(derivation.productionType) {
-                    case PREFER:
-                        if(preferred == null)
-                            preferred = new ArrayList<Derivation>();
-
-                        preferred.add(derivation);
-                        break;
-                    case AVOID:
-                        if(avoided == null)
-                            avoided = new ArrayList<Derivation>();
-
-                        avoided.add(derivation);
-                        break;
-                    default:
-                        if(other == null)
-                            other = new ArrayList<Derivation>();
-
-                        other.add(derivation);
-                }
-            }
-
-            if(preferred != null && !preferred.isEmpty())
-                return preferred;
-            else if(other != null && !other.isEmpty())
-                return other;
-            else
-                return avoided;
-        }
-    }
-
     public Derivation getOnlyDerivation() {
         return firstDerivation;
     }
@@ -89,7 +52,7 @@ public class ParseNode extends HybridParseForest {
     public String descriptor() {
         return production.descriptor();
     }
-    
+
     protected void prettyPrint(TreePrettyPrinter printer) {
     	printer.println("p" + production.id() + " : " + production.sort() + "{");
     	if (isAmbiguous()) {
@@ -99,9 +62,9 @@ public class ParseNode extends HybridParseForest {
     	} else {
     		printer.indent(2);
     	}
-    	
+
     	firstDerivation.prettyPrint(printer);
-    	
+
     	if (otherDerivations != null) {
     		for (Derivation derivation : otherDerivations)
     			derivation.prettyPrint(printer);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/Parser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/Parser.java
@@ -6,6 +6,7 @@ import org.metaborg.parsetable.actions.IAction;
 import org.metaborg.parsetable.actions.IReduce;
 import org.metaborg.parsetable.actions.IShift;
 import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.failure.DefaultParseFailureHandler;
 import org.spoofax.jsglr2.parser.failure.IParseFailureHandler;
@@ -22,8 +23,13 @@ import org.spoofax.jsglr2.stack.collections.IActiveStacksFactory;
 import org.spoofax.jsglr2.stack.collections.IForActorStacks;
 import org.spoofax.jsglr2.stack.collections.IForActorStacksFactory;
 
-public class Parser<ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation, StackNode extends AbstractStackNode<ParseForest>, Parse extends AbstractParse<ParseForest, StackNode>>
-    implements IParser<ParseForest, StackNode> {
+public class Parser<
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>,
+        StackNode extends AbstractStackNode<ParseForest>,
+        Parse extends AbstractParse<ParseForest, StackNode>
+        > implements IParser<ParseForest, StackNode> {
 
     protected final ParseFactory<ParseForest, StackNode, Parse> parseFactory;
     protected final IParseTable parseTable;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReduceManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReduceManager.java
@@ -4,6 +4,7 @@ import org.metaborg.parsetable.IParseTable;
 import org.metaborg.parsetable.IState;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
@@ -12,7 +13,11 @@ import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.StackManager;
 import org.spoofax.jsglr2.stack.paths.StackPath;
 
-public class ReduceManager<ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation, StackNode extends AbstractStackNode<ParseForest>> {
+public class ReduceManager<
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>,
+        StackNode extends AbstractStackNode<ParseForest>> {
 
     protected final IParseTable parseTable;
     protected final StackManager<ParseForest, StackNode> stackManager;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/Reducer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/Reducer.java
@@ -3,13 +3,18 @@ package org.spoofax.jsglr2.reducing;
 import org.metaborg.parsetable.IState;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.stack.AbstractStackNode;
 import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.StackManager;
 
-public class Reducer<ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation, StackNode extends AbstractStackNode<ParseForest>> {
+public class Reducer<
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>,
+        StackNode extends AbstractStackNode<ParseForest>> {
 
     protected final StackManager<ParseForest, StackNode> stackManager;
     protected final ParseForestManager<ParseForest, ParseNode, Derivation> parseForestManager;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexical.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexical.java
@@ -3,14 +3,19 @@ package org.spoofax.jsglr2.reducing;
 import org.metaborg.parsetable.IState;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.stack.AbstractStackNode;
 import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.StackManager;
 
-public class ReducerSkipLayoutAndLexical<StackNode extends AbstractStackNode<ParseForest>, ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation>
-    extends Reducer<ParseForest, ParseNode, Derivation, StackNode> {
+public class ReducerSkipLayoutAndLexical<
+        StackNode extends AbstractStackNode<ParseForest>,
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>
+        > extends Reducer<ParseForest, ParseNode, Derivation, StackNode> {
 
     public ReducerSkipLayoutAndLexical(StackManager<ParseForest, StackNode> stackManager,
         ParseForestManager<ParseForest, ParseNode, Derivation> parseForestManager) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexicalAndRejects.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexicalAndRejects.java
@@ -3,14 +3,19 @@ package org.spoofax.jsglr2.reducing;
 import org.metaborg.parsetable.IState;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.stack.AbstractStackNode;
 import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.StackManager;
 
-public class ReducerSkipLayoutAndLexicalAndRejects<ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation, StackNode extends AbstractStackNode<ParseForest>>
-    extends Reducer<ParseForest, ParseNode, Derivation, StackNode> {
+public class ReducerSkipLayoutAndLexicalAndRejects<
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>,
+        StackNode extends AbstractStackNode<ParseForest>
+        > extends Reducer<ParseForest, ParseNode, Derivation, StackNode> {
 
     public ReducerSkipLayoutAndLexicalAndRejects(StackManager<ParseForest, StackNode> stackManager,
         ParseForestManager<ParseForest, ParseNode, Derivation> parseForestManager) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipRejects.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipRejects.java
@@ -3,14 +3,19 @@ package org.spoofax.jsglr2.reducing;
 import org.metaborg.parsetable.IState;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.parseforest.AbstractParseForest;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.stack.AbstractStackNode;
 import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.StackManager;
 
-public class ReducerSkipRejects<StackNode extends AbstractStackNode<ParseForest>, ParseForest extends AbstractParseForest, ParseNode extends ParseForest, Derivation>
-    extends Reducer<ParseForest, ParseNode, Derivation, StackNode> {
+public class ReducerSkipRejects<
+        ParseForest extends AbstractParseForest,
+        ParseNode extends ParseForest,
+        Derivation extends IDerivation<ParseForest>,
+        StackNode extends AbstractStackNode<ParseForest>
+        > extends Reducer<ParseForest, ParseNode, Derivation, StackNode> {
 
     public ReducerSkipRejects(StackManager<ParseForest, StackNode> stackManager,
         ParseForestManager<ParseForest, ParseNode, Derivation> parseForestManager) {


### PR DESCRIPTION
I found that the `getPreferredAvoidedDerivations` method for `SymbolNode`s and `hybrid.ParseNode` was duplicated four times. I've extracted this method to a `default` method as part of a new `ISymbolNode` interface. For the `DataDependent-`, `LayoutSensitive-`, and `SymbolNode` (which all use an `ArrayList` to store derivations), I've added an interface `IBasicSymbolNode` which can be seen as a trait that implements some of the methods of `ISymbolNode`, as they are all implemented in the same way throughout the three `*SymbolNode` classes anyway.

Related to this, the `Derivation` node classes (`*.RuleNode` and `hybrid.Derivation`) now have a method that returns the `productionType`, so that it can be used in the `getPreferredAvoidedDerivations` method in `ISymbolNode`. The type parameter `Derivation` now also consistently has `IDerivation<ParseForest>` as upper type bound in the parser (instead of only on certain places, such as the `imploder` package).

As a bonus, while I was editing the type parameters, I've added newlines between each type parameter to make them more readable on GitHub (no more need to scroll to the right). There are also some other small whitespace changes that have been automatically performed by IntelliJ.