### PR TITLE
Refactor JSGLR2Variants and add ImploderVariant

### DIFF
--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParseTable.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParseTable.java
@@ -3,10 +3,11 @@ package org.spoofax.jsglr2.benchmark.jsglr2;
 import org.metaborg.sdf2table.parsetable.query.ActionsForCharacterRepresentation;
 import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
 import org.openjdk.jmh.annotations.Param;
-import org.spoofax.jsglr2.JSGLR2Variants.ParseTableVariant;
 import org.spoofax.jsglr2.JSGLR2Variants.ParserVariant;
-import org.spoofax.jsglr2.JSGLR2Variants.Variant;
 import org.spoofax.jsglr2.benchmark.BenchmarkStringInputTestSetReader;
+import org.spoofax.jsglr2.imploder.ImploderVariant;
+import org.spoofax.jsglr2.integration.IntegrationVariant;
+import org.spoofax.jsglr2.integration.ParseTableVariant;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
 import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
 import org.spoofax.jsglr2.parser.ParseException;
@@ -41,14 +42,15 @@ public abstract class JSGLR2BenchmarkParseTable extends JSGLR2Benchmark<StringIn
 
     @Param({ "Basic" }) public Reducing reducing;
 
-    @Override protected Variant variant() {
-        Variant variant =
-            new Variant(new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation),
-                new ParserVariant(activeStacksRepresentation, forActorStacksRepresentation, parseForestRepresentation,
-                    parseForestConstruction, stackRepresentation, reducing));
+    @Override protected IntegrationVariant variant() {
+        IntegrationVariant variant = new IntegrationVariant(
+            new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation),
+            new ParserVariant(activeStacksRepresentation, forActorStacksRepresentation, parseForestRepresentation,
+                parseForestConstruction, stackRepresentation, reducing),
+            ImploderVariant.CombinedRecursive);
         System.out.println("JSGLR2 PT Var: " + variant.name());
-        if(variant.equals(new Variant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted,
-            ProductionToGotoRepresentation.JavaHashMap), naiveParserVariant)))
+        if(variant.equals(new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted,
+            ProductionToGotoRepresentation.JavaHashMap), naiveParserVariant, ImploderVariant.CombinedRecursive)))
             throw new IllegalStateException("naive variant is only benchmarked once");
         else
             return variant;

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParsing.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParsing.java
@@ -3,10 +3,11 @@ package org.spoofax.jsglr2.benchmark.jsglr2;
 import org.metaborg.sdf2table.parsetable.query.ActionsForCharacterRepresentation;
 import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
 import org.openjdk.jmh.annotations.Param;
-import org.spoofax.jsglr2.JSGLR2Variants.ParseTableVariant;
 import org.spoofax.jsglr2.JSGLR2Variants.ParserVariant;
-import org.spoofax.jsglr2.JSGLR2Variants.Variant;
 import org.spoofax.jsglr2.benchmark.BenchmarkStringInputTestSetReader;
+import org.spoofax.jsglr2.imploder.ImploderVariant;
+import org.spoofax.jsglr2.integration.IntegrationVariant;
+import org.spoofax.jsglr2.integration.ParseTableVariant;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
 import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
 import org.spoofax.jsglr2.parser.ParseException;
@@ -42,10 +43,12 @@ public abstract class JSGLR2BenchmarkParsing extends JSGLR2Benchmark<StringInput
 
     @Param({ "Basic", "Elkhound" }) public Reducing reducing;
 
