### PR TITLE
Fix observers

### DIFF
--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/BenchmarkParserObserver.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/BenchmarkParserObserver.java
@@ -7,6 +7,7 @@ import org.metaborg.parsetable.IState;
 import org.metaborg.parsetable.actions.IAction;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.elkhound.AbstractElkhoundStackNode;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.ForShifterElement;
@@ -17,7 +18,7 @@ import org.spoofax.jsglr2.stack.IStackNode;
 import org.spoofax.jsglr2.stack.StackLink;
 import org.spoofax.jsglr2.stack.collections.IForActorStacks;
 
-public class BenchmarkParserObserver<ParseForest extends IParseForest, StackNode extends IStackNode<ParseForest>>
+public class BenchmarkParserObserver<ParseForest extends IParseForest, StackNode extends IStackNode>
     implements IParserObserver<ParseForest, StackNode> {
 
     @Override public void parseStart(AbstractParse<ParseForest, StackNode> parse) {
@@ -61,7 +62,7 @@ public class BenchmarkParserObserver<ParseForest extends IParseForest, StackNode
     @Override public void skipRejectedStack(StackNode stack) {
     }
 
-    @Override public void addForShifter(ForShifterElement<ParseForest, StackNode> forShifterElement) {
+    @Override public void addForShifter(ForShifterElement<StackNode> forShifterElement) {
     }
 
     @Override public void doReductions(AbstractParse<ParseForest, StackNode> parse, StackNode stack, IReduce reduce) {
@@ -88,7 +89,8 @@ public class BenchmarkParserObserver<ParseForest extends IParseForest, StackNode
     @Override public void createParseNode(ParseForest parseNode, IProduction production) {
     }
 
-    @Override public void createDerivation(int nodeNumber, IProduction production, ParseForest[] parseNodes) {
+    @Override public void createDerivation(IDerivation<ParseForest> derivationNode, IProduction production,
+        ParseForest[] parseNodes) {
     }
 
     @Override public void createCharacterNode(ParseForest characterNode, int character) {
@@ -97,7 +99,7 @@ public class BenchmarkParserObserver<ParseForest extends IParseForest, StackNode
     @Override public void addDerivation(ParseForest parseNode) {
     }
 
-    @Override public void shifter(ParseForest termNode, Queue<ForShifterElement<ParseForest, StackNode>> forShifter) {
+    @Override public void shifter(ParseForest termNode, Queue<ForShifterElement<StackNode>> forShifter) {
     }
 
     @Override public void remark(String remark) {

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/datastructures/JSGLR2ActiveStacksBenchmark.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/datastructures/JSGLR2ActiveStacksBenchmark.java
@@ -105,7 +105,7 @@ public abstract class JSGLR2ActiveStacksBenchmark extends JSGLR2DataStructureBen
         }
 
         @Override public void shifter(BasicParseForest termNode,
-            Queue<ForShifterElement<BasicParseForest, BasicStackNode<BasicParseForest>>> forShifter) {
+            Queue<ForShifterElement<BasicStackNode<BasicParseForest>>> forShifter) {
             operations.add(bh -> activeStacks.clear());
         }
 

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/datastructures/JSGLR2ForShifterBenchmark.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/datastructures/JSGLR2ForShifterBenchmark.java
@@ -26,7 +26,7 @@ public abstract class JSGLR2ForShifterBenchmark extends JSGLR2DataStructureBench
 
     @Param public Representation representation;
 
-    Collection<ForShifterElement<?, ?>> forShifter;
+    Collection<ForShifterElement<?>> forShifter;
 
     @Override public void postParserSetup() {
         forShifterObserver = new ForShifterObserver();
@@ -56,7 +56,7 @@ public abstract class JSGLR2ForShifterBenchmark extends JSGLR2DataStructureBench
     }
 
     class ParseRound {
-        final List<ForShifterElement<?, ?>> forShifterElements = new ArrayList<>();
+        final List<ForShifterElement<?>> forShifterElements = new ArrayList<>();
     }
 
     class ForShifterObserver extends BenchmarkParserObserver<BasicParseForest, BasicStackNode<BasicParseForest>> {
@@ -73,7 +73,7 @@ public abstract class JSGLR2ForShifterBenchmark extends JSGLR2DataStructureBench
         }
 
         @Override public void
-            addForShifter(ForShifterElement<BasicParseForest, BasicStackNode<BasicParseForest>> forShifterElement) {
+            addForShifter(ForShifterElement<BasicStackNode<BasicParseForest>> forShifterElement) {
             currentParseRound().forShifterElements.add(forShifterElement);
         }
 
@@ -83,10 +83,10 @@ public abstract class JSGLR2ForShifterBenchmark extends JSGLR2DataStructureBench
         for(ParseRound parseRound : forShifterObserver.parseRounds) {
             forShifter.clear();
 
-            for(ForShifterElement<?, ?> forShifterElement : parseRound.forShifterElements)
+            for(ForShifterElement<?> forShifterElement : parseRound.forShifterElements)
                 forShifter.add(forShifterElement);
 
-            for(ForShifterElement<?, ?> forShifterElement : forShifter)
+            for(ForShifterElement<?> forShifterElement : forShifter)
                 bh.consume(forShifterElement);
         }
     }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/ParserMeasureObserver.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/ParserMeasureObserver.java
@@ -9,6 +9,7 @@ import org.metaborg.parsetable.IState;
 import org.metaborg.parsetable.actions.IAction;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.elkhound.AbstractElkhoundStackNode;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parseforest.hybrid.HybridParseNode;
 import org.spoofax.jsglr2.parser.AbstractParse;
@@ -175,7 +176,8 @@ public class ParserMeasureObserver<ParseForest extends IParseForest>
         parseNodes.add((HybridParseNode) parseNode);
     }
 
-    @Override public void createDerivation(int nodeNumber, IProduction production, ParseForest[] parseNodes) {
+    @Override public void createDerivation(IDerivation<ParseForest> derivationNode, IProduction production,
+        ParseForest[] parseNodes) {
     }
 
     @Override public void createCharacterNode(ParseForest characterNode, int character) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentParseForestManager.java
@@ -16,7 +16,7 @@ public class DataDependentParseForestManager
         Position beginPosition, IProduction production, DataDependentDerivation firstDerivation) {
         DataDependentParseNode parseNode = new DataDependentParseNode(production);
 
-        // parse.notify(observer -> observer.createParseNode(parseNode, production));
+        // parse.observing.notify(observer -> observer.createParseNode(parseNode, production));
 
         addDerivation(parse, parseNode, firstDerivation);
 
@@ -52,14 +52,14 @@ public class DataDependentParseForestManager
         DataDependentParseForest[] parseForests) {
         DataDependentDerivation derivation = new DataDependentDerivation(production, productionType, parseForests);
 
-        // parse.notify(observer -> observer.createDerivation(derivation.nodeNumber, production, parseForests));
+        // parse.observing.notify(observer -> observer.createDerivation(derivation, production, parseForests));
 
         return derivation;
     }
 
     @Override public void addDerivation(AbstractParse<DataDependentParseForest, ?> parse,
         DataDependentParseNode parseNode, DataDependentDerivation derivation) {
-        // parse.notify(observer -> observer.addDerivation(parseNode));
+        // parse.observing.notify(observer -> observer.addDerivation(parseNode));
 
         parseNode.addDerivation(derivation);
     }
@@ -67,7 +67,7 @@ public class DataDependentParseForestManager
     @Override public DataDependentCharacterNode createCharacterNode(AbstractParse<DataDependentParseForest, ?> parse) {
         DataDependentCharacterNode characterNode = new DataDependentCharacterNode(parse.currentChar);
 
-        // parse.notify(observer -> observer.createCharacterNode(termNode, termNode.character));
+        // parse.observing.notify(observer -> observer.createCharacterNode(termNode, termNode.character));
 
         return characterNode;
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
@@ -18,7 +18,7 @@ public class LayoutSensitiveParseForestManager
         LayoutSensitiveParseNode parseNode =
             new LayoutSensitiveParseNode(beginPosition, parse.currentPosition(), production);
 
-        // parse.notify(observer -> observer.createParseNode(parseNode, production));
+        // parse.observing.notify(observer -> observer.createParseNode(parseNode, production));
 
         addDerivation(parse, parseNode, firstDerivation);
 
@@ -139,7 +139,7 @@ public class LayoutSensitiveParseForestManager
         LayoutSensitiveDerivation derivation = new LayoutSensitiveDerivation(parse, beginPosition, leftPosition,
             rightPosition, parse.currentPosition(), production, productionType, parseForests);
 
-        // parse.notify(observer -> observer.createDerivation(derivation.nodeNumber, production, parseForests));
+        // parse.observing.notify(observer -> observer.createDerivation(derivation, production, parseForests));
 
         return derivation;
     }
@@ -170,7 +170,7 @@ public class LayoutSensitiveParseForestManager
 
     @Override public void addDerivation(AbstractParse<LayoutSensitiveParseForest, ?> parse,
         LayoutSensitiveParseNode parseNode, LayoutSensitiveDerivation derivation) {
-        // parse.notify(observer -> observer.addDerivation(parseNode));
+        // parse.observing.notify(observer -> observer.addDerivation(parseNode));
 
         parseNode.addDerivation(derivation);
     }
@@ -180,7 +180,7 @@ public class LayoutSensitiveParseForestManager
         LayoutSensitiveCharacterNode termNode =
             new LayoutSensitiveCharacterNode(parse.currentPosition(), parse.currentChar);
 
-        // parse.notify(observer -> observer.createCharacterNode(termNode, termNode.character));
+        // parse.observing.notify(observer -> observer.createCharacterNode(termNode, termNode.character));
 
         return termNode;
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/BasicParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/BasicParseForestManager.java
@@ -15,7 +15,7 @@ public class BasicParseForestManager extends ParseForestManager<BasicParseForest
         IProduction production, BasicDerivation firstDerivation) {
         BasicParseNode parseNode = new BasicParseNode(production);
 
-        // parse.notify(observer -> observer.createParseNode(parseNode, production));
+        // parse.observing.notify(observer -> observer.createParseNode(parseNode, production));
 
         addDerivation(parse, parseNode, firstDerivation);
 
@@ -50,14 +50,14 @@ public class BasicParseForestManager extends ParseForestManager<BasicParseForest
         IProduction production, ProductionType productionType, BasicParseForest[] parseForests) {
         BasicDerivation derivation = new BasicDerivation(production, productionType, parseForests);
 
-        // parse.notify(observer -> observer.createDerivation(derivation.nodeNumber, production, parseForests));
+        // parse.observing.notify(observer -> observer.createDerivation(derivation, production, parseForests));
 
         return derivation;
     }
 
     @Override public void addDerivation(AbstractParse<BasicParseForest, ?> parse, BasicParseNode parseNode,
         BasicDerivation derivation) {
-        // parse.notify(observer -> observer.addDerivation(parseNode));
+        // parse.observing.notify(observer -> observer.addDerivation(parseNode));
 
         parseNode.addDerivation(derivation);
     }
@@ -65,7 +65,7 @@ public class BasicParseForestManager extends ParseForestManager<BasicParseForest
     @Override public BasicCharacterNode createCharacterNode(AbstractParse<BasicParseForest, ?> parse) {
         BasicCharacterNode termNode = new BasicCharacterNode(parse.currentChar);
 
-        // parse.notify(observer -> observer.createCharacterNode(termNode, termNode.character));
+        // parse.observing.notify(observer -> observer.createCharacterNode(termNode, termNode.character));
 
         return termNode;
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/hybrid/HybridParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/hybrid/HybridParseForestManager.java
@@ -15,8 +15,8 @@ public class HybridParseForestManager extends ParseForestManager<HybridParseFore
         IProduction production, HybridDerivation firstDerivation) {
         HybridParseNode parseNode = new HybridParseNode(production, firstDerivation);
 
-        // parse.notify(observer -> observer.createParseNode(parseNode, production));
-        // parse.notify(observer -> observer.addDerivation(parseNode));
+        // parse.observing.notify(observer -> observer.createParseNode(parseNode, production));
+        // parse.observing.notify(observer -> observer.addDerivation(parseNode));
 
         return parseNode;
     }
@@ -50,14 +50,14 @@ public class HybridParseForestManager extends ParseForestManager<HybridParseFore
         HybridParseForest[] parseForests) {
         HybridDerivation derivation = new HybridDerivation(production, productionType, parseForests);
 
-        // parse.notify(observer -> observer.createDerivation(production, derivation.parseForests));
+        // parse.observing.notify(observer -> observer.createDerivation(derivation, production, parseForests));
 
         return derivation;
     }
 
     @Override public void addDerivation(AbstractParse<HybridParseForest, ?> parse, HybridParseNode parseNode,
         HybridDerivation derivation) {
-        // parse.notify(observer -> observer.addDerivation(parseNode));
+        // parse.observing.notify(observer -> observer.addDerivation(parseNode));
 
         parseNode.addDerivation(derivation);
     }
@@ -65,7 +65,7 @@ public class HybridParseForestManager extends ParseForestManager<HybridParseFore
     @Override public HybridCharacterNode createCharacterNode(AbstractParse<HybridParseForest, ?> parse) {
         HybridCharacterNode characterNode = new HybridCharacterNode(parse.currentChar);
 
-        // parse.notify(observer -> observer.createCharacterNode(characterNode, characterNode.character));
+        // parse.observing.notify(observer -> observer.createCharacterNode(characterNode, characterNode.character));
 
         return characterNode;
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/IParserObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/IParserObserver.java
@@ -7,6 +7,7 @@ import org.metaborg.parsetable.IState;
 import org.metaborg.parsetable.actions.IAction;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.elkhound.AbstractElkhoundStackNode;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.ForShifterElement;
@@ -66,7 +67,7 @@ public interface IParserObserver
 
     void createParseNode(ParseForest parseNode, IProduction production);
 
-    void createDerivation(int nodeNumber, IProduction production, ParseForest[] parseNodes);
+    void createDerivation(IDerivation<ParseForest> derivationNode, IProduction production, ParseForest[] parseNodes);
 
     void createCharacterNode(ParseForest characterNode, int character);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserLogObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserLogObserver.java
@@ -8,6 +8,7 @@ import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.actions.IAction;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.elkhound.AbstractElkhoundStackNode;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.ForShifterElement;
@@ -25,6 +26,7 @@ public class ParserLogObserver
     extends ParserObserver<ParseForest, StackNode> {
 
     @Override public void parseStart(AbstractParse<ParseForest, StackNode> parse) {
+        super.parseStart(parse);
         log("\n  ---  Starting parse for input '" + parse.inputString + "'  ---\n");
     }
 
@@ -104,7 +106,8 @@ public class ParserLogObserver
         log("Create parse node " + id(parseNode) + " for production " + production.id());
     }
 
-    @Override public void createDerivation(int nodeNumber, IProduction production, ParseForest[] parseNodes) {
+    @Override public void createDerivation(IDerivation<ParseForest> derivation, IProduction production,
+        ParseForest[] parseNodes) {
         log("Create derivation with parse nodes " + parseForestListToString(parseNodes));
     }
 
@@ -116,7 +119,7 @@ public class ParserLogObserver
     }
 
     @Override public void addDerivation(ParseForest parseNode) {
-        log("Add derivation to parse node '" + id(parseNode));
+        log("Add derivation to parse node " + id(parseNode));
     }
 
     @Override public void shifter(ParseForest termNode, Queue<ForShifterElement<StackNode>> forShifter) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserObserver.java
@@ -10,7 +10,10 @@ import org.metaborg.parsetable.IState;
 import org.metaborg.parsetable.actions.IAction;
 import org.metaborg.parsetable.actions.IReduce;
 import org.spoofax.jsglr2.elkhound.AbstractElkhoundStackNode;
+import org.spoofax.jsglr2.parseforest.ICharacterNode;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
+import org.spoofax.jsglr2.parseforest.IParseNode;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.ForShifterElement;
 import org.spoofax.jsglr2.parser.result.ParseFailure;
@@ -30,9 +33,15 @@ public abstract class ParserObserver
     private int stackNodeCount = 0;
     private int stackLinkCount = 0;
 
+    protected final Map<IDerivation<ParseForest>, Integer> derivationId = new HashMap<>();
     protected final Map<ParseForest, Integer> parseNodeId = new HashMap<>();
     protected final Map<StackNode, Integer> stackNodeId = new HashMap<>();
     protected final Map<StackLink<ParseForest, StackNode>, Integer> stackLinkId = new HashMap<>();
+
+    protected void registerDerivationNode(IDerivation<ParseForest> derivation) {
+        // use same count as parse nodes as they're in the same tree in the visualisation
+        derivationId.put(derivation, parseNodeCount++);
+    }
 
     protected void registerParseNode(ParseForest parseNode) {
         parseNodeId.put(parseNode, parseNodeCount++);
@@ -44,6 +53,10 @@ public abstract class ParserObserver
 
     protected void registerStackLink(StackLink<ParseForest, StackNode> stackLink) {
         stackLinkId.put(stackLink, stackLinkCount++);
+    }
+
+    protected int id(IDerivation<ParseForest> derivation) {
+        return derivationId.get(derivation);
     }
 
     protected int id(ParseForest parseNode) {
@@ -59,6 +72,13 @@ public abstract class ParserObserver
     }
 
     @Override public void parseStart(AbstractParse<ParseForest, StackNode> parse) {
+        parseNodeCount = 0;
+        stackNodeCount = 0;
+        stackLinkCount = 0;
+        derivationId.clear();
+        parseNodeId.clear();
+        stackNodeId.clear();
+        stackLinkId.clear();
     }
 
     @Override public void parseCharacter(AbstractParse<ParseForest, StackNode> parse,
@@ -129,7 +149,9 @@ public abstract class ParserObserver
         registerParseNode(parseNode);
     }
 
-    @Override public void createDerivation(int nodeNumber, IProduction production, ParseForest[] parseNodes) {
+    @Override public void createDerivation(IDerivation<ParseForest> derivation, IProduction production,
+        ParseForest[] parseNodes) {
+        registerDerivationNode(derivation);
     }
 
     @Override public void createCharacterNode(ParseForest characterNode, int character) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserVisualisationObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserVisualisationObserver.java
@@ -11,6 +11,7 @@ import org.metaborg.characterclasses.CharacterClassFactory;
 import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.actions.IAction;
 import org.metaborg.parsetable.actions.IReduce;
+import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.ForShifterElement;
@@ -30,6 +31,8 @@ public class ParserVisualisationObserver
     List<String> jsonTrace = new ArrayList<>();
 
     @Override public void parseStart(AbstractParse<ParseForest, StackNode> parse) {
+        super.parseStart(parse);
+        jsonTrace.clear();
         trace("{\"action\":\"start\",\"inputString\":\"" + parse.inputString + "\"}");
     }
 
@@ -59,7 +62,8 @@ public class ParserVisualisationObserver
     }
 
     @Override public void forActorStacks(IForActorStacks<StackNode> forActorStacks) {
-        trace("{\"action\":\"forActorStacks\",\"forActor\":" + forActorStacks + "}");
+        // TODO forActorStacks has no proper toString, luckily this is not needed for visualisation
+        // trace("{\"action\":\"forActorStacks\",\"forActor\":" + forActorStacks + "}");
     }
 
     @Override public void actor(StackNode stack, AbstractParse<ParseForest, StackNode> parse,
@@ -108,8 +112,11 @@ public class ParserVisualisationObserver
             + ",\"term\":\"" + escape(production.descriptor()) + "\"}");
     }
 
-    @Override public void createDerivation(int nodeNumber, IProduction production, ParseForest[] parseNodes) {
-        trace("{\"action\":\"createDerivation\",\"nodeNumber\":" + nodeNumber + ",\"production\":" + production.id()
+    @Override public void createDerivation(IDerivation<ParseForest> derivation, IProduction production,
+        ParseForest[] parseNodes) {
+        super.createDerivation(derivation, production, parseNodes);
+
+        trace("{\"action\":\"createDerivation\",\"nodeNumber\":" + id(derivation) + ",\"production\":" + production.id()
             + ",\"term\":\"" + escape(production.descriptor()) + "\",\"subTrees\":"
             + parseForestListToString(parseNodes) + "}");
     }


### PR DESCRIPTION
- The ParserObserver now resets id maps and counts when starting parse
- Fix type generics for some of the benchmarking observers
- Change createDerivation to accept derivation node instead of number
- Store derivation nodes in a new id map
  - Uses the same id space as parse nodes, because they are in one tree
    in the visualisation