### PR TITLE
Refactor integrationtest

### DIFF
--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/Sdf3ToParseTable.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/Sdf3ToParseTable.java
@@ -6,6 +6,8 @@ import java.util.function.Function;
 import org.apache.commons.vfs2.FileObject;
 import org.metaborg.core.MetaborgException;
 import org.metaborg.core.context.IContext;
+import org.metaborg.core.editor.IEditorRegistry;
+import org.metaborg.core.editor.NullEditorRegistry;
 import org.metaborg.core.language.ILanguageComponent;
 import org.metaborg.core.language.ILanguageImpl;
 import org.metaborg.core.project.IProject;
@@ -38,6 +40,10 @@ public class Sdf3ToParseTable {
         @Override protected void bindProject() {
             bind(SimpleProjectService.class).in(Singleton.class);
             bind(IProjectService.class).to(SimpleProjectService.class);
+        }
+
+        @Override protected void bindEditor() {
+            bind(IEditorRegistry.class).to(NullEditorRegistry.class).in(Singleton.class);
         }
     }
 

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/testset/TestSetReader.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/testset/TestSetReader.java
@@ -57,10 +57,7 @@ public abstract class TestSetReader implements WithParseTableFromTerm {
 
                 Sdf3ToParseTable sdf3ToParseTable = new Sdf3ToParseTable(resource -> basePath() + resource);
 
-                IStrategoTerm parseTableTerm =
-                    sdf3ToParseTable.getParseTableTerm(testSetParseTableFromSDF3.name + ".sdf3");
-
-                this.parseTableTerm = parseTableTerm;
+                this.parseTableTerm = sdf3ToParseTable.getParseTableTerm(testSetParseTableFromSDF3.name + ".sdf3");
 
                 break;
             default:

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -29,14 +29,10 @@ import org.spoofax.terms.io.binary.TermReader;
 
 public abstract class BaseTest implements WithParseTable {
 
-    private TermReader termReader;
-    protected AstUtilities astUtilities;
+    private TermReader termReader = new TermReader(new TermFactory());
+    protected AstUtilities astUtilities = new AstUtilities();
 
     protected BaseTest() {
-        TermFactory termFactory = new TermFactory();
-        this.termReader = new TermReader(termFactory);
-
-        this.astUtilities = new AstUtilities();
     }
 
     public TermReader getTermReader() {


### PR DESCRIPTION
I resolved the warning about the `DummyEditorRegistry` by binding the `NullEditorRegistry`. Besides that, I've done some small refactorings regarding inlining of variables.