### PR TITLE
Pass StackNode to ParseForestManager instead of just Position

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/actions/ActionsFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/actions/ActionsFactory.java
@@ -2,7 +2,10 @@ package org.spoofax.jsglr2.actions;
 
 import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.ProductionType;
-import org.metaborg.parsetable.actions.*;
+import org.metaborg.parsetable.actions.IAccept;
+import org.metaborg.parsetable.actions.IReduce;
+import org.metaborg.parsetable.actions.IReduceLookahead;
+import org.metaborg.parsetable.actions.IShift;
 import org.metaborg.parsetable.characterclasses.ICharacterClass;
 import org.spoofax.jsglr2.util.Cache;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/datadependent/DataDependentParseForestManager.java
@@ -7,13 +7,13 @@ import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.ProductionType;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
+import org.spoofax.jsglr2.stack.IStackNode;
 
 public class DataDependentParseForestManager
     extends ParseForestManager<DataDependentParseForest, DataDependentParseNode, DataDependentDerivation> {
 
     @Override public DataDependentParseNode createParseNode(AbstractParse<DataDependentParseForest, ?> parse,
-        Position beginPosition, IProduction production, DataDependentDerivation firstDerivation) {
+        IStackNode stack, IProduction production, DataDependentDerivation firstDerivation) {
         DataDependentParseNode parseNode = new DataDependentParseNode(production);
 
         // parse.observing.notify(observer -> observer.createParseNode(parseNode, production));
@@ -48,7 +48,7 @@ public class DataDependentParseForestManager
     }
 
     @Override public DataDependentDerivation createDerivation(AbstractParse<DataDependentParseForest, ?> parse,
-        Position beginPosition, IProduction production, ProductionType productionType,
+        IStackNode stack, IProduction production, ProductionType productionType,
         DataDependentParseForest[] parseForests) {
         DataDependentDerivation derivation = new DataDependentDerivation(production, productionType, parseForests);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
@@ -2,7 +2,6 @@ package org.spoofax.jsglr2.imploder;
 
 import static org.spoofax.jsglr.client.imploder.ImploderAttachment.putImploderAttachment;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
@@ -9,14 +9,15 @@ import org.metaborg.sdf2table.grammar.layoutconstraints.ConstraintSelector;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.Position;
+import org.spoofax.jsglr2.stack.IStackNode;
 
 public class LayoutSensitiveParseForestManager
     extends ParseForestManager<LayoutSensitiveParseForest, LayoutSensitiveParseNode, LayoutSensitiveDerivation> {
 
     @Override public LayoutSensitiveParseNode createParseNode(AbstractParse<LayoutSensitiveParseForest, ?> parse,
-        Position beginPosition, IProduction production, LayoutSensitiveDerivation firstDerivation) {
+        IStackNode stack, IProduction production, LayoutSensitiveDerivation firstDerivation) {
         LayoutSensitiveParseNode parseNode =
-            new LayoutSensitiveParseNode(beginPosition, parse.currentPosition(), production);
+            new LayoutSensitiveParseNode(stack.position(), parse.currentPosition(), production);
 
         // parse.observing.notify(observer -> observer.createParseNode(parseNode, production));
 
@@ -51,8 +52,9 @@ public class LayoutSensitiveParseForestManager
     }
 
     @Override public LayoutSensitiveDerivation createDerivation(AbstractParse<LayoutSensitiveParseForest, ?> parse,
-        Position beginPosition, IProduction production, ProductionType productionType,
+        IStackNode stack, IProduction production, ProductionType productionType,
         LayoutSensitiveParseForest[] parseForests) {
+        Position beginPosition = stack.position();
 
         // FIXME since EndPosition is wrong, right is also wrong
         Position leftPosition = null;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ParseForestManager.java
@@ -14,13 +14,15 @@ public abstract class ParseForestManager
 {
 
     /**
-     * @param stack The parse node will be added to the link _to_ this stack node.
+     * @param stack
+     *            The parse node will be added to the link _to_ this stack node.
      */
     abstract public ParseNode createParseNode(AbstractParse<ParseForest, ?> parse, IStackNode stack,
         IProduction production, Derivation firstDerivation);
 
     /**
-     * @param stack The derivation will be added to the parse node on the link _to_ this stack node.
+     * @param stack
+     *            The derivation will be added to the parse node on the link _to_ this stack node.
      */
     abstract public Derivation createDerivation(AbstractParse<ParseForest, ?> parse, IStackNode stack,
         IProduction production, ProductionType productionType, ParseForest[] parseForests);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ParseForestManager.java
@@ -13,9 +13,15 @@ public abstract class ParseForestManager
 //@formatter:on
 {
 
+    /**
+     * @param stack The parse node will be added to the link _to_ this stack node.
+     */
     abstract public ParseNode createParseNode(AbstractParse<ParseForest, ?> parse, IStackNode stack,
         IProduction production, Derivation firstDerivation);
 
+    /**
+     * @param stack The derivation will be added to the parse node on the link _to_ this stack node.
+     */
     abstract public Derivation createDerivation(AbstractParse<ParseForest, ?> parse, IStackNode stack,
         IProduction production, ProductionType productionType, ParseForest[] parseForests);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/ParseForestManager.java
@@ -3,7 +3,7 @@ package org.spoofax.jsglr2.parseforest;
 import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.ProductionType;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
+import org.spoofax.jsglr2.stack.IStackNode;
 
 public abstract class ParseForestManager
 //@formatter:off
@@ -13,10 +13,10 @@ public abstract class ParseForestManager
 //@formatter:on
 {
 
-    abstract public ParseNode createParseNode(AbstractParse<ParseForest, ?> parse, Position beginPosition,
+    abstract public ParseNode createParseNode(AbstractParse<ParseForest, ?> parse, IStackNode stack,
         IProduction production, Derivation firstDerivation);
 
-    abstract public Derivation createDerivation(AbstractParse<ParseForest, ?> parse, Position beginPosition,
+    abstract public Derivation createDerivation(AbstractParse<ParseForest, ?> parse, IStackNode stack,
         IProduction production, ProductionType productionType, ParseForest[] parseForests);
 
     abstract public void addDerivation(AbstractParse<ParseForest, ?> parse, ParseNode parseNode, Derivation derivation);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/BasicParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/basic/BasicParseForestManager.java
@@ -7,11 +7,11 @@ import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.ProductionType;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
+import org.spoofax.jsglr2.stack.IStackNode;
 
 public class BasicParseForestManager extends ParseForestManager<BasicParseForest, BasicParseNode, BasicDerivation> {
 
-    @Override public BasicParseNode createParseNode(AbstractParse<BasicParseForest, ?> parse, Position beginPosition,
+    @Override public BasicParseNode createParseNode(AbstractParse<BasicParseForest, ?> parse, IStackNode stack,
         IProduction production, BasicDerivation firstDerivation) {
         BasicParseNode parseNode = new BasicParseNode(production);
 
@@ -46,7 +46,7 @@ public class BasicParseForestManager extends ParseForestManager<BasicParseForest
         }
     }
 
-    @Override public BasicDerivation createDerivation(AbstractParse<BasicParseForest, ?> parse, Position beginPosition,
+    @Override public BasicDerivation createDerivation(AbstractParse<BasicParseForest, ?> parse, IStackNode stack,
         IProduction production, ProductionType productionType, BasicParseForest[] parseForests) {
         BasicDerivation derivation = new BasicDerivation(production, productionType, parseForests);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/empty/NullParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/empty/NullParseForestManager.java
@@ -8,11 +8,11 @@ import org.spoofax.jsglr2.parseforest.hybrid.HybridDerivation;
 import org.spoofax.jsglr2.parseforest.hybrid.HybridParseForest;
 import org.spoofax.jsglr2.parseforest.hybrid.HybridParseNode;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
+import org.spoofax.jsglr2.stack.IStackNode;
 
 public class NullParseForestManager extends ParseForestManager<HybridParseForest, HybridParseNode, HybridDerivation> {
 
-    @Override public HybridParseNode createParseNode(AbstractParse<HybridParseForest, ?> parse, Position beginPosition,
+    @Override public HybridParseNode createParseNode(AbstractParse<HybridParseForest, ?> parse, IStackNode stack,
         IProduction production, HybridDerivation firstDerivation) {
         return null;
     }
@@ -22,9 +22,8 @@ public class NullParseForestManager extends ParseForestManager<HybridParseForest
         return null;
     }
 
-    @Override public HybridDerivation createDerivation(AbstractParse<HybridParseForest, ?> parse,
-        Position beginPosition, IProduction production, ProductionType productionType,
-        HybridParseForest[] parseForests) {
+    @Override public HybridDerivation createDerivation(AbstractParse<HybridParseForest, ?> parse, IStackNode stack,
+        IProduction production, ProductionType productionType, HybridParseForest[] parseForests) {
         return null;
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/hybrid/HybridParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parseforest/hybrid/HybridParseForestManager.java
@@ -7,11 +7,11 @@ import org.metaborg.parsetable.IProduction;
 import org.metaborg.parsetable.ProductionType;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
-import org.spoofax.jsglr2.parser.Position;
+import org.spoofax.jsglr2.stack.IStackNode;
 
 public class HybridParseForestManager extends ParseForestManager<HybridParseForest, HybridParseNode, HybridDerivation> {
 
-    @Override public HybridParseNode createParseNode(AbstractParse<HybridParseForest, ?> parse, Position beginPosition,
+    @Override public HybridParseNode createParseNode(AbstractParse<HybridParseForest, ?> parse, IStackNode stack,
         IProduction production, HybridDerivation firstDerivation) {
         HybridParseNode parseNode = new HybridParseNode(production, firstDerivation);
 
@@ -45,9 +45,8 @@ public class HybridParseForestManager extends ParseForestManager<HybridParseFore
         }
     }
 
-    @Override public HybridDerivation createDerivation(AbstractParse<HybridParseForest, ?> parse,
-        Position beginPosition, IProduction production, ProductionType productionType,
-        HybridParseForest[] parseForests) {
+    @Override public HybridDerivation createDerivation(AbstractParse<HybridParseForest, ?> parse, IStackNode stack,
+        IProduction production, ProductionType productionType, HybridParseForest[] parseForests) {
         HybridDerivation derivation = new HybridDerivation(production, productionType, parseForests);
 
         // parse.observing.notify(observer -> observer.createDerivation(derivation, production, parseForests));

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReduceManagerFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReduceManagerFactory.java
@@ -15,15 +15,13 @@ import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.stack.AbstractStackManager;
 import org.spoofax.jsglr2.stack.IStackNode;
 
-/*
-Implementation note: in theory, this factory is an unnecessary bypass for the constructors of ReduceManagers.
-It is unnecessary, because after the factory has been created and passed to the Parser, the factory is only used once.
-However, using this factory prevents the duplication of the new StackManager in JSGLR2Variants.getParser.
-This duplication would either mean
-- having to extract the new StackManager as a variable and having to explicitly write all type parameters, or
-- constructing two new StackManagers instead.
-Having a ReduceManagerFactory was preferred over these other two options.
-*/
+// Implementation note: in theory, this factory is an unnecessary bypass for the constructors of ReduceManagers.
+// It is unnecessary, because the factory is only used once after it has been created and passed to the Parser.
+// However, using this factory prevents the duplication of the new StackManager in JSGLR2Variants.getParser.
+// This duplication would either mean
+// - having to extract the new StackManager as a variable and having to explicitly write all type parameters, or
+// - constructing two new StackManagers instead.
+// Having a ReduceManagerFactory was preferred over these other two options.
 public interface ReduceManagerFactory
 //@formatter:off
    <ParseForest   extends IParseForest,

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/Reducer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/Reducer.java
@@ -37,9 +37,8 @@ public class Reducer
      */
     public void reducerExistingStackWithDirectLink(Parse parse, IReduce reduce,
         StackLink<ParseForest, StackNode> existingDirectLinkToActiveStateWithGoto, ParseForest[] parseForests) {
-        Derivation derivation =
-            parseForestManager.createDerivation(parse, existingDirectLinkToActiveStateWithGoto.to.position(),
-                reduce.production(), reduce.productionType(), parseForests);
+        Derivation derivation = parseForestManager.createDerivation(parse, existingDirectLinkToActiveStateWithGoto.to,
+            reduce.production(), reduce.productionType(), parseForests);
 
         @SuppressWarnings("unchecked") ParseNode parseNode =
             (ParseNode) existingDirectLinkToActiveStateWithGoto.parseForest;
@@ -58,10 +57,9 @@ public class Reducer
      */
     public StackLink<ParseForest, StackNode> reducerExistingStackWithoutDirectLink(Parse parse, IReduce reduce,
         StackNode existingActiveStackWithGotoState, StackNode stack, ParseForest[] parseForests) {
-        Derivation derivation = parseForestManager.createDerivation(parse, stack.position(), reduce.production(),
+        Derivation derivation = parseForestManager.createDerivation(parse, stack, reduce.production(),
             reduce.productionType(), parseForests);
-        ParseForest parseNode =
-            parseForestManager.createParseNode(parse, stack.position(), reduce.production(), derivation);
+        ParseForest parseNode = parseForestManager.createParseNode(parse, stack, reduce.production(), derivation);
 
         StackLink<ParseForest, StackNode> newDirectLinkToActiveStateWithGoto =
             stackManager.createStackLink(parse, existingActiveStackWithGotoState, stack, parseNode);
@@ -79,10 +77,9 @@ public class Reducer
      */
     public StackNode reducerNoExistingStack(Parse parse, IReduce reduce, StackNode stack, IState gotoState,
         ParseForest[] parseForests) {
-        Derivation derivation = parseForestManager.createDerivation(parse, stack.position(), reduce.production(),
+        Derivation derivation = parseForestManager.createDerivation(parse, stack, reduce.production(),
             reduce.productionType(), parseForests);
-        ParseForest parseNode =
-            parseForestManager.createParseNode(parse, stack.position(), reduce.production(), derivation);
+        ParseForest parseNode = parseForestManager.createParseNode(parse, stack, reduce.production(), derivation);
 
         StackNode newStackWithGotoState = stackManager.createStackNode(parse, gotoState);
         StackLink<ParseForest, StackNode> link =

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexical.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexical.java
@@ -31,9 +31,8 @@ public class ReducerSkipLayoutAndLexical
             (ParseNode) existingDirectLinkToActiveStateWithGoto.parseForest;
 
         if(parseNode != null) {
-            Derivation derivation =
-                parseForestManager.createDerivation(parse, existingDirectLinkToActiveStateWithGoto.to.position(),
-                    reduce.production(), reduce.productionType(), parseForests);
+            Derivation derivation = parseForestManager.createDerivation(parse,
+                existingDirectLinkToActiveStateWithGoto.to, reduce.production(), reduce.productionType(), parseForests);
             parseForestManager.addDerivation(parse, parseNode, derivation);
         }
 
@@ -48,9 +47,9 @@ public class ReducerSkipLayoutAndLexical
         if(reduce.production().isSkippableInParseForest())
             parseNode = null;
         else {
-            Derivation derivation = parseForestManager.createDerivation(parse, stack.position(), reduce.production(),
+            Derivation derivation = parseForestManager.createDerivation(parse, stack, reduce.production(),
                 reduce.productionType(), parseForests);
-            parseNode = parseForestManager.createParseNode(parse, stack.position(), reduce.production(), derivation);
+            parseNode = parseForestManager.createParseNode(parse, stack, reduce.production(), derivation);
         }
 
         StackLink<ParseForest, StackNode> newDirectLinkToActiveStateWithGoto =
@@ -69,9 +68,9 @@ public class ReducerSkipLayoutAndLexical
         if(reduce.production().isSkippableInParseForest())
             parseNode = null;
         else {
-            Derivation derivation = parseForestManager.createDerivation(parse, stack.position(), reduce.production(),
+            Derivation derivation = parseForestManager.createDerivation(parse, stack, reduce.production(),
                 reduce.productionType(), parseForests);
-            parseNode = parseForestManager.createParseNode(parse, stack.position(), reduce.production(), derivation);
+            parseNode = parseForestManager.createParseNode(parse, stack, reduce.production(), derivation);
         }
 
         StackNode newStackWithGotoState = stackManager.createStackNode(parse, gotoState);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexicalAndRejects.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipLayoutAndLexicalAndRejects.java
@@ -33,9 +33,8 @@ public class ReducerSkipLayoutAndLexicalAndRejects
         if(reduce.isRejectProduction())
             stackManager.rejectStackLink(parse, existingDirectLinkToActiveStateWithGoto);
         else if(!existingDirectLinkToActiveStateWithGoto.isRejected() && parseNode != null) {
-            Derivation derivation =
-                parseForestManager.createDerivation(parse, existingDirectLinkToActiveStateWithGoto.to.position(),
-                    reduce.production(), reduce.productionType(), parseForests);
+            Derivation derivation = parseForestManager.createDerivation(parse,
+                existingDirectLinkToActiveStateWithGoto.to, reduce.production(), reduce.productionType(), parseForests);
             parseForestManager.addDerivation(parse, parseNode, derivation);
         }
     }
@@ -55,10 +54,9 @@ public class ReducerSkipLayoutAndLexicalAndRejects
             if(reduce.production().isSkippableInParseForest())
                 parseNode = null;
             else {
-                Derivation derivation = parseForestManager.createDerivation(parse, stack.position(),
-                    reduce.production(), reduce.productionType(), parseForests);
-                parseNode =
-                    parseForestManager.createParseNode(parse, stack.position(), reduce.production(), derivation);
+                Derivation derivation = parseForestManager.createDerivation(parse, stack, reduce.production(),
+                    reduce.productionType(), parseForests);
+                parseNode = parseForestManager.createParseNode(parse, stack, reduce.production(), derivation);
             }
 
             newDirectLinkToActiveStateWithGoto =
@@ -84,10 +82,9 @@ public class ReducerSkipLayoutAndLexicalAndRejects
             if(reduce.production().isSkippableInParseForest())
                 parseNode = null;
             else {
-                Derivation derivation = parseForestManager.createDerivation(parse, stack.position(),
-                    reduce.production(), reduce.productionType(), parseForests);
-                parseNode =
-                    parseForestManager.createParseNode(parse, stack.position(), reduce.production(), derivation);
+                Derivation derivation = parseForestManager.createDerivation(parse, stack, reduce.production(),
+                    reduce.productionType(), parseForests);
+                parseNode = parseForestManager.createParseNode(parse, stack, reduce.production(), derivation);
             }
 
             link = stackManager.createStackLink(parse, newStackWithGotoState, stack, parseNode);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipRejects.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/reducing/ReducerSkipRejects.java
@@ -33,9 +33,8 @@ public class ReducerSkipRejects
         if(reduce.isRejectProduction())
             stackManager.rejectStackLink(parse, existingDirectLinkToActiveStateWithGoto);
         else if(!existingDirectLinkToActiveStateWithGoto.isRejected()) {
-            Derivation derivation =
-                parseForestManager.createDerivation(parse, existingDirectLinkToActiveStateWithGoto.to.position(),
-                    reduce.production(), reduce.productionType(), parseForests);
+            Derivation derivation = parseForestManager.createDerivation(parse,
+                existingDirectLinkToActiveStateWithGoto.to, reduce.production(), reduce.productionType(), parseForests);
 
             parseForestManager.addDerivation(parse, parseNode, derivation);
         }
@@ -51,10 +50,9 @@ public class ReducerSkipRejects
 
             stackManager.rejectStackLink(parse, newDirectLinkToActiveStateWithGoto);
         } else {
-            Derivation derivation = parseForestManager.createDerivation(parse, stack.position(), reduce.production(),
+            Derivation derivation = parseForestManager.createDerivation(parse, stack, reduce.production(),
                 reduce.productionType(), parseForests);
-            ParseForest parseNode =
-                parseForestManager.createParseNode(parse, stack.position(), reduce.production(), derivation);
+            ParseForest parseNode = parseForestManager.createParseNode(parse, stack, reduce.production(), derivation);
 
             newDirectLinkToActiveStateWithGoto =
                 stackManager.createStackLink(parse, existingActiveStackWithGotoState, stack, parseNode);
@@ -74,10 +72,9 @@ public class ReducerSkipRejects
 
             stackManager.rejectStackLink(parse, link);
         } else {
-            Derivation derivation = parseForestManager.createDerivation(parse, stack.position(), reduce.production(),
+            Derivation derivation = parseForestManager.createDerivation(parse, stack, reduce.production(),
                 reduce.productionType(), parseForests);
-            ParseForest parseNode =
-                parseForestManager.createParseNode(parse, stack.position(), reduce.production(), derivation);
+            ParseForest parseNode = parseForestManager.createParseNode(parse, stack, reduce.production(), derivation);
 
             link = stackManager.createStackLink(parse, newStackWithGotoState, stack, parseNode);
         }


### PR DESCRIPTION
This will be useful for incremental parsing, as the state of the stack will be saved in the parse nodes.
The `LayoutSensitiveParseForestManager` can still use the stack position as `beginPosition`, as it used to.
Other `ParseForestManager`s are not affected (besides method signature changes), as they do not use the `Position` anymore.