-    @Override protected Variant variant() {
-        return new Variant(new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation),
+    @Override protected IntegrationVariant variant() {
+        return new IntegrationVariant(
+            new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation),
             new ParserVariant(activeStacksRepresentation, forActorStacksRepresentation, parseForestRepresentation,
-                parseForestConstruction, stackRepresentation, reducing));
+                parseForestConstruction, stackRepresentation, reducing),
+            ImploderVariant.CombinedRecursive);
     }
 
     @Override protected boolean implode() {

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParsingAndImploding.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParsingAndImploding.java
@@ -3,10 +3,11 @@ package org.spoofax.jsglr2.benchmark.jsglr2;
 import org.metaborg.sdf2table.parsetable.query.ActionsForCharacterRepresentation;
 import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
 import org.openjdk.jmh.annotations.Param;
-import org.spoofax.jsglr2.JSGLR2Variants.ParseTableVariant;
 import org.spoofax.jsglr2.JSGLR2Variants.ParserVariant;
-import org.spoofax.jsglr2.JSGLR2Variants.Variant;
 import org.spoofax.jsglr2.benchmark.BenchmarkStringInputTestSetReader;
+import org.spoofax.jsglr2.imploder.ImploderVariant;
+import org.spoofax.jsglr2.integration.IntegrationVariant;
+import org.spoofax.jsglr2.integration.ParseTableVariant;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
 import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
 import org.spoofax.jsglr2.parser.ParseException;
@@ -41,13 +42,15 @@ public abstract class JSGLR2BenchmarkParsingAndImploding extends JSGLR2Benchmark
 
     @Param({ "Basic", "Elkhound" }) public Reducing reducing;
 
-    @Override protected Variant variant() {
+    @Override protected IntegrationVariant variant() {
         if(!implode)
             throw new IllegalStateException("this variant is not used for benchmarking");
 
-        return new Variant(new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation),
+        return new IntegrationVariant(
+            new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation),
             new ParserVariant(activeStacksRepresentation, forActorStacksRepresentation, parseForestRepresentation,
-                parseForestConstruction, stackRepresentation, reducing));
+                parseForestConstruction, stackRepresentation, reducing),
+            ImploderVariant.CombinedRecursive);
     }
 
     @Override protected boolean implode() {

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/IntegrationVariant.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/IntegrationVariant.java
@@ -1,0 +1,68 @@
+package org.spoofax.jsglr2.integration;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.metaborg.sdf2table.parsetable.query.ActionsForCharacterRepresentation;
+import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
+import org.spoofax.jsglr2.JSGLR2Variants;
+import org.spoofax.jsglr2.imploder.ImploderVariant;
+import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
+import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
+import org.spoofax.jsglr2.reducing.Reducing;
+import org.spoofax.jsglr2.stack.StackRepresentation;
+import org.spoofax.jsglr2.stack.collections.ActiveStacksRepresentation;
+import org.spoofax.jsglr2.stack.collections.ForActorStacksRepresentation;
+
+public class IntegrationVariant {
+    public final ParseTableVariant parseTable;
+    public final JSGLR2Variants.Variant jsglr2;
+    public final JSGLR2Variants.ParserVariant parser;
+    public final ImploderVariant imploder;
+
+    public IntegrationVariant(ParseTableVariant parseTableVariant, JSGLR2Variants.ParserVariant parserVariant,
+        ImploderVariant imploderVariant) {
+        this.parseTable = parseTableVariant;
+        this.jsglr2 = new JSGLR2Variants.Variant(parserVariant, imploderVariant);
+        this.parser = parserVariant;
+        this.imploder = imploderVariant;
+    }
+
+    public IntegrationVariant(ParseTableVariant parseTableVariant, JSGLR2Variants.Variant jsglr2Variant) {
+        this.parseTable = parseTableVariant;
+        this.jsglr2 = jsglr2Variant;
+        this.parser = jsglr2Variant.parser;
+        this.imploder = jsglr2Variant.imploder;
+    }
+
+    public String name() {
+        return parseTable.name() + "/" + parser.name() + "/Imploder:" + imploder.name();
+    }
+
+    @Override public boolean equals(Object o) {
+        if(this == o) {
+            return true;
+        }
+        if(o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        IntegrationVariant that = (IntegrationVariant) o;
+
+        return parseTable.equals(that.parseTable) && parser.equals(that.parser) && imploder.equals(that.imploder);
+    }
+
+    public static List<IntegrationVariant> testVariants() {
+        //@formatter:off
+        return Arrays.asList(
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.ArrayList,     ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Basic,          Reducing.Basic), ImploderVariant.CombinedRecursive),
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted, ProductionToGotoRepresentation.JavaHashMap), new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.ArrayList,     ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Basic,          Reducing.Basic), ImploderVariant.CombinedRecursive),
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.Hybrid,         Reducing.Basic), ImploderVariant.CombinedRecursive),
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound, Reducing.Elkhound), ImploderVariant.CombinedRecursive),/*
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.Hybrid,         Reducing.Basic)),
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.HybridElkhound, Reducing.Elkhound)),*/
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Incremental, ParseForestConstruction.Full,      StackRepresentation.Hybrid, Reducing.Basic), ImploderVariant.CombinedRecursive)
+        );
+        //@formatter:on
+    }
+}

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/ParseTableVariant.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/ParseTableVariant.java
@@ -1,0 +1,35 @@
+package org.spoofax.jsglr2.integration;
+
+import org.metaborg.sdf2table.parsetable.query.ActionsForCharacterRepresentation;
+import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
+
+// TODO move to SDF and use in StateFactory?
+public class ParseTableVariant {
+    public final ActionsForCharacterRepresentation actionsForCharacterRepresentation;
+    public final ProductionToGotoRepresentation productionToGotoRepresentation;
+
+    public ParseTableVariant(ActionsForCharacterRepresentation actionsForCharacterRepresentation,
+        ProductionToGotoRepresentation productionToGotoRepresentation) {
+        this.actionsForCharacterRepresentation = actionsForCharacterRepresentation;
+        this.productionToGotoRepresentation = productionToGotoRepresentation;
+    }
+
+    public String name() {
+        return "ActionsForCharacterRepresentation:" + actionsForCharacterRepresentation
+            + "/ProductionToGotoRepresentation:" + productionToGotoRepresentation;
+    }
+
+    @Override public boolean equals(Object o) {
+        if(this == o) {
+            return true;
+        }
+        if(o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ParseTableVariant that = (ParseTableVariant) o;
+
+        return actionsForCharacterRepresentation == that.actionsForCharacterRepresentation
+            && productionToGotoRepresentation == that.productionToGotoRepresentation;
+    }
+}

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/Sdf3ToParseTable.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/Sdf3ToParseTable.java
@@ -28,7 +28,6 @@ import org.metaborg.spoofax.meta.core.SpoofaxExtensionModule;
 import org.metaborg.spoofax.meta.core.SpoofaxMeta;
 import org.metaborg.util.concurrent.IClosableLock;
 import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.jsglr2.JSGLR2Variants.ParseTableVariant;
 import org.strategoxt.HybridInterpreter;
 
 import com.google.common.collect.Iterables;

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/WithParseTable.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/WithParseTable.java
@@ -1,10 +1,9 @@
 package org.spoofax.jsglr2.integration;
 
 import org.metaborg.parsetable.IParseTable;
-import org.spoofax.jsglr2.JSGLR2Variants;
 
 public interface WithParseTable {
 
-    IParseTable getParseTable(JSGLR2Variants.ParseTableVariant variant) throws Exception;
+    IParseTable getParseTable(ParseTableVariant variant) throws Exception;
 
 }

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/WithParseTableFromTerm.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/WithParseTableFromTerm.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import org.metaborg.characterclasses.CharacterClassFactory;
 import org.metaborg.parsetable.IParseTable;
 import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.jsglr2.JSGLR2Variants;
 import org.spoofax.jsglr2.actions.ActionsFactory;
 import org.spoofax.jsglr2.parsetable.ParseTableReader;
 import org.spoofax.jsglr2.states.StateFactory;
@@ -13,7 +12,7 @@ import org.spoofax.terms.io.binary.TermReader;
 
 public interface WithParseTableFromTerm extends WithParseTable {
 
-    default IParseTable getParseTable(JSGLR2Variants.ParseTableVariant variant) throws Exception {
+    default IParseTable getParseTable(ParseTableVariant variant) throws Exception {
         return new ParseTableReader(new CharacterClassFactory(true, true), new ActionsFactory(true),
             new StateFactory(variant.actionsForCharacterRepresentation, variant.productionToGotoRepresentation))
                 .read(getParseTableTerm());
@@ -31,7 +30,7 @@ public interface WithParseTableFromTerm extends WithParseTable {
         setParseTableTerm(parseTableTerm);
     }
 
-    public InputStream resourceInputStream(String resource) throws Exception;
+    InputStream resourceInputStream(String resource) throws Exception;
 
     default IStrategoTerm parseTableTerm(String filename) throws Exception {
         InputStream inputStream = resourceInputStream(filename);

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/testset/TestSetReader.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/testset/TestSetReader.java
@@ -9,8 +9,8 @@ import java.util.*;
 import org.metaborg.characterclasses.CharacterClassFactory;
 import org.metaborg.parsetable.IParseTable;
 import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.jsglr2.JSGLR2Variants;
 import org.spoofax.jsglr2.actions.ActionsFactory;
+import org.spoofax.jsglr2.integration.ParseTableVariant;
 import org.spoofax.jsglr2.integration.Sdf3ToParseTable;
 import org.spoofax.jsglr2.integration.WithParseTableFromTerm;
 import org.spoofax.jsglr2.parsetable.ParseTableReader;
@@ -38,7 +38,7 @@ public abstract class TestSetReader<Input> implements WithParseTableFromTerm {
         }
     }
 
-    public IParseTable getParseTable(JSGLR2Variants.ParseTableVariant variant) throws Exception {
+    public IParseTable getParseTable(ParseTableVariant variant) throws Exception {
         return new ParseTableReader(new CharacterClassFactory(true, true), new ActionsFactory(true),
             new StateFactory(variant.actionsForCharacterRepresentation, variant.productionToGotoRepresentation))
                 .read(getParseTableTerm());

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -18,6 +18,8 @@ import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr2.JSGLR2;
 import org.spoofax.jsglr2.JSGLR2Result;
 import org.spoofax.jsglr2.JSGLR2Variants;
+import org.spoofax.jsglr2.integration.IntegrationVariant;
+import org.spoofax.jsglr2.integration.ParseTableVariant;
 import org.spoofax.jsglr2.integration.WithParseTable;
 import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
 import org.spoofax.jsglr2.parser.IParser;
@@ -40,7 +42,7 @@ public abstract class BaseTest implements WithParseTable {
         return termReader;
     }
 
-    protected IParseTable getParseTableFailOnException(JSGLR2Variants.ParseTableVariant variant) {
+    protected IParseTable getParseTableFailOnException(ParseTableVariant variant) {
         try {
             return getParseTable(variant);
         } catch(Exception e) {
@@ -53,7 +55,7 @@ public abstract class BaseTest implements WithParseTable {
     }
 
     protected void testParseSuccess(String inputString) {
-        for(JSGLR2Variants.Variant variant : JSGLR2Variants.testVariants()) {
+        for(IntegrationVariant variant : IntegrationVariant.testVariants()) {
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
             IParser<?, ?> parser = JSGLR2Variants.getParser(parseTable, variant.parser);
 
@@ -64,7 +66,7 @@ public abstract class BaseTest implements WithParseTable {
     }
 
     protected void testParseFailure(String inputString) {
-        for(JSGLR2Variants.Variant variant : JSGLR2Variants.testVariants()) {
+        for(IntegrationVariant variant : IntegrationVariant.testVariants()) {
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
             IParser<?, ?> parser = JSGLR2Variants.getParser(parseTable, variant.parser);
 
@@ -96,17 +98,17 @@ public abstract class BaseTest implements WithParseTable {
 
     private void testSuccess(String inputString, String expectedOutputAstString, String startSymbol,
         boolean equalityByExpansions) {
-        for(JSGLR2Variants.Variant variant : JSGLR2Variants.testVariants()) {
+        for(IntegrationVariant variant : IntegrationVariant.testVariants()) {
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
-            IStrategoTerm actualOutputAst = testSuccess(parseTable, variant.parser, startSymbol, inputString);
+            IStrategoTerm actualOutputAst = testSuccess(parseTable, variant.jsglr2, startSymbol, inputString);
 
             assertEqualAST("Variant '" + variant.name() + "' has incorrect AST", expectedOutputAstString,
                 actualOutputAst, equalityByExpansions);
         }
     }
 
-    protected IStrategoTerm testSuccess(IParseTable parseTable, JSGLR2Variants.ParserVariant variant,
-        String startSymbol, String inputString) {
+    protected IStrategoTerm testSuccess(IParseTable parseTable, JSGLR2Variants.Variant variant, String startSymbol,
+        String inputString) {
         JSGLR2<?, IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant);
 
         return testSuccess("Variant '" + variant.name() + "' failed parsing: ",
@@ -135,12 +137,12 @@ public abstract class BaseTest implements WithParseTable {
 
     private void testIncrementalSuccess(String[] inputStrings, String[] expectedOutputAstStrings, String startSymbol,
         boolean equalityByExpansions) {
-        for(JSGLR2Variants.Variant variant : JSGLR2Variants.testVariants()) {
+        for(IntegrationVariant variant : IntegrationVariant.testVariants()) {
             if(variant.parser.parseForestRepresentation != ParseForestRepresentation.Incremental)
                 continue;
 
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
-            JSGLR2<?, IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant.parser);
+            JSGLR2<?, IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant.jsglr2);
 
             IStrategoTerm actualOutputAst;
             String filename = "" + System.nanoTime(); // To ensure the results will be cached
@@ -191,9 +193,9 @@ public abstract class BaseTest implements WithParseTable {
     }
 
     protected void testTokens(String inputString, List<TokenDescriptor> expectedTokens) {
-        for(JSGLR2Variants.Variant variant : JSGLR2Variants.testVariants()) {
+        for(IntegrationVariant variant : IntegrationVariant.testVariants()) {
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
-            JSGLR2<?, IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant.parser);
+            JSGLR2<?, IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant.jsglr2);
 
             JSGLR2Result<?> jsglr2Result = jsglr2.parseResult(inputString, "", null);
 

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTestWithParseTableFromTermWithJSGLR1.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTestWithParseTableFromTermWithJSGLR1.java
@@ -6,7 +6,7 @@ import org.metaborg.parsetable.IParseTable;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.InvalidParseTableException;
 import org.spoofax.jsglr.shared.SGLRException;
-import org.spoofax.jsglr2.JSGLR2Variants;
+import org.spoofax.jsglr2.integration.IntegrationVariant;
 import org.spoofax.jsglr2.integration.WithJSGLR1;
 
 public abstract class BaseTestWithParseTableFromTermWithJSGLR1 extends BaseTestWithParseTableFromTerm
@@ -16,9 +16,9 @@ public abstract class BaseTestWithParseTableFromTermWithJSGLR1 extends BaseTestW
         try {
             IStrategoTerm expectedOutputAst = (IStrategoTerm) getJSGLR1().parse(inputString, null, null).output;
 
-            for(JSGLR2Variants.Variant variant : JSGLR2Variants.testVariants()) {
+            for(IntegrationVariant variant : IntegrationVariant.testVariants()) {
                 IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
-                IStrategoTerm actualOutputAst = testSuccess(parseTable, variant.parser, null, inputString);
+                IStrategoTerm actualOutputAst = testSuccess(parseTable, variant.jsglr2, null, inputString);
 
                 assertEqualTermExpansions(expectedOutputAst, actualOutputAst);
             }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTestWithSdf3ParseTables.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTestWithSdf3ParseTables.java
@@ -3,7 +3,7 @@ package org.spoofax.jsglr2.integrationtest;
 import org.junit.BeforeClass;
 import org.metaborg.core.MetaborgException;
 import org.metaborg.parsetable.IParseTable;
-import org.spoofax.jsglr2.JSGLR2Variants.ParseTableVariant;
+import org.spoofax.jsglr2.integration.ParseTableVariant;
 import org.spoofax.jsglr2.integration.Sdf3ToParseTable;
 
 public abstract class BaseTestWithSdf3ParseTables extends BaseTest {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2.java
@@ -4,9 +4,11 @@ import org.metaborg.characterclasses.CharacterClassFactory;
 import org.metaborg.parsetable.IParseTable;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr2.JSGLR2Variants.ParserVariant;
+import org.spoofax.jsglr2.JSGLR2Variants.Variant;
 import org.spoofax.jsglr2.actions.ActionsFactory;
 import org.spoofax.jsglr2.imploder.IImploder;
 import org.spoofax.jsglr2.imploder.ImplodeResult;
+import org.spoofax.jsglr2.imploder.ImploderVariant;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
 import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
@@ -30,30 +32,30 @@ public class JSGLR2<ParseForest extends IParseForest, AbstractSyntaxTree> {
 
     public static JSGLR2<?, IStrategoTerm> standard(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
-            new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
+            new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound,
-                Reducing.Elkhound));
+                Reducing.Elkhound), ImploderVariant.CombinedRecursive));
     }
 
     public static JSGLR2<?, IStrategoTerm> dataDependent(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
-            new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
+            new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.DataDependent, ParseForestConstruction.Full, StackRepresentation.Basic,
-                Reducing.DataDependent));
+                Reducing.DataDependent), ImploderVariant.CombinedRecursive));
     }
 
     public static JSGLR2<?, IStrategoTerm> layoutSensitive(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
-            new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
+            new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.LayoutSensitive, ParseForestConstruction.Full, StackRepresentation.Basic,
-                Reducing.DataDependent));
+                Reducing.DataDependent), ImploderVariant.CombinedRecursive));
     }
 
     public static JSGLR2<?, IStrategoTerm> incremental(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
-            new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
+            new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.Incremental, ParseForestConstruction.Full, StackRepresentation.Basic,
-                Reducing.Basic));
+                Reducing.Basic), ImploderVariant.CombinedRecursive));
     }
 
     public static JSGLR2<?, IStrategoTerm> standard(IStrategoTerm parseTableTerm) throws ParseTableReadException {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variants.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variants.java
@@ -1,18 +1,17 @@
 package org.spoofax.jsglr2;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.metaborg.parsetable.IParseTable;
-import org.metaborg.sdf2table.parsetable.query.ActionsForCharacterRepresentation;
-import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr2.datadependent.DataDependentParseForestManager;
 import org.spoofax.jsglr2.elkhound.BasicElkhoundStackManager;
 import org.spoofax.jsglr2.elkhound.ElkhoundParser;
 import org.spoofax.jsglr2.elkhound.HybridElkhoundStackManager;
 import org.spoofax.jsglr2.imploder.IImploder;
+import org.spoofax.jsglr2.imploder.ImploderVariant;
 import org.spoofax.jsglr2.imploder.NullStrategoImploder;
 import org.spoofax.jsglr2.imploder.StrategoTermImploder;
 import org.spoofax.jsglr2.incremental.IncrementalParse;
@@ -28,7 +27,6 @@ import org.spoofax.jsglr2.parser.Parse;
 import org.spoofax.jsglr2.parser.Parser;
 import org.spoofax.jsglr2.reducing.ReduceManagerFactory;
 import org.spoofax.jsglr2.reducing.Reducing;
-import org.spoofax.jsglr2.stack.IStackNode;
 import org.spoofax.jsglr2.stack.StackRepresentation;
 import org.spoofax.jsglr2.stack.basic.BasicStackManager;
 import org.spoofax.jsglr2.stack.collections.ActiveStacksRepresentation;
@@ -38,69 +36,37 @@ import org.spoofax.jsglr2.stack.hybrid.HybridStackManager;
 public class JSGLR2Variants {
 
     public static class Variant {
-        public ParseTableVariant parseTable;
-        public ParserVariant parser;
+        public final ParserVariant parser;
+        public final ImploderVariant imploder;
 
-        public Variant(ParseTableVariant parseTableVariant, ParserVariant parserVariant) {
-            this.parseTable = parseTableVariant;
+        public Variant(ParserVariant parserVariant, ImploderVariant imploderVariant) {
             this.parser = parserVariant;
+            this.imploder = imploderVariant;
         }
 
         public String name() {
-            return parseTable.name() + "/" + parser.name();
+            return parser.name() + "/" + imploder.name();
         }
 
         @Override public boolean equals(Object o) {
-            if(this == o) {
+            if(this == o)
                 return true;
-            }
-            if(o == null || getClass() != o.getClass()) {
+            if(o == null || getClass() != o.getClass())
                 return false;
-            }
 
-            Variant that = (Variant) o;
+            Variant variant = (Variant) o;
 
-            return parseTable.equals(that.parseTable) && parser.equals(that.parser);
-        }
-    }
-
-    public static class ParseTableVariant {
-        public ActionsForCharacterRepresentation actionsForCharacterRepresentation;
-        public ProductionToGotoRepresentation productionToGotoRepresentation;
-
-        public ParseTableVariant(ActionsForCharacterRepresentation actionsForCharacterRepresentation,
-            ProductionToGotoRepresentation productionToGotoRepresentation) {
-            this.actionsForCharacterRepresentation = actionsForCharacterRepresentation;
-            this.productionToGotoRepresentation = productionToGotoRepresentation;
-        }
-
-        public String name() {
-            return "ActionsForCharacterRepresentation:" + actionsForCharacterRepresentation
-                + "/ProductionToGotoRepresentation:" + productionToGotoRepresentation;
-        }
-
-        @Override public boolean equals(Object o) {
-            if(this == o) {
-                return true;
-            }
-            if(o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            ParseTableVariant that = (ParseTableVariant) o;
-
-            return actionsForCharacterRepresentation == that.actionsForCharacterRepresentation
-                && productionToGotoRepresentation == that.productionToGotoRepresentation;
+            return Objects.equals(parser, variant.parser) && imploder == variant.imploder;
         }
     }
 
     public static class ParserVariant {
-        public ActiveStacksRepresentation activeStacksRepresentation;
-        public ForActorStacksRepresentation forActorStacksRepresentation;
-        public ParseForestRepresentation parseForestRepresentation;
-        public ParseForestConstruction parseForestConstruction;
-        public StackRepresentation stackRepresentation;
-        public Reducing reducing;
+        public final ActiveStacksRepresentation activeStacksRepresentation;
+        public final ForActorStacksRepresentation forActorStacksRepresentation;
+        public final ParseForestRepresentation parseForestRepresentation;
+        public final ParseForestConstruction parseForestConstruction;
+        public final StackRepresentation stackRepresentation;
+        public final Reducing reducing;
 
         public ParserVariant(ActiveStacksRepresentation activeStacksRepresentation,
             ForActorStacksRepresentation forActorStacksRepresentation,
@@ -135,12 +101,10 @@ public class JSGLR2Variants {
         }
 
         @Override public boolean equals(Object o) {
-            if(this == o) {
+            if(this == o)
                 return true;
-            }
-            if(o == null || getClass() != o.getClass()) {
+            if(o == null || getClass() != o.getClass())
                 return false;
-            }
 
             ParserVariant that = (ParserVariant) o;
 
@@ -152,8 +116,8 @@ public class JSGLR2Variants {
         }
     }
 
-    public static List<ParserVariant> allVariants() {
-        List<ParserVariant> variants = new ArrayList<>();
+    public static List<Variant> allVariants() {
+        List<Variant> variants = new ArrayList<>();
 
         for(ActiveStacksRepresentation activeStacksRepresentation : ActiveStacksRepresentation.values()) {
             for(ForActorStacksRepresentation forActorStacksRepresentation : ForActorStacksRepresentation.values()) {
@@ -162,12 +126,14 @@ public class JSGLR2Variants {
                         for(ParseForestConstruction parseForestConstruction : ParseForestConstruction.values()) {
                             for(StackRepresentation stackRepresentation : StackRepresentation.values()) {
                                 for(Reducing reducing : Reducing.values()) {
-                                    ParserVariant variant = new ParserVariant(activeStacksRepresentation,
+                                    ParserVariant parserVariant = new ParserVariant(activeStacksRepresentation,
                                         forActorStacksRepresentation, parseForestRepresentation,
                                         parseForestConstruction, stackRepresentation, reducing);
 
-                                    if(variant.isValid())
-                                        variants.add(variant);
+                                    if(parserVariant.isValid())
+                                        for(ImploderVariant imploderVariant : ImploderVariant.values()) {
+                                            variants.add(new Variant(parserVariant, imploderVariant));
+                                        }
                                 }
                             }
                         }
@@ -176,20 +142,6 @@ public class JSGLR2Variants {
         }
 
         return variants;
-    }
-
-    public static List<Variant> testVariants() {
-        //@formatter:off
-        return Arrays.asList(
-            new Variant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new ParserVariant(ActiveStacksRepresentation.ArrayList,     ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Basic,          Reducing.Basic)),
-            new Variant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted, ProductionToGotoRepresentation.JavaHashMap), new ParserVariant(ActiveStacksRepresentation.ArrayList,     ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Basic,          Reducing.Basic)),
-            new Variant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.Hybrid,         Reducing.Basic)),
-            new Variant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound, Reducing.Elkhound)),/*
-            new Variant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.Hybrid,         Reducing.Basic)),
-            new Variant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.HybridElkhound, Reducing.Elkhound)),*/
-            new Variant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Incremental, ParseForestConstruction.Full,      StackRepresentation.Hybrid, Reducing.Basic))
-        );
-        //@formatter:on
     }
 
 
@@ -259,7 +211,7 @@ public class JSGLR2Variants {
     }
 
     private static <ParseForest extends IParseForest, ParseNode extends ParseForest, Derivation extends IDerivation<ParseForest>, PFM extends ParseForestManager<ParseForest, ParseNode, Derivation>>
-        IParser<?, ?> getParser(IParseTable parseTable, ParserVariant variant, PFM parseForestManager) {
+        IParser<ParseForest, ?> getParser(IParseTable parseTable, ParserVariant variant, PFM parseForestManager) {
         switch(variant.reducing) {
             case Elkhound:
                 switch(variant.stackRepresentation) {
@@ -300,25 +252,29 @@ public class JSGLR2Variants {
     public static List<IParser<?, ?>> allParsers(IParseTable parseTable) {
         List<IParser<?, ?>> parsers = new ArrayList<>();
 
-        for(ParserVariant variant : allVariants()) {
-            parsers.add(getParser(parseTable,
-                new ParserVariant(variant.activeStacksRepresentation, variant.forActorStacksRepresentation,
-                    variant.parseForestRepresentation, variant.parseForestConstruction, variant.stackRepresentation,
-                    variant.reducing)));
+        for(Variant variant : allVariants()) {
+            parsers.add(getParser(parseTable, variant.parser));
         }
 
         return parsers;
     }
 
-    public static JSGLR2<?, IStrategoTerm> getJSGLR2(IParseTable parseTable, ParserVariant variant) {
-        @SuppressWarnings("unchecked") IParser<IParseForest, IStackNode> parser =
-            (IParser<IParseForest, IStackNode>) getParser(parseTable, variant);
+    public static IImploder<?, ?> getImploder(Variant variant) {
+        if(variant.parser.parseForestRepresentation == ParseForestRepresentation.Null)
+            return new NullStrategoImploder<>();
+        switch(variant.imploder) {
+            default:
+            case CombinedRecursive:
+                return new StrategoTermImploder<>();
+        }
+    }
 
-        IImploder<IParseForest, IStrategoTerm> imploder;
-        if(variant.parseForestRepresentation == ParseForestRepresentation.Null)
-            imploder = new NullStrategoImploder<>();
-        else
-            imploder = new StrategoTermImploder<>();
+    public static JSGLR2<?, IStrategoTerm> getJSGLR2(IParseTable parseTable, Variant variant) {
+        @SuppressWarnings("unchecked") final IParser<IParseForest, ?> parser =
+            (IParser<IParseForest, ?>) getParser(parseTable, variant.parser);
+
+        @SuppressWarnings("unchecked") final IImploder<IParseForest, IStrategoTerm> imploder =
+            (IImploder<IParseForest, IStrategoTerm>) getImploder(variant);
 
         return new JSGLR2<>(parser, imploder);
     }
@@ -326,7 +282,7 @@ public class JSGLR2Variants {
     public static List<JSGLR2<?, IStrategoTerm>> allJSGLR2(IParseTable parseTable) {
         List<JSGLR2<?, IStrategoTerm>> jsglr2s = new ArrayList<>();
 
-        for(ParserVariant variant : allVariants()) {
+        for(Variant variant : allVariants()) {
             JSGLR2<?, IStrategoTerm> jsglr2 = getJSGLR2(parseTable, variant);
 
             jsglr2s.add(jsglr2);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variants.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variants.java
@@ -145,7 +145,7 @@ public class JSGLR2Variants {
     }
 
 
-    public static IParser<?, ?> getParser(IParseTable parseTable, ParserVariant variant) {
+    public static IParser<? extends IParseForest, ?> getParser(IParseTable parseTable, ParserVariant variant) {
         if(!variant.isValid())
             throw new IllegalStateException("Invalid parser variant");
 
@@ -259,9 +259,12 @@ public class JSGLR2Variants {
         return parsers;
     }
 
-    public static IImploder<?, ?> getImploder(Variant variant) {
+    public static <ParseForest extends IParseForest> IImploder<ParseForest, IStrategoTerm>
+        getImploder(Variant variant) {
+
         if(variant.parser.parseForestRepresentation == ParseForestRepresentation.Null)
             return new NullStrategoImploder<>();
+
         switch(variant.imploder) {
             default:
             case CombinedRecursive:
@@ -273,10 +276,7 @@ public class JSGLR2Variants {
         @SuppressWarnings("unchecked") final IParser<IParseForest, ?> parser =
             (IParser<IParseForest, ?>) getParser(parseTable, variant.parser);
 
-        @SuppressWarnings("unchecked") final IImploder<IParseForest, IStrategoTerm> imploder =
-            (IImploder<IParseForest, IStrategoTerm>) getImploder(variant);
-
-        return new JSGLR2<>(parser, imploder);
+        return new JSGLR2<>(parser, getImploder(variant));
     }
 
     public static List<JSGLR2<?, IStrategoTerm>> allJSGLR2(IParseTable parseTable) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/ImploderVariant.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/ImploderVariant.java
@@ -1,0 +1,5 @@
+package org.spoofax.jsglr2.imploder;
+
+public enum ImploderVariant {
+    CombinedRecursive
+}


### PR DESCRIPTION
- `JSGLR2Variants.Variant` has been moved to the integration package and renamed to `IntegrationVariant`
	- The method `testVariants` is now a member of `IntegrationVariant`
- `JSGLR2Variants.ParseTableVariant` has been moved to the integration package as well
- Added `ImploderVariant`
- Added `JSGLR2Variants.Variant`, which combines a `ParserVariant` with an `ImploderVariant`

I've made sure that all methods inside `JSGLR2` and `JSGLR2Variants` do not use anything from the integration project.