### PR TITLE
Decouple Parse state from Imploder state

### DIFF
--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -60,7 +60,7 @@ public abstract class BaseTest implements WithParseTable {
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
             Parser<?, ?, ?, ?, ?> parser = JSGLR2Variants.getParser(parseTable, variant.parser);
 
-            ParseResult<?, ?> parseResult = parser.parse(inputString);
+            ParseResult<?> parseResult = parser.parse(inputString);
 
             assertEquals("Variant '" + variant.name() + "' failed parsing: ", true, parseResult.isSuccess);
         }
@@ -71,7 +71,7 @@ public abstract class BaseTest implements WithParseTable {
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
             Parser<?, ?, ?, ?, ?> parser = JSGLR2Variants.getParser(parseTable, variant.parser);
 
-            ParseResult<?, ?> parseResult = parser.parse(inputString);
+            ParseResult<?> parseResult = parser.parse(inputString);
 
             assertEquals("Variant '" + variant.name() + "' should fail: ", false, parseResult.isSuccess);
         }
@@ -144,14 +144,14 @@ public abstract class BaseTest implements WithParseTable {
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
             JSGLR2<?, IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant.parser);
 
-            JSGLR2Result<?, ?> parseResult = jsglr2.parseResult(inputString, "", null);
+            JSGLR2Result<?, ?> jsglr2Result = jsglr2.parseResult(inputString, "", null);
 
-            assertTrue("Variant '" + variant.name() + "' failed: ", parseResult.isSuccess);
+            assertTrue("Variant '" + variant.name() + "' failed: ", jsglr2Result.isSuccess);
 
             List<TokenDescriptor> actualTokens = new ArrayList<>();
 
