### PR TITLE
Remove type parameters that are not needed for users

### DIFF
--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2Benchmark.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2Benchmark.java
@@ -37,7 +37,7 @@ import org.spoofax.terms.ParseError;
 
 public abstract class JSGLR2Benchmark<Input> extends BaseBenchmark<Input> {
 
-    protected IParser<?, ?> parser; // Just parsing
+    protected IParser<?> parser; // Just parsing
     protected JSGLR2<?> jsglr2; // Parsing and imploding (including tokenization)
 
     public JSGLR2Benchmark(TestSetReader<Input> testSetReader) {

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2Benchmark.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2Benchmark.java
@@ -38,7 +38,7 @@ import org.spoofax.terms.ParseError;
 public abstract class JSGLR2Benchmark<Input> extends BaseBenchmark<Input> {
 
     protected IParser<?, ?> parser; // Just parsing
-    protected JSGLR2<?, ?> jsglr2; // Parsing and imploding (including tokenization)
+    protected JSGLR2<?> jsglr2; // Parsing and imploding (including tokenization)
 
     public JSGLR2Benchmark(TestSetReader<Input> testSetReader) {
         super(testSetReader);

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/datastructures/JSGLR2DataStructureBenchmark.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/datastructures/JSGLR2DataStructureBenchmark.java
@@ -14,7 +14,7 @@ import org.spoofax.jsglr2.benchmark.BenchmarkStringInputTestSetReader;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
 import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
 import org.spoofax.jsglr2.parseforest.basic.BasicParseForest;
-import org.spoofax.jsglr2.parser.IParser;
+import org.spoofax.jsglr2.parser.IObservableParser;
 import org.spoofax.jsglr2.parser.ParseException;
 import org.spoofax.jsglr2.parsetable.ParseTableReadException;
 import org.spoofax.jsglr2.parsetable.ParseTableReader;
@@ -31,7 +31,7 @@ import org.spoofax.terms.ParseError;
 
 public abstract class JSGLR2DataStructureBenchmark extends BaseBenchmark<StringInput> {
 
-    protected IParser<BasicParseForest, BasicStackNode<BasicParseForest>> parser;
+    protected IObservableParser<BasicParseForest, BasicStackNode<BasicParseForest>> parser;
 
     protected JSGLR2DataStructureBenchmark(TestSet testSet) {
         super(new BenchmarkStringInputTestSetReader(testSet));
@@ -40,10 +40,11 @@ public abstract class JSGLR2DataStructureBenchmark extends BaseBenchmark<StringI
     @SuppressWarnings("unchecked") @Setup public void parserSetup() throws ParseError, ParseTableReadException {
         IParseTable parseTable = readParseTable(testSetReader.getParseTableTerm());
 
-        parser = (IParser<BasicParseForest, BasicStackNode<BasicParseForest>>) JSGLR2Variants.getParser(parseTable,
-            new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
-                ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic,
-                Reducing.Basic));
+        parser =
+            (IObservableParser<BasicParseForest, BasicStackNode<BasicParseForest>>) JSGLR2Variants.getParser(parseTable,
+                new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
+                    ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic,
+                    Reducing.Basic));
 
         postParserSetup();
 

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -109,14 +109,14 @@ public abstract class BaseTest implements WithParseTable {
 
     protected IStrategoTerm testSuccess(IParseTable parseTable, JSGLR2Variants.Variant variant, String startSymbol,
         String inputString) {
-        JSGLR2<?, IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant);
+        JSGLR2<IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant);
 
         return testSuccess("Variant '" + variant.name() + "' failed parsing: ",
             "Variant '" + variant.name() + "' failed imploding: ", jsglr2, "", startSymbol, inputString);
     }
 
-    private IStrategoTerm testSuccess(String parseFailMessage, String implodeFailMessage,
-        JSGLR2<?, IStrategoTerm> jsglr2, String filename, String startSymbol, String inputString) {
+    private IStrategoTerm testSuccess(String parseFailMessage, String implodeFailMessage, JSGLR2<IStrategoTerm> jsglr2,
+        String filename, String startSymbol, String inputString) {
         try {
 
             IStrategoTerm result = jsglr2.parseUnsafe(inputString, filename, startSymbol);
@@ -142,7 +142,7 @@ public abstract class BaseTest implements WithParseTable {
                 continue;
 
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
-            JSGLR2<?, IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant.jsglr2);
+            JSGLR2<IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant.jsglr2);
 
             IStrategoTerm actualOutputAst;
             String filename = "" + System.nanoTime(); // To ensure the results will be cached
@@ -195,7 +195,7 @@ public abstract class BaseTest implements WithParseTable {
     protected void testTokens(String inputString, List<TokenDescriptor> expectedTokens) {
         for(IntegrationVariant variant : IntegrationVariant.testVariants()) {
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
-            JSGLR2<?, IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant.jsglr2);
+            JSGLR2<IStrategoTerm> jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant.jsglr2);
 
             JSGLR2Result<?> jsglr2Result = jsglr2.parseResult(inputString, "", null);
 

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -57,7 +57,7 @@ public abstract class BaseTest implements WithParseTable {
     protected void testParseSuccess(String inputString) {
         for(IntegrationVariant variant : IntegrationVariant.testVariants()) {
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
-            IParser<?, ?> parser = JSGLR2Variants.getParser(parseTable, variant.parser);
+            IParser<?> parser = JSGLR2Variants.getParser(parseTable, variant.parser);
 
             ParseResult<?> parseResult = parser.parse(inputString);
 
@@ -68,7 +68,7 @@ public abstract class BaseTest implements WithParseTable {
     protected void testParseFailure(String inputString) {
         for(IntegrationVariant variant : IntegrationVariant.testVariants()) {
             IParseTable parseTable = getParseTableFailOnException(variant.parseTable);
-            IParser<?, ?> parser = JSGLR2Variants.getParser(parseTable, variant.parser);
+            IParser<?> parser = JSGLR2Variants.getParser(parseTable, variant.parser);
 
             ParseResult<?> parseResult = parser.parse(inputString);
 

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/ParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/ParsingMeasurements.java
@@ -16,7 +16,7 @@ import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
 import org.spoofax.jsglr2.parseforest.hybrid.HybridDerivation;
 import org.spoofax.jsglr2.parseforest.hybrid.HybridParseForest;
 import org.spoofax.jsglr2.parseforest.hybrid.HybridParseNode;
-import org.spoofax.jsglr2.parser.IParser;
+import org.spoofax.jsglr2.parser.IObservableParser;
 import org.spoofax.jsglr2.parser.ParseException;
 import org.spoofax.jsglr2.parsetable.ParseTableReadException;
 import org.spoofax.jsglr2.parsetable.ParseTableReader;
@@ -70,8 +70,8 @@ public class ParsingMeasurements extends Measurements {
             MeasureActiveStacksFactory measureActiveStacksFactory = new MeasureActiveStacksFactory();
             MeasureForActorStacksFactory measureForActorStacksFactory = new MeasureForActorStacksFactory();
 
-            @SuppressWarnings("unchecked") IParser<HybridParseForest, AbstractElkhoundStackNode<HybridParseForest>> parser =
-                (IParser<HybridParseForest, AbstractElkhoundStackNode<HybridParseForest>>) JSGLR2Variants
+            @SuppressWarnings("unchecked") IObservableParser<HybridParseForest, AbstractElkhoundStackNode<HybridParseForest>> parser =
+                (IObservableParser<HybridParseForest, AbstractElkhoundStackNode<HybridParseForest>>) JSGLR2Variants
                     .getParser(parseTable, variant);
 
             ParserMeasureObserver<HybridParseForest> measureObserver = new ParserMeasureObserver<>();

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2.java
@@ -6,17 +6,10 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr2.JSGLR2Variants.ParserVariant;
 import org.spoofax.jsglr2.JSGLR2Variants.Variant;
 import org.spoofax.jsglr2.actions.ActionsFactory;
-import org.spoofax.jsglr2.imploder.IImploder;
-import org.spoofax.jsglr2.imploder.ImplodeResult;
 import org.spoofax.jsglr2.imploder.ImploderVariant;
-import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
 import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
-import org.spoofax.jsglr2.parser.IParser;
 import org.spoofax.jsglr2.parser.ParseException;
-import org.spoofax.jsglr2.parser.result.ParseFailure;
-import org.spoofax.jsglr2.parser.result.ParseResult;
-import org.spoofax.jsglr2.parser.result.ParseSuccess;
 import org.spoofax.jsglr2.parsetable.ParseTableReadException;
 import org.spoofax.jsglr2.parsetable.ParseTableReader;
 import org.spoofax.jsglr2.reducing.Reducing;
@@ -25,40 +18,36 @@ import org.spoofax.jsglr2.stack.collections.ActiveStacksRepresentation;
 import org.spoofax.jsglr2.stack.collections.ForActorStacksRepresentation;
 import org.spoofax.jsglr2.states.StateFactory;
 
-public class JSGLR2<ParseForest extends IParseForest, AbstractSyntaxTree> {
-
-    public final IParser<ParseForest, ?> parser;
-    public final IImploder<ParseForest, AbstractSyntaxTree> imploder;
-
-    public static JSGLR2<?, IStrategoTerm> standard(IParseTable parseTable) {
+public interface JSGLR2<AbstractSyntaxTree> {
+    static JSGLR2<IStrategoTerm> standard(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
             new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound,
                 Reducing.Elkhound), ImploderVariant.CombinedRecursive));
     }
 
-    public static JSGLR2<?, IStrategoTerm> dataDependent(IParseTable parseTable) {
+    static JSGLR2<IStrategoTerm> dataDependent(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
             new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.DataDependent, ParseForestConstruction.Full, StackRepresentation.Basic,
                 Reducing.DataDependent), ImploderVariant.CombinedRecursive));
     }
 
-    public static JSGLR2<?, IStrategoTerm> layoutSensitive(IParseTable parseTable) {
+    static JSGLR2<IStrategoTerm> layoutSensitive(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
             new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.LayoutSensitive, ParseForestConstruction.Full, StackRepresentation.Basic,
                 Reducing.DataDependent), ImploderVariant.CombinedRecursive));
     }
 
-    public static JSGLR2<?, IStrategoTerm> incremental(IParseTable parseTable) {
+    static JSGLR2<IStrategoTerm> incremental(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
             new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.Incremental, ParseForestConstruction.Full, StackRepresentation.Basic,
                 Reducing.Basic), ImploderVariant.CombinedRecursive));
     }
 
-    public static JSGLR2<?, IStrategoTerm> standard(IStrategoTerm parseTableTerm) throws ParseTableReadException {
+    static JSGLR2<IStrategoTerm> standard(IStrategoTerm parseTableTerm) throws ParseTableReadException {
         IParseTable parseTable =
             new ParseTableReader(new CharacterClassFactory(true, true), new ActionsFactory(true), new StateFactory())
                 .read(parseTableTerm);
@@ -66,20 +55,15 @@ public class JSGLR2<ParseForest extends IParseForest, AbstractSyntaxTree> {
         return standard(parseTable);
     }
 
-    public JSGLR2(IParser<ParseForest, ?> parser, IImploder<ParseForest, AbstractSyntaxTree> imploder) {
-        this.parser = parser;
-        this.imploder = imploder;
-    }
-
-    public AbstractSyntaxTree parse(String input) {
+    default AbstractSyntaxTree parse(String input) {
         return parse(input, "", null);
     }
 
-    public AbstractSyntaxTree parse(String input, String filename, String startSymbol) {
+    default AbstractSyntaxTree parse(String input, String filename, String startSymbol) {
         return parseResult(input, filename, startSymbol).ast;
     }
 
-    public JSGLR2Result<AbstractSyntaxTree> parseResult(String input, String filename, String startSymbol) {
+    default JSGLR2Result<AbstractSyntaxTree> parseResult(String input, String filename, String startSymbol) {
         try {
             return parseUnsafeResult(input, filename, startSymbol);
         } catch(ParseException e) {
@@ -87,26 +71,10 @@ public class JSGLR2<ParseForest extends IParseForest, AbstractSyntaxTree> {
         }
     }
 
-    public AbstractSyntaxTree parseUnsafe(String input, String filename, String startSymbol) throws ParseException {
+    default AbstractSyntaxTree parseUnsafe(String input, String filename, String startSymbol) throws ParseException {
         return parseUnsafeResult(input, filename, startSymbol).ast;
     }
 
-    public JSGLR2Result<AbstractSyntaxTree> parseUnsafeResult(String input, String filename, String startSymbol)
-        throws ParseException {
-
-        ParseResult<ParseForest> parseResult = parser.parse(input, filename, startSymbol);
-
-        if(parseResult.isSuccess) {
-            ParseSuccess<ParseForest> success = (ParseSuccess<ParseForest>) parseResult;
-
-            ImplodeResult<AbstractSyntaxTree> implodeResult = imploder.implode(input, filename, success.parseResult);
-
-            return new JSGLR2Result<>(implodeResult);
-        } else {
-            ParseFailure<ParseForest> failure = (ParseFailure<ParseForest>) parseResult;
-
-            throw failure.exception();
-        }
-    }
-
+    JSGLR2Result<AbstractSyntaxTree> parseUnsafeResult(String input, String filename, String startSymbol)
+        throws ParseException;
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Implementation.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Implementation.java
@@ -9,13 +9,12 @@ import org.spoofax.jsglr2.parser.result.ParseFailure;
 import org.spoofax.jsglr2.parser.result.ParseResult;
 import org.spoofax.jsglr2.parser.result.ParseSuccess;
 
-class JSGLR2Implementation<ParseForest extends IParseForest, AbstractSyntaxTree>
-    implements JSGLR2<AbstractSyntaxTree> {
+class JSGLR2Implementation<ParseForest extends IParseForest, AbstractSyntaxTree> implements JSGLR2<AbstractSyntaxTree> {
 
-    private final IParser<ParseForest, ?> parser;
+    private final IParser<ParseForest> parser;
     private final IImploder<ParseForest, AbstractSyntaxTree> imploder;
 
-    JSGLR2Implementation(IParser<ParseForest, ?> parser, IImploder<ParseForest, AbstractSyntaxTree> imploder) {
+    JSGLR2Implementation(IParser<ParseForest> parser, IImploder<ParseForest, AbstractSyntaxTree> imploder) {
         this.parser = parser;
         this.imploder = imploder;
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Implementation.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Implementation.java
@@ -1,0 +1,41 @@
+package org.spoofax.jsglr2;
+
+import org.spoofax.jsglr2.imploder.IImploder;
+import org.spoofax.jsglr2.imploder.ImplodeResult;
+import org.spoofax.jsglr2.parseforest.IParseForest;
+import org.spoofax.jsglr2.parser.IParser;
+import org.spoofax.jsglr2.parser.ParseException;
+import org.spoofax.jsglr2.parser.result.ParseFailure;
+import org.spoofax.jsglr2.parser.result.ParseResult;
+import org.spoofax.jsglr2.parser.result.ParseSuccess;
+
+class JSGLR2Implementation<ParseForest extends IParseForest, AbstractSyntaxTree>
+    implements JSGLR2<AbstractSyntaxTree> {
+
+    private final IParser<ParseForest, ?> parser;
+    private final IImploder<ParseForest, AbstractSyntaxTree> imploder;
+
+    JSGLR2Implementation(IParser<ParseForest, ?> parser, IImploder<ParseForest, AbstractSyntaxTree> imploder) {
+        this.parser = parser;
+        this.imploder = imploder;
+    }
+
+    @Override public JSGLR2Result<AbstractSyntaxTree> parseUnsafeResult(String input, String filename,
+        String startSymbol) throws ParseException {
+
+        ParseResult<ParseForest> parseResult = parser.parse(input, filename, startSymbol);
+
+        if(parseResult.isSuccess) {
+            ParseSuccess<ParseForest> success = (ParseSuccess<ParseForest>) parseResult;
+
+            ImplodeResult<AbstractSyntaxTree> implodeResult = imploder.implode(input, filename, success.parseResult);
+
+            return new JSGLR2Result<>(implodeResult);
+        } else {
+            ParseFailure<ParseForest> failure = (ParseFailure<ParseForest>) parseResult;
+
+            throw failure.exception();
+        }
+    }
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variants.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variants.java
@@ -273,18 +273,18 @@ public class JSGLR2Variants {
         }
     }
 
-    public static JSGLR2<?, IStrategoTerm> getJSGLR2(IParseTable parseTable, Variant variant) {
+    public static JSGLR2<IStrategoTerm> getJSGLR2(IParseTable parseTable, Variant variant) {
         @SuppressWarnings("unchecked") final IParser<IParseForest, ?> parser =
             (IParser<IParseForest, ?>) getParser(parseTable, variant.parser);
 
-        return new JSGLR2<>(parser, getImploder(variant));
+        return new JSGLR2Implementation<>(parser, getImploder(variant));
     }
 
-    public static List<JSGLR2<?, IStrategoTerm>> allJSGLR2(IParseTable parseTable) {
-        List<JSGLR2<?, IStrategoTerm>> jsglr2s = new ArrayList<>();
+    public static List<JSGLR2<IStrategoTerm>> allJSGLR2(IParseTable parseTable) {
+        List<JSGLR2<IStrategoTerm>> jsglr2s = new ArrayList<>();
 
         for(Variant variant : allVariants()) {
-            JSGLR2<?, IStrategoTerm> jsglr2 = getJSGLR2(parseTable, variant);
+            JSGLR2<IStrategoTerm> jsglr2 = getJSGLR2(parseTable, variant);
 
             jsglr2s.add(jsglr2);
         }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variants.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variants.java
@@ -142,7 +142,7 @@ public class JSGLR2Variants {
     }
 
 
-    public static IParser<? extends IParseForest, ?> getParser(IParseTable parseTable, ParserVariant variant) {
+    public static IParser<? extends IParseForest> getParser(IParseTable parseTable, ParserVariant variant) {
         if(!variant.isValid())
             throw new IllegalStateException("Invalid parser variant");
 
@@ -208,7 +208,7 @@ public class JSGLR2Variants {
     }
 
     private static <ParseForest extends IParseForest, ParseNode extends ParseForest, Derivation extends IDerivation<ParseForest>, PFM extends ParseForestManager<ParseForest, ParseNode, Derivation>>
-        IParser<ParseForest, ?> getParser(IParseTable parseTable, ParserVariant variant, PFM parseForestManager) {
+        IParser<ParseForest> getParser(IParseTable parseTable, ParserVariant variant, PFM parseForestManager) {
         switch(variant.reducing) {
             case Elkhound:
                 switch(variant.stackRepresentation) {
@@ -246,8 +246,8 @@ public class JSGLR2Variants {
         }
     }
 
-    public static List<IParser<?, ?>> allParsers(IParseTable parseTable) {
-        List<IParser<?, ?>> parsers = new ArrayList<>();
+    public static List<IParser<?>> allParsers(IParseTable parseTable) {
+        List<IParser<?>> parsers = new ArrayList<>();
 
         for(Variant variant : allVariants()) {
             parsers.add(getParser(parseTable, variant.parser));
@@ -274,8 +274,8 @@ public class JSGLR2Variants {
     }
 
     public static JSGLR2<IStrategoTerm> getJSGLR2(IParseTable parseTable, Variant variant) {
-        @SuppressWarnings("unchecked") final IParser<IParseForest, ?> parser =
-            (IParser<IParseForest, ?>) getParser(parseTable, variant.parser);
+        @SuppressWarnings("unchecked") final IParser<IParseForest> parser =
+            (IParser<IParseForest>) getParser(parseTable, variant.parser);
 
         return new JSGLR2Implementation<>(parser, getImploder(variant));
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/IObservableParser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/IObservableParser.java
@@ -1,0 +1,12 @@
+package org.spoofax.jsglr2.parser;
+
+import org.spoofax.jsglr2.parseforest.IParseForest;
+import org.spoofax.jsglr2.parser.observing.ParserObserving;
+import org.spoofax.jsglr2.stack.IStackNode;
+
+public interface IObservableParser<ParseForest extends IParseForest, StackNode extends IStackNode>
+    extends IParser<ParseForest> {
+
+    ParserObserving<ParseForest, StackNode> observing();
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/IParser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/IParser.java
@@ -1,18 +1,11 @@
 package org.spoofax.jsglr2.parser;
 
 import org.spoofax.jsglr2.parseforest.IParseForest;
-import org.spoofax.jsglr2.parser.observing.ParserObserving;
 import org.spoofax.jsglr2.parser.result.ParseFailure;
 import org.spoofax.jsglr2.parser.result.ParseResult;
 import org.spoofax.jsglr2.parser.result.ParseSuccess;
-import org.spoofax.jsglr2.stack.IStackNode;
 
-public interface IParser
-//@formatter:off
-   <ParseForest extends IParseForest,
-    StackNode   extends IStackNode>
-//@formatter:on
-{
+public interface IParser<ParseForest extends IParseForest> {
 
     ParseResult<ParseForest> parse(String input, String filename, String startSymbol);
 
@@ -49,7 +42,5 @@ public interface IParser
     default ParseForest parseUnsafe(String input) throws ParseException {
         return parseUnsafe(input, "");
     }
-
-    ParserObserving<ParseForest, StackNode> observing();
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/Parser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/Parser.java
@@ -30,7 +30,7 @@ public class Parser
     ReduceManager extends org.spoofax.jsglr2.reducing.ReduceManager<
                               ParseForest, ParseNode, Derivation, StackNode, Parse>>
 //@formatter:on
-    implements IParser<ParseForest, StackNode> {
+    implements IObservableParser<ParseForest, StackNode> {
 
     protected final ParseFactory<ParseForest, StackNode, Parse> parseFactory;
     protected final IParseTable parseTable;


### PR DESCRIPTION
For the public `JSGLR2` interface and the semi-public `IParser` interface, I've removed type parameters that do not need to be known by users of these interfaces.
E.g. in Spoofax Core, we don't care anymore which type of parse forests are being used. (see also https://github.com/metaborg/spoofax/pull/45).

In the `IParser` interface, the type of the stack nodes was only necessary for the `observing` method. This method has been pushed down to a new interface (`IObservableParser`), which includes both the `observing` method and a type parameter for the stack nodes. The base parser now implements `IObservableParser` instead of `IParser`.

In the `JSGLR2` interface, the type of the parse forest is only useful for internal use. Therefore, a new class `JSGLR2Implementation` has been created that _does_ have a type parameter for the parse forest, so that the parser and imploder can still be properly linked together.