### PR TITLE
Change isAmbigous to isAmbiguous

### DIFF
--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/AbstractTokenizer.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/AbstractTokenizer.java
@@ -57,7 +57,7 @@ public abstract class AbstractTokenizer implements ITokenizer, ITokens {
 		return makeToken(endOffset, manager.getTokenKind(label), allowEmptyToken);
 	}
 
-	public boolean isAmbigous() {
+	public boolean isAmbiguous() {
 		return isAmbiguous;
 	}
 

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/ITokens.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/ITokens.java
@@ -42,6 +42,6 @@ public interface ITokens extends Iterable<IToken>, Serializable {
      * @see Tokenizer#getTokenAfter(IToken)   Gets the next token with a matching offset.
      * @see Tokenizer#getTokenBefore(IToken)  Gets the previous token with a matching offset.
      */
-    boolean isAmbigous();
+    boolean isAmbiguous();
 
 }

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/Tokenizer.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/Tokenizer.java
@@ -67,7 +67,7 @@ public class Tokenizer extends AbstractTokenizer {
     }
 
     public void setStartOffset(int startOffset) {
-        assert isAmbigous() || this.startOffset >= getInput().length();
+        assert isAmbiguous() || this.startOffset >= getInput().length();
         if(this.startOffset == startOffset)
             return;
         this.startOffset = startOffset;
@@ -112,7 +112,7 @@ public class Tokenizer extends AbstractTokenizer {
     }
 
     public IToken getTokenAtOffset(int offset) {
-        assert isAmbigous() || getTokenCount() < 2
+        assert isAmbiguous() || getTokenCount() < 2
             || internalGetTokenAt(getTokenCount() - 1)
                 .getStartOffset() == internalGetTokenAt(getTokenCount() - 2).getEndOffset()
                     + 1 : "Unordered tokens at end of tokenizer";

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/TreeBuilder.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/TreeBuilder.java
@@ -517,7 +517,7 @@ public class TreeBuilder extends TopdownTreeBuilder {
 		// Don't use tokens here in case tokenizer is disabled
 		IToken leftToken = rightToken.getStartOffset() == lastOffset ? rightToken : tokenizer.getTokenAtOffset(lastOffset);
 		String contents = tokenizer.toString(lastOffset, offset - 1);
-		assert disableTokens || tokenizer.isAmbigous()
+		assert disableTokens || tokenizer.isAmbiguous()
 			|| (contents.equals(tokenizer.toString(leftToken, rightToken)) && lastOffset == leftToken.getStartOffset());
 		
 		Object result = factory.createStringTerminal(sort, leftToken, rightToken, getPaddedLexicalValue(label, contents, lastOffset), label.isCaseInsensitive());

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/incremental/IncrementalSGLR.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/incremental/IncrementalSGLR.java
@@ -252,7 +252,7 @@ public class IncrementalSGLR<TNode extends ISimpleTerm> {
 	}
 	
 	private static boolean isAmbiguous(ISimpleTerm tree) {
-		return getLeftToken(tree).getTokenizer().isAmbigous();
+		return getLeftToken(tree).getTokenizer().isAmbiguous();
 	}
 
 	protected static boolean isRangeOverlap(int start1, int end1, int start2, int end2) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/Tokens.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/Tokens.java
@@ -126,7 +126,7 @@ public class Tokens implements IParseTokens {
         return input.substring(startOffset, endOffset);
     }
 
-    @Override public boolean isAmbigous() {
+    @Override public boolean isAmbiguous() {
         return false; // TODO: implement
     }
 


### PR DESCRIPTION
Once I noticed, I could not un-see it. :see_no_evil: 

This rename also causes one change in Spoofax core (see metaborg/spoofax#47). 