-            for(IToken token : parseResult.parse.tokens) {
-                actualTokens.add(TokenDescriptor.from(parseResult.parse, token));
+            for(IToken token : jsglr2Result.tokens) {
+                actualTokens.add(TokenDescriptor.from(inputString, token));
             }
 
             TokenDescriptor expectedBeginToken = new TokenDescriptor("", IToken.TK_RESERVED, 0, 1, 1);
@@ -159,7 +159,7 @@ public abstract class BaseTest implements WithParseTable {
 
             assertEquals("Start token incorrect:", expectedBeginToken, actualBeginToken);
 
-            Position endPosition = Position.atEnd(parseResult.parse.inputString);
+            Position endPosition = Position.atEnd(inputString);
 
             int endLine = endPosition.line;
             int endColumn = endPosition.column;

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/TokenDescriptor.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/TokenDescriptor.java
@@ -1,7 +1,6 @@
 package org.spoofax.jsglr2.integrationtest;
 
 import org.spoofax.jsglr.client.imploder.IToken;
-import org.spoofax.jsglr2.parser.AbstractParse;
 
 public final class TokenDescriptor {
 
@@ -17,11 +16,11 @@ public final class TokenDescriptor {
         this.column = column;
     }
 
-    public static TokenDescriptor from(AbstractParse<?, ?> parse, IToken token) {
+    public static TokenDescriptor from(String inputString, IToken token) {
         String inputPart;
 
         if(token.getStartOffset() >= 0 && token.getEndOffset() >= 0)
-            inputPart = parse.getPart(token.getStartOffset(), token.getEndOffset() + 1);
+            inputPart = inputString.substring(token.getStartOffset(), token.getEndOffset() + 1);
         else
             inputPart = "";
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2.java
@@ -68,32 +68,30 @@ public class JSGLR2<ParseForest extends IParseForest, AbstractSyntaxTree> {
     }
 
     public AbstractSyntaxTree parse(String input, String filename, String startSymbol) {
-        ParseResult<ParseForest, ?> parseResult = parser.parse(input, filename, startSymbol);
+        ParseResult<ParseForest> parseResult = parser.parse(input, filename, startSymbol);
 
         if(!parseResult.isSuccess)
             return null;
 
-        ParseSuccess<ParseForest, ?> parseSuccess = (ParseSuccess<ParseForest, ?>) parseResult;
+        ParseSuccess<ParseForest> parseSuccess = (ParseSuccess<ParseForest>) parseResult;
 
-        ImplodeResult<ParseForest, AbstractSyntaxTree> implodeResult =
-            imploder.implode(parseSuccess.parse, parseSuccess.parseResult);
+        ImplodeResult<AbstractSyntaxTree> implodeResult = imploder.implode(input, filename, parseSuccess.parseResult);
 
         return implodeResult.ast;
     }
 
-    @SuppressWarnings("unchecked") public JSGLR2Result<ParseForest, AbstractSyntaxTree> parseResult(String input,
-        String filename, String startSymbol) {
-        ParseResult<ParseForest, ?> parseResult = parser.parse(input, filename, startSymbol);
+    public JSGLR2Result<ParseForest, AbstractSyntaxTree> parseResult(String input, String filename,
+        String startSymbol) {
+        ParseResult<ParseForest> parseResult = parser.parse(input, filename, startSymbol);
 
         if(!parseResult.isSuccess)
-            return (JSGLR2Result<ParseForest, AbstractSyntaxTree>) parseResult;
+            return new JSGLR2Result<>(parseResult);
 
-        ParseSuccess<ParseForest, ?> parseSuccess = (ParseSuccess<ParseForest, ?>) parseResult;
+        ParseSuccess<ParseForest> parseSuccess = (ParseSuccess<ParseForest>) parseResult;
 
-        ImplodeResult<ParseForest, AbstractSyntaxTree> implodeResult =
-            imploder.implode(parseSuccess.parse, parseSuccess.parseResult);
+        ImplodeResult<AbstractSyntaxTree> implodeResult = imploder.implode(input, filename, parseSuccess.parseResult);
 
-        return implodeResult;
+        return new JSGLR2Result<>(parseResult, implodeResult);
     }
 
     public AbstractSyntaxTree parse(String input) {
@@ -101,17 +99,16 @@ public class JSGLR2<ParseForest extends IParseForest, AbstractSyntaxTree> {
     }
 
     public AbstractSyntaxTree parseUnsafe(String input, String filename, String startSymbol) throws ParseException {
-        ParseResult<ParseForest, ?> result = parser.parse(input, filename, startSymbol);
+        ParseResult<ParseForest> result = parser.parse(input, filename, startSymbol);
 
         if(result.isSuccess) {
-            ParseSuccess<ParseForest, ?> success = (ParseSuccess<ParseForest, ?>) result;
+            ParseSuccess<ParseForest> success = (ParseSuccess<ParseForest>) result;
 
-            ImplodeResult<ParseForest, AbstractSyntaxTree> implodeResult =
-                imploder.implode(success.parse, success.parseResult);
+            ImplodeResult<AbstractSyntaxTree> implodeResult = imploder.implode(input, filename, success.parseResult);
 
             return implodeResult.ast;
         } else {
-            ParseFailure<ParseForest, ?> failure = (ParseFailure<ParseForest, ?>) result;
+            ParseFailure<ParseForest> failure = (ParseFailure<ParseForest>) result;
 
             throw failure.exception();
         }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Result.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Result.java
@@ -1,16 +1,49 @@
 package org.spoofax.jsglr2;
 
+import org.spoofax.jsglr2.imploder.ImplodeResult;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
+import org.spoofax.jsglr2.parser.result.ParseResult;
+import org.spoofax.jsglr2.tokens.Tokens;
 
-public abstract class JSGLR2Result<ParseForest extends IParseForest, AbstractSyntaxTree> {
+public final class JSGLR2Result<ParseForest extends IParseForest, AbstractSyntaxTree> {
 
     public final AbstractParse<ParseForest, ?> parse;
     public final boolean isSuccess;
+    public final Tokens tokens;
+    public final AbstractSyntaxTree ast;
 
-    protected JSGLR2Result(AbstractParse<ParseForest, ?> parse, boolean isSuccess) {
-        this.parse = parse;
-        this.isSuccess = isSuccess;
+    /**
+     * Constructs a result in the case that the parse failed. There is no ImplodeResult, so the fields `tokens` and
+     * `ast` are `null`.
+     * 
+     * @param parseResult
+     *            The parse failure result.
+     */
+    protected JSGLR2Result(ParseResult<ParseForest> parseResult) {
+        // Implementation note: it would be cleaner to only accept `ParseFailure` as argument to this constructor.
+        // However, this would always require casting at the call site (after checking for `isSuccess`.
+        // If we ever change to a language that has class matching (e.g. Scala), we can still change this.
+        // (The same goes for the success constructor)
+        this.parse = parseResult.parse;
+        this.isSuccess = parseResult.isSuccess;
+        this.tokens = null;
+        this.ast = null;
+    }
+
+    /**
+     * Constructs a result in the case that the parse succeeded.
+     * 
+     * @param parseResult
+     *            The parse success result.
+     * @param implodeResult
+     *            The implode result.
+     */
+    protected JSGLR2Result(ParseResult<ParseForest> parseResult, ImplodeResult<AbstractSyntaxTree> implodeResult) {
+        this.parse = parseResult.parse;
+        this.isSuccess = parseResult.isSuccess;
+        this.tokens = implodeResult.tokens;
+        this.ast = implodeResult.ast;
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IImploder.java
@@ -1,11 +1,9 @@
 package org.spoofax.jsglr2.imploder;
 
 import org.spoofax.jsglr2.parseforest.IParseForest;
-import org.spoofax.jsglr2.parser.AbstractParse;
 
 public interface IImploder<ParseForest extends IParseForest, AbstractSyntaxTree> {
 
-    ImplodeResult<ParseForest, AbstractSyntaxTree> implode(AbstractParse<ParseForest, ?> parse,
-        ParseForest parseForest);
+    ImplodeResult<AbstractSyntaxTree> implode(String input, String filename, ParseForest parseForest);
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/ImplodeResult.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/ImplodeResult.java
@@ -1,17 +1,14 @@
 package org.spoofax.jsglr2.imploder;
 
-import org.spoofax.jsglr2.JSGLR2Result;
-import org.spoofax.jsglr2.parseforest.IParseForest;
-import org.spoofax.jsglr2.parser.AbstractParse;
+import org.spoofax.jsglr2.tokens.Tokens;
 
-public class ImplodeResult<ParseForest extends IParseForest, AbstractSyntaxTree>
-    extends JSGLR2Result<ParseForest, AbstractSyntaxTree> {
+public class ImplodeResult<AbstractSyntaxTree> {
 
+    public final Tokens tokens;
     public final AbstractSyntaxTree ast;
 
-    public ImplodeResult(AbstractParse<ParseForest, ?> parse, AbstractSyntaxTree ast) {
-        super(parse, true);
-
+    public ImplodeResult(Tokens tokens, AbstractSyntaxTree ast) {
+        this.tokens = tokens;
         this.ast = ast;
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/NullParseForestStrategoImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/NullParseForestStrategoImploder.java
@@ -2,12 +2,10 @@ package org.spoofax.jsglr2.imploder;
 
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr2.parseforest.hybrid.HybridParseForest;
-import org.spoofax.jsglr2.parser.AbstractParse;
 
 public class NullParseForestStrategoImploder implements IImploder<HybridParseForest, IStrategoTerm> {
 
-    @Override public ImplodeResult<HybridParseForest, IStrategoTerm> implode(AbstractParse<HybridParseForest, ?> parse,
-        HybridParseForest parseForest) {
+    @Override public ImplodeResult<IStrategoTerm> implode(String input, String filename, HybridParseForest forest) {
         return null;
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/AbstractParse.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/AbstractParse.java
@@ -11,8 +11,6 @@ import org.spoofax.jsglr2.parser.observing.ParserObserving;
 import org.spoofax.jsglr2.stack.AbstractStackNode;
 import org.spoofax.jsglr2.stack.collections.IActiveStacks;
 import org.spoofax.jsglr2.stack.collections.IForActorStacks;
-import org.spoofax.jsglr2.tokens.IParseTokens;
-import org.spoofax.jsglr2.tokens.Tokens;
 
 import com.google.common.collect.Maps;
 
@@ -26,8 +24,6 @@ public abstract class AbstractParse
     final public String filename;
     final public String inputString;
     final public int inputLength;
-
-    final public IParseTokens tokens;
 
     final public Map<Integer, Object> longestMatchPos = Maps.newHashMap();
 
@@ -48,8 +44,6 @@ public abstract class AbstractParse
         this.filename = filename;
         this.inputString = inputString;
         this.inputLength = inputString.length();
-
-        this.tokens = new Tokens(inputString, filename);
 
         this.acceptingStack = null;
         this.activeStacks = activeStacks;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/IParser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/IParser.java
@@ -14,13 +14,13 @@ public interface IParser
 //@formatter:on
 {
 
-    ParseResult<ParseForest, ?> parse(String input, String filename, String startSymbol);
+    ParseResult<ParseForest> parse(String input, String filename, String startSymbol);
 
-    default ParseResult<ParseForest, ?> parse(String input, String filename) {
+    default ParseResult<ParseForest> parse(String input, String filename) {
         return parse(input, filename, null);
     }
 
-    default ParseResult<ParseForest, ?> parse(String input) {
+    default ParseResult<ParseForest> parse(String input) {
         return parse(input, "");
     }
 
@@ -29,14 +29,14 @@ public interface IParser
      * otherwise.
      */
     default ParseForest parseUnsafe(String input, String filename, String startSymbol) throws ParseException {
-        ParseResult<ParseForest, ?> result = parse(input, filename, startSymbol);
+        ParseResult<ParseForest> result = parse(input, filename, startSymbol);
 
         if(result.isSuccess) {
-            ParseSuccess<ParseForest, ?> success = (ParseSuccess<ParseForest, ?>) result;
+            ParseSuccess<ParseForest> success = (ParseSuccess<ParseForest>) result;
 
             return success.parseResult;
         } else {
-            ParseFailure<ParseForest, ?> failure = (ParseFailure<ParseForest, ?>) result;
+            ParseFailure<ParseForest> failure = (ParseFailure<ParseForest>) result;
 
             throw failure.exception();
         }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/Parser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/Parser.java
@@ -59,7 +59,7 @@ public class Parser
         this.observing = new ParserObserving<>();
     }
 
-    @Override public ParseResult<ParseForest, ?> parse(String inputString, String filename, String startSymbol) {
+    @Override public ParseResult<ParseForest> parse(String inputString, String filename, String startSymbol) {
         IActiveStacks<StackNode> activeStacks = activeStacksFactory.get(observing);
         IForActorStacks<StackNode> forActorStacks = forActorStacksFactory.get(observing);
 
@@ -87,16 +87,16 @@ public class Parser
             return failure(parse, failureHandler.failureType(parse));
     }
 
-    private ParseSuccess<ParseForest, ?> success(Parse parse, ParseForest parseForest) {
-        ParseSuccess<ParseForest, ?> success = new ParseSuccess<>(parse, parseForest);
+    private ParseSuccess<ParseForest> success(Parse parse, ParseForest parseForest) {
+        ParseSuccess<ParseForest> success = new ParseSuccess<>(parse, parseForest);
 
         observing.notify(observer -> observer.success(success));
 
         return success;
     }
 
-    private ParseFailure<ParseForest, ?> failure(Parse parse, ParseFailureType failureType) {
-        ParseFailure<ParseForest, ?> failure = new ParseFailure<>(parse, failureType);
+    private ParseFailure<ParseForest> failure(Parse parse, ParseFailureType failureType) {
+        ParseFailure<ParseForest> failure = new ParseFailure<>(parse, failureType);
 
         observing.notify(observer -> observer.failure(failure));
 
@@ -198,8 +198,7 @@ public class Parser
     }
 
     private void addForShifter(Parse parse, StackNode stack, IState shiftState) {
-        ForShifterElement<ParseForest, StackNode> forShifterElement =
-            new ForShifterElement<ParseForest, StackNode>(stack, shiftState);
+        ForShifterElement<ParseForest, StackNode> forShifterElement = new ForShifterElement<>(stack, shiftState);
 
         observing.notify(observer -> observer.addForShifter(forShifterElement));
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/IParserObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/IParserObserver.java
@@ -76,8 +76,8 @@ public interface IParserObserver
 
     void remark(String remark);
 
-    void success(ParseSuccess<ParseForest, ?> success);
+    void success(ParseSuccess<ParseForest> success);
 
-    void failure(ParseFailure<ParseForest, ?> failure);
+    void failure(ParseFailure<ParseForest> failure);
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserLogObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserLogObserver.java
@@ -127,11 +127,11 @@ public class ParserLogObserver
         log(remark);
     }
 
-    @Override public void success(ParseSuccess<ParseForest, ?> success) {
+    @Override public void success(ParseSuccess<ParseForest> success) {
         log("Parsing succeeded. Result: " + success.parseResult.toString());
     }
 
-    @Override public void failure(ParseFailure<ParseForest, ?> failure) {
+    @Override public void failure(ParseFailure<ParseForest> failure) {
         log("Parsing failed");
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserObserver.java
@@ -145,10 +145,10 @@ public abstract class ParserObserver
     @Override public void remark(String remark) {
     }
 
-    @Override public void success(ParseSuccess<ParseForest, ?> success) {
+    @Override public void success(ParseSuccess<ParseForest> success) {
     }
 
-    @Override public void failure(ParseFailure<ParseForest, ?> failure) {
+    @Override public void failure(ParseFailure<ParseForest> failure) {
     }
 
     String stackQueueToString(Iterable<StackNode> stacks) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserVisualisationObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserVisualisationObserver.java
@@ -134,11 +134,11 @@ public class ParserVisualisationObserver
         trace("{\"action\":\"remark\",\"remark\":\"" + remark + "\"}");
     }
 
-    @Override public void success(ParseSuccess<ParseForest, ?> success) {
+    @Override public void success(ParseSuccess<ParseForest> success) {
         trace("{\"action\":\"success\"}");
     }
 
-    @Override public void failure(ParseFailure<ParseForest, ?> failure) {
+    @Override public void failure(ParseFailure<ParseForest> failure) {
         trace("{\"action\":\"failure\"}");
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseFailure.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseFailure.java
@@ -4,8 +4,7 @@ import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.ParseException;
 
-public class ParseFailure<ParseForest extends IParseForest, AbstractSyntaxTree>
-    extends ParseResult<ParseForest, AbstractSyntaxTree> {
+public class ParseFailure<ParseForest extends IParseForest> extends ParseResult<ParseForest> {
 
     public final ParseFailureType failureType;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseResult.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseResult.java
@@ -1,14 +1,16 @@
 package org.spoofax.jsglr2.parser.result;
 
-import org.spoofax.jsglr2.JSGLR2Result;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
 
-public abstract class ParseResult<ParseForest extends IParseForest, AbstractSyntaxTree>
-    extends JSGLR2Result<ParseForest, AbstractSyntaxTree> {
+public abstract class ParseResult<ParseForest extends IParseForest> {
+
+    public final AbstractParse<ParseForest, ?> parse;
+    public final boolean isSuccess;
 
     protected ParseResult(AbstractParse<ParseForest, ?> parse, boolean isSuccess) {
-        super(parse, isSuccess);
+        this.parse = parse;
+        this.isSuccess = isSuccess;
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseSuccess.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseSuccess.java
@@ -3,8 +3,7 @@ package org.spoofax.jsglr2.parser.result;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
 
-public class ParseSuccess<ParseForest extends IParseForest, AbstractSyntaxTree>
-    extends ParseResult<ParseForest, AbstractSyntaxTree> {
+public class ParseSuccess<ParseForest extends IParseForest> extends ParseResult<ParseForest> {
 
     public final ParseForest parseResult;
 


### PR DESCRIPTION
It used to be the case that the Parse (AbstractParse) state contained a
reference to a Tokens object, that would be passed along during
imploding.
Now, the Tokens object is only created inside the Imploder, as the
parser does not need to know anything about this Tokens object.
To do this, the IImploder interface has been updated to:
&nbsp;&nbsp;&nbsp;&nbsp;`implode(String input, String filename, ParseForest parseForest)`

Related to this, also the Result classes have been decoupled.
ParseResult and ImplodeResult now only have one type parameter*,
as the first only needs to know the type of the ParseForest,
while the second only needs to know the type of the AbstractSyntaxTree.
The class JSGLR2Result is now constructed as the combination of a
ParseResult and an ImplodeResult, rather than the ParseResult being
threaded through to the ImplodeResult.

*) This saves on a whole bunch of `?` in type declarations :smile: