### PR TITLE
No longer store position in stack nodes

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentParseForestManager.java
@@ -7,13 +7,12 @@ import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.ProductionType;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 
 public class DataDependentParseForestManager
     extends ParseForestManager<DataDependentParseForest, DataDependentParseNode, DataDependentDerivation> {
 
     @Override public DataDependentParseNode createParseNode(AbstractParse<DataDependentParseForest, ?> parse,
-        Position beginPosition, IProduction production, DataDependentDerivation firstDerivation) {
+        IProduction production, DataDependentDerivation firstDerivation) {
         DataDependentParseNode parseNode = new DataDependentParseNode(production);
 
         // parse.notify(observer -> observer.createParseNode(parseNode, production));
@@ -48,8 +47,7 @@ public class DataDependentParseForestManager
     }
 
     @Override public DataDependentDerivation createDerivation(AbstractParse<DataDependentParseForest, ?> parse,
-        Position beginPosition, IProduction production, ProductionType productionType,
-        DataDependentParseForest[] parseForests) {
+        IProduction production, ProductionType productionType, DataDependentParseForest[] parseForests) {
         DataDependentDerivation derivation = new DataDependentDerivation(production, productionType, parseForests);
 
         // parse.notify(observer -> observer.createDerivation(derivation.nodeNumber, production, parseForests));

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/BasicElkhoundStackManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/BasicElkhoundStackManager.java
@@ -3,15 +3,13 @@ package org.spoofax.jsglr2.elkhound;
 import org.metaborg.parsetable.IState;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.stack.StackLink;
 
 public class BasicElkhoundStackManager<ParseForest extends IParseForest>
     extends ElkhoundStackManager<ParseForest, BasicElkhoundStackNode<ParseForest>> {
 
-    @Override protected BasicElkhoundStackNode<ParseForest> createStackNode(IState state, Position position,
-        boolean isRoot) {
-        return new BasicElkhoundStackNode<>(state, position, isRoot);
+    @Override protected BasicElkhoundStackNode<ParseForest> createStackNode(IState state, boolean isRoot) {
+        return new BasicElkhoundStackNode<>(state, isRoot);
     }
 
     @Override protected StackLink<ParseForest, BasicElkhoundStackNode<ParseForest>> addStackLink(

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/BasicElkhoundStackNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/BasicElkhoundStackNode.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import org.metaborg.parsetable.IState;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.stack.StackLink;
 
 public class BasicElkhoundStackNode<ParseForest extends IParseForest> extends ElkhoundStackNode<ParseForest> {
@@ -13,8 +12,8 @@ public class BasicElkhoundStackNode<ParseForest extends IParseForest> extends El
     // Directed to the initial stack node
     private ArrayList<StackLink<ParseForest, BasicElkhoundStackNode<ParseForest>>> links = new ArrayList<>();
 
-    public BasicElkhoundStackNode(IState state, Position position, boolean isRoot) {
-        super(state, position, isRoot);
+    public BasicElkhoundStackNode(IState state, boolean isRoot) {
+        super(state, isRoot);
     }
 
     @Override @SuppressWarnings("unchecked") public

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/ElkhoundStackManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/ElkhoundStackManager.java
@@ -4,7 +4,6 @@ import org.metaborg.parsetable.IState;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.stack.AbstractStackManager;
 import org.spoofax.jsglr2.stack.StackLink;
 
@@ -15,11 +14,11 @@ public abstract class ElkhoundStackManager
 //@formatter:on
     extends AbstractStackManager<ParseForest, ElkhoundStackNode> {
 
-    protected abstract ElkhoundStackNode createStackNode(IState state, Position position, boolean isRoot);
+    protected abstract ElkhoundStackNode createStackNode(IState state, boolean isRoot);
 
     @Override public ElkhoundStackNode createInitialStackNode(AbstractParse<ParseForest, ElkhoundStackNode> parse,
         IState state) {
-        ElkhoundStackNode newStackNode = createStackNode(state, parse.currentPosition(), true);
+        ElkhoundStackNode newStackNode = createStackNode(state, true);
 
         parse.observing.notify(observer -> observer.createStackNode(newStackNode));
 
@@ -28,7 +27,7 @@ public abstract class ElkhoundStackManager
 
     @Override public ElkhoundStackNode createStackNode(AbstractParse<ParseForest, ElkhoundStackNode> parse,
         IState state) {
-        ElkhoundStackNode newStackNode = createStackNode(state, parse.currentPosition(), false);
+        ElkhoundStackNode newStackNode = createStackNode(state, false);
 
         parse.observing.notify(observer -> observer.createStackNode(newStackNode));
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/ElkhoundStackNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/ElkhoundStackNode.java
@@ -2,7 +2,6 @@ package org.spoofax.jsglr2.elkhound;
 
 import org.metaborg.parsetable.IState;
 import org.spoofax.jsglr2.parseforest.IParseForest;
-import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.stack.AbstractStackNode;
 import org.spoofax.jsglr2.stack.StackLink;
 
@@ -12,8 +11,8 @@ public abstract class ElkhoundStackNode<ParseForest extends IParseForest> extend
     public int deterministicDepth;
     public int referenceCount;
 
-    protected ElkhoundStackNode(IState state, Position position, boolean isRoot) {
-        super(state, position);
+    protected ElkhoundStackNode(IState state, boolean isRoot) {
+        super(state);
         this.isRoot = isRoot;
         this.deterministicDepth = isRoot ? 1 : 0;
         this.referenceCount = 0;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/HybridElkhoundStackManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/HybridElkhoundStackManager.java
@@ -3,15 +3,13 @@ package org.spoofax.jsglr2.elkhound;
 import org.metaborg.parsetable.IState;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.stack.StackLink;
 
 public class HybridElkhoundStackManager<ParseForest extends IParseForest>
     extends ElkhoundStackManager<ParseForest, HybridElkhoundStackNode<ParseForest>> {
 
-    @Override protected HybridElkhoundStackNode<ParseForest> createStackNode(IState state, Position position,
-        boolean isRoot) {
-        return new HybridElkhoundStackNode<>(state, position, isRoot);
+    @Override protected HybridElkhoundStackNode<ParseForest> createStackNode(IState state, boolean isRoot) {
+        return new HybridElkhoundStackNode<>(state, isRoot);
     }
 
     @Override protected StackLink<ParseForest, HybridElkhoundStackNode<ParseForest>> addStackLink(

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/HybridElkhoundStackNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/elkhound/HybridElkhoundStackNode.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import org.metaborg.parsetable.IState;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.util.iterators.SingleElementWithListIterable;
 
@@ -16,8 +15,8 @@ public class HybridElkhoundStackNode<ParseForest extends IParseForest> extends E
     private StackLink<ParseForest, HybridElkhoundStackNode<ParseForest>> firstLink;
     private ArrayList<StackLink<ParseForest, HybridElkhoundStackNode<ParseForest>>> otherLinks;
 
-    public HybridElkhoundStackNode(IState state, Position position, boolean isRoot) {
-        super(state, position, isRoot);
+    public HybridElkhoundStackNode(IState state, boolean isRoot) {
+        super(state, isRoot);
     }
 
     @Override @SuppressWarnings("unchecked") public

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
@@ -14,9 +14,11 @@ public class LayoutSensitiveParseForestManager
     extends ParseForestManager<LayoutSensitiveParseForest, LayoutSensitiveParseNode, LayoutSensitiveDerivation> {
 
     @Override public LayoutSensitiveParseNode createParseNode(AbstractParse<LayoutSensitiveParseForest, ?> parse,
-        Position beginPosition, IProduction production, LayoutSensitiveDerivation firstDerivation) {
+        IProduction production, LayoutSensitiveDerivation firstDerivation) {
+
+        // TODO @udesou Please verify that this has the same effect as storing positions on the stack
         LayoutSensitiveParseNode parseNode =
-            new LayoutSensitiveParseNode(beginPosition, parse.currentPosition(), production);
+            new LayoutSensitiveParseNode(firstDerivation.getStartPosition(), parse.currentPosition(), production);
 
         // parse.notify(observer -> observer.createParseNode(parseNode, production));
 
@@ -51,8 +53,14 @@ public class LayoutSensitiveParseForestManager
     }
 
     @Override public LayoutSensitiveDerivation createDerivation(AbstractParse<LayoutSensitiveParseForest, ?> parse,
-        Position beginPosition, IProduction production, ProductionType productionType,
-        LayoutSensitiveParseForest[] parseForests) {
+        IProduction production, ProductionType productionType, LayoutSensitiveParseForest[] parseForests) {
+
+        // TODO @udesou Please verify that this has the same effect as storing positions on the stack
+        Position beginPosition = parseForests.length == 0
+            // If this derivation corresponds with an epsilon production, use current parse position as startPosition
+            ? parse.currentPosition()
+            // Else, just use the start position of the first child node
+            : parseForests[0].getStartPosition();
 
         // FIXME since EndPosition is wrong, right is also wrong
         Position leftPosition = null;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ParseForestManager.java
@@ -3,7 +3,6 @@ package org.spoofax.jsglr2.parseforest;
 import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.ProductionType;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 
 public abstract class ParseForestManager
 //@formatter:off
@@ -13,11 +12,11 @@ public abstract class ParseForestManager
 //@formatter:on
 {
 
-    abstract public ParseNode createParseNode(AbstractParse<ParseForest, ?> parse, Position beginPosition,
-        IProduction production, Derivation firstDerivation);
+    abstract public ParseNode createParseNode(AbstractParse<ParseForest, ?> parse, IProduction production,
+        Derivation firstDerivation);
 
-    abstract public Derivation createDerivation(AbstractParse<ParseForest, ?> parse, Position beginPosition,
-        IProduction production, ProductionType productionType, ParseForest[] parseForests);
+    abstract public Derivation createDerivation(AbstractParse<ParseForest, ?> parse, IProduction production,
+        ProductionType productionType, ParseForest[] parseForests);
 
     abstract public void addDerivation(AbstractParse<ParseForest, ?> parse, ParseNode parseNode, Derivation derivation);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/BasicParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/BasicParseForestManager.java
@@ -7,12 +7,11 @@ import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.ProductionType;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 
 public class BasicParseForestManager extends ParseForestManager<BasicParseForest, BasicParseNode, BasicDerivation> {
 
-    @Override public BasicParseNode createParseNode(AbstractParse<BasicParseForest, ?> parse, Position beginPosition,
-        IProduction production, BasicDerivation firstDerivation) {
+    @Override public BasicParseNode createParseNode(AbstractParse<BasicParseForest, ?> parse, IProduction production,
+        BasicDerivation firstDerivation) {
         BasicParseNode parseNode = new BasicParseNode(production);
 
         // parse.notify(observer -> observer.createParseNode(parseNode, production));
@@ -46,8 +45,8 @@ public class BasicParseForestManager extends ParseForestManager<BasicParseForest
         }
     }
 
-    @Override public BasicDerivation createDerivation(AbstractParse<BasicParseForest, ?> parse, Position beginPosition,
-        IProduction production, ProductionType productionType, BasicParseForest[] parseForests) {
+    @Override public BasicDerivation createDerivation(AbstractParse<BasicParseForest, ?> parse, IProduction production,
+        ProductionType productionType, BasicParseForest[] parseForests) {
         BasicDerivation derivation = new BasicDerivation(production, productionType, parseForests);
 
         // parse.notify(observer -> observer.createDerivation(derivation.nodeNumber, production, parseForests));

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/empty/NullParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/empty/NullParseForestManager.java
@@ -8,12 +8,11 @@ import org.spoofax.jsglr2.parseforest.hybrid.HybridDerivation;
 import org.spoofax.jsglr2.parseforest.hybrid.HybridParseForest;
 import org.spoofax.jsglr2.parseforest.hybrid.HybridParseNode;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 
 public class NullParseForestManager extends ParseForestManager<HybridParseForest, HybridParseNode, HybridDerivation> {
 
-    @Override public HybridParseNode createParseNode(AbstractParse<HybridParseForest, ?> parse, Position beginPosition,
-        IProduction production, HybridDerivation firstDerivation) {
+    @Override public HybridParseNode createParseNode(AbstractParse<HybridParseForest, ?> parse, IProduction production,
+        HybridDerivation firstDerivation) {
         return null;
     }
 
@@ -23,8 +22,7 @@ public class NullParseForestManager extends ParseForestManager<HybridParseForest
     }
 
     @Override public HybridDerivation createDerivation(AbstractParse<HybridParseForest, ?> parse,
-        Position beginPosition, IProduction production, ProductionType productionType,
-        HybridParseForest[] parseForests) {
+        IProduction production, ProductionType productionType, HybridParseForest[] parseForests) {
         return null;
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/hybrid/HybridParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/hybrid/HybridParseForestManager.java
@@ -7,12 +7,11 @@ import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.ProductionType;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 
 public class HybridParseForestManager extends ParseForestManager<HybridParseForest, HybridParseNode, HybridDerivation> {
 
-    @Override public HybridParseNode createParseNode(AbstractParse<HybridParseForest, ?> parse, Position beginPosition,
-        IProduction production, HybridDerivation firstDerivation) {
+    @Override public HybridParseNode createParseNode(AbstractParse<HybridParseForest, ?> parse, IProduction production,
+        HybridDerivation firstDerivation) {
         HybridParseNode parseNode = new HybridParseNode(production, firstDerivation);
 
         // parse.notify(observer -> observer.createParseNode(parseNode, production));
@@ -46,8 +45,7 @@ public class HybridParseForestManager extends ParseForestManager<HybridParseFore
     }
 
     @Override public HybridDerivation createDerivation(AbstractParse<HybridParseForest, ?> parse,
-        Position beginPosition, IProduction production, ProductionType productionType,
-        HybridParseForest[] parseForests) {
+        IProduction production, ProductionType productionType, HybridParseForest[] parseForests) {
         HybridDerivation derivation = new HybridDerivation(production, productionType, parseForests);
 
         // parse.notify(observer -> observer.createDerivation(production, derivation.parseForests));

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/AbstractParse.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/AbstractParse.java
@@ -59,6 +59,8 @@ public abstract class AbstractParse
         this.observing = observing;
     }
 
+    // Should only be used in LayoutSensitive parsing
+    // TODO this method should only be available in LayoutSensitive parsing to prevent it from being used elsewhere
     public Position currentPosition() {
         return new Position(currentOffset, currentLine, currentColumn);
     }
@@ -95,16 +97,12 @@ public abstract class AbstractParse
             return CharacterClassFactory.EOF_INT;
     }
 
-    public String getPart(int begin, int end) {
-        return inputString.substring(begin, end);
-    }
-
     @Override public int actionQueryCharacter() {
         return currentChar;
     }
 
     @Override public String actionQueryLookahead(int length) {
-        return getPart(currentOffset + 1, Math.min(currentOffset + 1 + length, inputLength));
+        return inputString.substring(currentOffset + 1, Math.min(currentOffset + 1 + length, inputLength));
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/Reducer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/Reducer.java
@@ -37,8 +37,7 @@ public class Reducer
     public void reducerExistingStackWithDirectLink(AbstractParse<ParseForest, StackNode> parse, IReduce reduce,
         StackLink<ParseForest, StackNode> existingDirectLinkToActiveStateWithGoto, ParseForest[] parseForests) {
         Derivation derivation =
-            parseForestManager.createDerivation(parse, existingDirectLinkToActiveStateWithGoto.to.position,
-                reduce.production(), reduce.productionType(), parseForests);
+            parseForestManager.createDerivation(parse, reduce.production(), reduce.productionType(), parseForests);
 
         @SuppressWarnings("unchecked") ParseNode parseNode =
             (ParseNode) existingDirectLinkToActiveStateWithGoto.parseForest;
@@ -58,10 +57,9 @@ public class Reducer
     public StackLink<ParseForest, StackNode> reducerExistingStackWithoutDirectLink(
         AbstractParse<ParseForest, StackNode> parse, IReduce reduce, StackNode existingActiveStackWithGotoState,
         StackNode stack, ParseForest[] parseForests) {
-        Derivation derivation = parseForestManager.createDerivation(parse, stack.position, reduce.production(),
-            reduce.productionType(), parseForests);
-        ParseForest parseNode =
-            parseForestManager.createParseNode(parse, stack.position, reduce.production(), derivation);
+        Derivation derivation =
+            parseForestManager.createDerivation(parse, reduce.production(), reduce.productionType(), parseForests);
+        ParseForest parseNode = parseForestManager.createParseNode(parse, reduce.production(), derivation);
 
         StackLink<ParseForest, StackNode> newDirectLinkToActiveStateWithGoto =
             stackManager.createStackLink(parse, existingActiveStackWithGotoState, stack, parseNode);
@@ -79,10 +77,9 @@ public class Reducer
      */
     public StackNode reducerNoExistingStack(AbstractParse<ParseForest, StackNode> parse, IReduce reduce,
         StackNode stack, IState gotoState, ParseForest[] parseForests) {
-        Derivation derivation = parseForestManager.createDerivation(parse, stack.position, reduce.production(),
-            reduce.productionType(), parseForests);
-        ParseForest parseNode =
-            parseForestManager.createParseNode(parse, stack.position, reduce.production(), derivation);
+        Derivation derivation =
+            parseForestManager.createDerivation(parse, reduce.production(), reduce.productionType(), parseForests);
+        ParseForest parseNode = parseForestManager.createParseNode(parse, reduce.production(), derivation);
 
         StackNode newStackWithGotoState = stackManager.createStackNode(parse, gotoState);
         StackLink<ParseForest, StackNode> link =

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexical.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexical.java
@@ -32,8 +32,7 @@ public class ReducerSkipLayoutAndLexical
 
         if(parseNode != null) {
             Derivation derivation =
-                parseForestManager.createDerivation(parse, existingDirectLinkToActiveStateWithGoto.to.position,
-                    reduce.production(), reduce.productionType(), parseForests);
+                parseForestManager.createDerivation(parse, reduce.production(), reduce.productionType(), parseForests);
             parseForestManager.addDerivation(parse, parseNode, derivation);
         }
 
@@ -49,9 +48,9 @@ public class ReducerSkipLayoutAndLexical
         if(reduce.production().isSkippableInParseForest())
             parseNode = null;
         else {
-            Derivation derivation = parseForestManager.createDerivation(parse, stack.position, reduce.production(),
-                reduce.productionType(), parseForests);
-            parseNode = parseForestManager.createParseNode(parse, stack.position, reduce.production(), derivation);
+            Derivation derivation =
+                parseForestManager.createDerivation(parse, reduce.production(), reduce.productionType(), parseForests);
+            parseNode = parseForestManager.createParseNode(parse, reduce.production(), derivation);
         }
 
         StackLink<ParseForest, StackNode> newDirectLinkToActiveStateWithGoto =
@@ -70,9 +69,9 @@ public class ReducerSkipLayoutAndLexical
         if(reduce.production().isSkippableInParseForest())
             parseNode = null;
         else {
-            Derivation derivation = parseForestManager.createDerivation(parse, stack.position, reduce.production(),
-                reduce.productionType(), parseForests);
-            parseNode = parseForestManager.createParseNode(parse, stack.position, reduce.production(), derivation);
+            Derivation derivation =
+                parseForestManager.createDerivation(parse, reduce.production(), reduce.productionType(), parseForests);
+            parseNode = parseForestManager.createParseNode(parse, reduce.production(), derivation);
         }
 
         StackNode newStackWithGotoState = stackManager.createStackNode(parse, gotoState);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexicalAndRejects.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexicalAndRejects.java
@@ -34,8 +34,7 @@ public class ReducerSkipLayoutAndLexicalAndRejects
             stackManager.rejectStackLink(parse, existingDirectLinkToActiveStateWithGoto);
         else if(!existingDirectLinkToActiveStateWithGoto.isRejected() && parseNode != null) {
             Derivation derivation =
-                parseForestManager.createDerivation(parse, existingDirectLinkToActiveStateWithGoto.to.position,
-                    reduce.production(), reduce.productionType(), parseForests);
+                parseForestManager.createDerivation(parse, reduce.production(), reduce.productionType(), parseForests);
             parseForestManager.addDerivation(parse, parseNode, derivation);
         }
     }
@@ -56,9 +55,9 @@ public class ReducerSkipLayoutAndLexicalAndRejects
             if(reduce.production().isSkippableInParseForest())
                 parseNode = null;
             else {
-                Derivation derivation = parseForestManager.createDerivation(parse, stack.position, reduce.production(),
+                Derivation derivation = parseForestManager.createDerivation(parse, reduce.production(),
                     reduce.productionType(), parseForests);
-                parseNode = parseForestManager.createParseNode(parse, stack.position, reduce.production(), derivation);
+                parseNode = parseForestManager.createParseNode(parse, reduce.production(), derivation);
             }
 
             newDirectLinkToActiveStateWithGoto =
@@ -84,9 +83,9 @@ public class ReducerSkipLayoutAndLexicalAndRejects
             if(reduce.production().isSkippableInParseForest())
                 parseNode = null;
             else {
-                Derivation derivation = parseForestManager.createDerivation(parse, stack.position, reduce.production(),
+                Derivation derivation = parseForestManager.createDerivation(parse, reduce.production(),
                     reduce.productionType(), parseForests);
-                parseNode = parseForestManager.createParseNode(parse, stack.position, reduce.production(), derivation);
+                parseNode = parseForestManager.createParseNode(parse, reduce.production(), derivation);
             }
 
             link = stackManager.createStackLink(parse, newStackWithGotoState, stack, parseNode);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipRejects.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipRejects.java
@@ -34,8 +34,7 @@ public class ReducerSkipRejects
             stackManager.rejectStackLink(parse, existingDirectLinkToActiveStateWithGoto);
         else if(!existingDirectLinkToActiveStateWithGoto.isRejected()) {
             Derivation derivation =
-                parseForestManager.createDerivation(parse, existingDirectLinkToActiveStateWithGoto.to.position,
-                    reduce.production(), reduce.productionType(), parseForests);
+                parseForestManager.createDerivation(parse, reduce.production(), reduce.productionType(), parseForests);
 
             parseForestManager.addDerivation(parse, parseNode, derivation);
         }
@@ -52,10 +51,9 @@ public class ReducerSkipRejects
 
             stackManager.rejectStackLink(parse, newDirectLinkToActiveStateWithGoto);
         } else {
-            Derivation derivation = parseForestManager.createDerivation(parse, stack.position, reduce.production(),
-                reduce.productionType(), parseForests);
-            ParseForest parseNode =
-                parseForestManager.createParseNode(parse, stack.position, reduce.production(), derivation);
+            Derivation derivation =
+                parseForestManager.createDerivation(parse, reduce.production(), reduce.productionType(), parseForests);
+            ParseForest parseNode = parseForestManager.createParseNode(parse, reduce.production(), derivation);
 
             newDirectLinkToActiveStateWithGoto =
                 stackManager.createStackLink(parse, existingActiveStackWithGotoState, stack, parseNode);
@@ -75,10 +73,9 @@ public class ReducerSkipRejects
 
             stackManager.rejectStackLink(parse, link);
         } else {
-            Derivation derivation = parseForestManager.createDerivation(parse, stack.position, reduce.production(),
-                reduce.productionType(), parseForests);
-            ParseForest parseNode =
-                parseForestManager.createParseNode(parse, stack.position, reduce.production(), derivation);
+            Derivation derivation =
+                parseForestManager.createDerivation(parse, reduce.production(), reduce.productionType(), parseForests);
+            ParseForest parseNode = parseForestManager.createParseNode(parse, reduce.production(), derivation);
 
             link = stackManager.createStackLink(parse, newStackWithGotoState, stack, parseNode);
         }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/AbstractStackNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/AbstractStackNode.java
@@ -1,16 +1,13 @@
 package org.spoofax.jsglr2.stack;
 
 import org.metaborg.parsetable.IState;
-import org.spoofax.jsglr2.parser.Position;
 
 public abstract class AbstractStackNode<ParseForest> {
 
     public final IState state;
-    public final Position position;
 
-    public AbstractStackNode(IState state, Position position) {
+    public AbstractStackNode(IState state) {
         this.state = state;
-        this.position = position;
     }
 
     // True if non-empty and all links are rejected

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/StackManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/StackManager.java
@@ -3,7 +3,6 @@ package org.spoofax.jsglr2.stack;
 import org.metaborg.parsetable.IState;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
 
 public abstract class StackManager
 //@formatter:off
@@ -12,12 +11,11 @@ public abstract class StackManager
 //@formatter:on
     extends AbstractStackManager<ParseForest, org.spoofax.jsglr2.stack.StackNode<ParseForest>> {
 
-    protected abstract StackNode createStackNode(IState state, Position position, boolean isRoot);
+    protected abstract StackNode createStackNode(IState state, boolean isRoot);
 
     @Override public org.spoofax.jsglr2.stack.StackNode<ParseForest> createInitialStackNode(
         AbstractParse<ParseForest, org.spoofax.jsglr2.stack.StackNode<ParseForest>> parse, IState state) {
-        org.spoofax.jsglr2.stack.StackNode<ParseForest> newStackNode =
-            createStackNode(state, parse.currentPosition(), true);
+        org.spoofax.jsglr2.stack.StackNode<ParseForest> newStackNode = createStackNode(state, true);
 
         parse.observing.notify(observer -> observer.createStackNode(newStackNode));
 
@@ -26,8 +24,7 @@ public abstract class StackManager
 
     @Override public org.spoofax.jsglr2.stack.StackNode<ParseForest> createStackNode(
         AbstractParse<ParseForest, org.spoofax.jsglr2.stack.StackNode<ParseForest>> parse, IState state) {
-        org.spoofax.jsglr2.stack.StackNode<ParseForest> newStackNode =
-            createStackNode(state, parse.currentPosition(), false);
+        org.spoofax.jsglr2.stack.StackNode<ParseForest> newStackNode = createStackNode(state, false);
 
         parse.observing.notify(observer -> observer.createStackNode(newStackNode));
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/StackNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/StackNode.java
@@ -1,12 +1,11 @@
 package org.spoofax.jsglr2.stack;
 
 import org.metaborg.parsetable.IState;
-import org.spoofax.jsglr2.parser.Position;
 
 public abstract class StackNode<ParseForest> extends AbstractStackNode<ParseForest> {
 
-    public StackNode(IState state, Position position) {
-        super(state, position);
+    public StackNode(IState state) {
+        super(state);
     }
 
     public abstract Iterable<StackLink<ParseForest, StackNode<ParseForest>>> getLinks();

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/basic/BasicStackManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/basic/BasicStackManager.java
@@ -2,14 +2,13 @@ package org.spoofax.jsglr2.stack.basic;
 
 import org.metaborg.parsetable.IState;
 import org.spoofax.jsglr2.parseforest.IParseForest;
-import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.stack.StackManager;
 
 public class BasicStackManager<ParseForest extends IParseForest>
     extends StackManager<ParseForest, BasicStackNode<ParseForest>> {
 
-    @Override protected BasicStackNode<ParseForest> createStackNode(IState state, Position position, boolean isRoot) {
-        return new BasicStackNode<>(state, position);
+    @Override protected BasicStackNode<ParseForest> createStackNode(IState state, boolean isRoot) {
+        return new BasicStackNode<>(state);
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/basic/BasicStackNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/basic/BasicStackNode.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.metaborg.parsetable.IState;
-import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.StackNode;
 
@@ -13,8 +12,8 @@ public class BasicStackNode<ParseForest> extends StackNode<ParseForest> {
     // Directed to the initial stack node
     private final ArrayList<StackLink<ParseForest, StackNode<ParseForest>>> links = new ArrayList<>();
 
-    public BasicStackNode(IState state, Position position) {
-        super(state, position);
+    public BasicStackNode(IState state) {
+        super(state);
     }
 
     @Override public List<StackLink<ParseForest, StackNode<ParseForest>>> getLinks() {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/hybrid/HybridStackManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/hybrid/HybridStackManager.java
@@ -2,14 +2,13 @@ package org.spoofax.jsglr2.stack.hybrid;
 
 import org.metaborg.parsetable.IState;
 import org.spoofax.jsglr2.parseforest.IParseForest;
-import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.stack.StackManager;
 
 public class HybridStackManager<ParseForest extends IParseForest>
     extends StackManager<ParseForest, HybridStackNode<ParseForest>> {
 
-    @Override protected HybridStackNode<ParseForest> createStackNode(IState state, Position position, boolean isRoot) {
-        return new HybridStackNode<>(state, position);
+    @Override protected HybridStackNode<ParseForest> createStackNode(IState state, boolean isRoot) {
+        return new HybridStackNode<>(state);
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/hybrid/HybridStackNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/stack/hybrid/HybridStackNode.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import org.metaborg.parsetable.IState;
-import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.StackNode;
 import org.spoofax.jsglr2.util.iterators.SingleElementWithListIterable;
@@ -14,8 +13,8 @@ public class HybridStackNode<ParseForest> extends StackNode<ParseForest> {
     private StackLink<ParseForest, StackNode<ParseForest>> firstLink;
     private ArrayList<StackLink<ParseForest, StackNode<ParseForest>>> otherLinks;
 
-    public HybridStackNode(IState state, Position position) {
-        super(state, position);
+    public HybridStackNode(IState state) {
+        super(state);
     }
 
     @Override public Iterable<StackLink<ParseForest, StackNode<ParseForest>>> getLinks() {


### PR DESCRIPTION
@udesou In the interest of "reducing state during parsing", as indicated by @jasperdenkers in Slack, I have removed the storing of positions in stack nodes. This field was never used, except as `beginPosition` in the `LayoutSenstivieParseForestManager` to create new parse nodes and derivation nodes. However, we think that this `beginPosition` can also be derived from other parts of the state. We would like you to review this change, to check whether this change is valid and does not semantically change the layout sensitive parsing algorithm.

To link the change back to the pseudocode in http://udesou.info/wp-content/uploads/2018/10/layout-pp.pdf:
In figure 3, I have removed the `beginPos` argument from the `CREATE-TREE-NODE` function. As replacement, I say that `beginPos = t1.first` (or `beginPos = endPos` in the case that the list of sub-trees is empty).
In the code of JSGLR2, this corresponds with the `TODO` comments on [line 19](https://github.com/metaborg/jsglr/pull/20/files#diff-dc1db834c381b0d3af6328307c19ea21R19) and [line 58](https://github.com/metaborg/jsglr/pull/20/files#diff-dc1db834c381b0d3af6328307c19ea21R58) of LayoutSensitiveParseForestManager.java.

@jasperdenkers Besides removing a whole bunch of `position`s, I've also made a slight change to AbstractParse.java.