### PR TITLE
Put imploder attachments on sublists.

### DIFF
--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/TermTreeFactory.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/TermTreeFactory.java
@@ -335,5 +335,16 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
         if(enableTokens)
             putImploderAttachment(term, isListOrTuple, sort, leftToken, rightToken, isBracket, isCompletion,
                 isNestedCompletion, isSinglePlaceholderCompletion);
+            if(term.getTermType() == LIST) {
+                IStrategoList sublist = (IStrategoList) term;
+                IToken lastRightToken;
+                while(!sublist.isEmpty()) {
+                    lastRightToken = getRightToken(sublist.head());
+                    sublist = sublist.tail();
+                    leftToken = sublist.isEmpty() ? lastRightToken : getLeftToken(sublist.head());
+                    putImploderAttachment(sublist, isListOrTuple, sort, leftToken, rightToken, isBracket, isCompletion,
+                        isNestedCompletion, isSinglePlaceholderCompletion);
+                }
+            }
     }
 }

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/TermTreeFactory.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/TermTreeFactory.java
@@ -333,6 +333,7 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
         boolean isSinglePlaceholderCompletion) {
         assert isListOrTuple == (term.getTermType() == TUPLE || term.getTermType() == LIST);
         if(enableTokens)
+            rightToken = rightToken != null ? rightToken : leftToken;
             putImploderAttachment(term, isListOrTuple, sort, leftToken, rightToken, isBracket, isCompletion,
                 isNestedCompletion, isSinglePlaceholderCompletion);
             if(term.getTermType() == LIST) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
@@ -6,9 +6,11 @@ import java.util.Collections;
 import java.util.List;
 
 import org.spoofax.interpreter.terms.IStrategoConstructor;
+import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.jsglr.client.imploder.IToken;
+import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 
 public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
 
@@ -77,6 +79,18 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
         // rightToken can be null, e.g. for an empty string lexical
         putImploderAttachment(term, false, sort, leftToken, rightToken != null ? rightToken : leftToken, false, false,
             false, false);
+        if(term.getTermType() == IStrategoTerm.LIST) {
+            IStrategoList sublist = (IStrategoList) term;
+            IToken lastRightToken;
+            while(!sublist.isEmpty()) {
+                lastRightToken = ImploderAttachment.getRightToken(sublist.head());
+                sublist = sublist.tail();
+                leftToken = sublist.isEmpty() ? lastRightToken : ImploderAttachment.getLeftToken(sublist.head());
+            }
+            // assuming rightToken is never null for lists
+            putImploderAttachment(term, false, sort, leftToken, rightToken, false, false,
+                false, false);
+        }
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
@@ -31,7 +31,7 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
     @Override public IStrategoTerm createNonTerminal(String sort, String constructor, List<IStrategoTerm> childASTs,
         IToken leftToken, IToken rightToken) {
         IStrategoConstructor constructorTerm =
-                termFactory.makeConstructor(constructor != null ? constructor : sort, childASTs.size());
+            termFactory.makeConstructor(constructor != null ? constructor : sort, childASTs.size());
         IStrategoTerm nonTerminalTerm = termFactory.makeAppl(constructorTerm, toArray(childASTs));
 
         configure(nonTerminalTerm, sort, leftToken, rightToken);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
@@ -29,7 +29,7 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
     }
 
     @Override public IStrategoTerm createNonTerminal(String sort, String constructor, List<IStrategoTerm> childASTs,
-            IToken leftToken, IToken rightToken) {
+        IToken leftToken, IToken rightToken) {
         IStrategoConstructor constructorTerm =
                 termFactory.makeConstructor(constructor != null ? constructor : sort, childASTs.size());
         IStrategoTerm nonTerminalTerm = termFactory.makeAppl(constructorTerm, toArray(childASTs));
@@ -40,7 +40,7 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
     }
 
     @Override public IStrategoTerm createList(String sort, List<IStrategoTerm> children, IToken leftToken,
-            IToken rightToken) {
+        IToken rightToken) {
         IStrategoTerm listTerm = termFactory.makeList(toArray(children));
 
         configure(listTerm, sort, leftToken, rightToken);
@@ -49,14 +49,14 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
     }
 
     @Override public IStrategoTerm createOptional(String sort, List<IStrategoTerm> children, IToken leftToken,
-            IToken rightToken) {
+        IToken rightToken) {
         String constructor = children == null || children.isEmpty() ? "None" : "Some";
 
         return createNonTerminal(sort, constructor, children, leftToken, rightToken);
     }
 
     @Override public IStrategoTerm createTuple(String sort, List<IStrategoTerm> children, IToken leftToken,
-            IToken rightToken) {
+        IToken rightToken) {
         IStrategoTerm tupleTerm = termFactory.makeTuple(toArray(children));
 
         configure(tupleTerm, sort, leftToken, rightToken);
@@ -65,7 +65,7 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
     }
 
     @Override public IStrategoTerm createAmb(String sort, List<IStrategoTerm> alternatives, IToken leftToken,
-            IToken rightToken) {
+        IToken rightToken) {
         IStrategoTerm alternativesListTerm = createList(null, alternatives, leftToken, rightToken);
 
         return createNonTerminal(null, "amb", Collections.singletonList(alternativesListTerm), leftToken, rightToken);
@@ -77,8 +77,7 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
 
     protected void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
         // rightToken can be null, e.g. for an empty string lexical
-        putImploderAttachment(term, false, sort, leftToken, rightToken != null ? rightToken : leftToken, false, false,
-                false, false);
+        putImploderAttachment(term, false, sort, leftToken, rightToken != null ? rightToken : leftToken, false, false, false, false);
         if(term.getTermType() == IStrategoTerm.LIST) {
             IStrategoList sublist = (IStrategoList) term;
             IToken lastRightToken;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
@@ -77,7 +77,8 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
 
     protected void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
         // rightToken can be null, e.g. for an empty string lexical
-        putImploderAttachment(term, false, sort, leftToken, rightToken != null ? rightToken : leftToken, false, false, false, false);
+        rightToken = rightToken != null ? rightToken : leftToken;
+        putImploderAttachment(term, false, sort, leftToken, rightToken, false, false, false, false);
         if(term.getTermType() == IStrategoTerm.LIST) {
             IStrategoList sublist = (IStrategoList) term;
             IToken lastRightToken;
@@ -85,7 +86,6 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
                 lastRightToken = ImploderAttachment.getRightToken(sublist.head());
                 sublist = sublist.tail();
                 leftToken = sublist.isEmpty() ? lastRightToken : ImploderAttachment.getLeftToken(sublist.head());
-                // assuming rightToken is never null for lists
                 putImploderAttachment(sublist, false, sort, leftToken, rightToken, false, false, false, false);
             }
         }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TermTreeFactory.java
@@ -29,9 +29,9 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
     }
 
     @Override public IStrategoTerm createNonTerminal(String sort, String constructor, List<IStrategoTerm> childASTs,
-        IToken leftToken, IToken rightToken) {
+            IToken leftToken, IToken rightToken) {
         IStrategoConstructor constructorTerm =
-            termFactory.makeConstructor(constructor != null ? constructor : sort, childASTs.size());
+                termFactory.makeConstructor(constructor != null ? constructor : sort, childASTs.size());
         IStrategoTerm nonTerminalTerm = termFactory.makeAppl(constructorTerm, toArray(childASTs));
 
         configure(nonTerminalTerm, sort, leftToken, rightToken);
@@ -40,7 +40,7 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
     }
 
     @Override public IStrategoTerm createList(String sort, List<IStrategoTerm> children, IToken leftToken,
-        IToken rightToken) {
+            IToken rightToken) {
         IStrategoTerm listTerm = termFactory.makeList(toArray(children));
 
         configure(listTerm, sort, leftToken, rightToken);
@@ -49,14 +49,14 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
     }
 
     @Override public IStrategoTerm createOptional(String sort, List<IStrategoTerm> children, IToken leftToken,
-        IToken rightToken) {
+            IToken rightToken) {
         String constructor = children == null || children.isEmpty() ? "None" : "Some";
 
         return createNonTerminal(sort, constructor, children, leftToken, rightToken);
     }
 
     @Override public IStrategoTerm createTuple(String sort, List<IStrategoTerm> children, IToken leftToken,
-        IToken rightToken) {
+            IToken rightToken) {
         IStrategoTerm tupleTerm = termFactory.makeTuple(toArray(children));
 
         configure(tupleTerm, sort, leftToken, rightToken);
@@ -65,7 +65,7 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
     }
 
     @Override public IStrategoTerm createAmb(String sort, List<IStrategoTerm> alternatives, IToken leftToken,
-        IToken rightToken) {
+            IToken rightToken) {
         IStrategoTerm alternativesListTerm = createList(null, alternatives, leftToken, rightToken);
 
         return createNonTerminal(null, "amb", Collections.singletonList(alternativesListTerm), leftToken, rightToken);
@@ -78,7 +78,7 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
     protected void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
         // rightToken can be null, e.g. for an empty string lexical
         putImploderAttachment(term, false, sort, leftToken, rightToken != null ? rightToken : leftToken, false, false,
-            false, false);
+                false, false);
         if(term.getTermType() == IStrategoTerm.LIST) {
             IStrategoList sublist = (IStrategoList) term;
             IToken lastRightToken;
@@ -86,10 +86,9 @@ public class TermTreeFactory implements ITreeFactory<IStrategoTerm> {
                 lastRightToken = ImploderAttachment.getRightToken(sublist.head());
                 sublist = sublist.tail();
                 leftToken = sublist.isEmpty() ? lastRightToken : ImploderAttachment.getLeftToken(sublist.head());
+                // assuming rightToken is never null for lists
+                putImploderAttachment(sublist, false, sort, leftToken, rightToken, false, false, false, false);
             }
-            // assuming rightToken is never null for lists
-            putImploderAttachment(term, false, sort, leftToken, rightToken, false, false,
-                false, false);
         }
     }
 


### PR DESCRIPTION
A small change to the imploder that puts imploder attachments on sublists.
Currently NaBL2 error messages can get lost if they are attached to lists
without origin information. Adding imploder attachments on sublists as well
seems to solve that problem.

The change does the following:
- The imploder attachment for the top-level element stays the same as it was.
- For sublists, it uses the left token of the first child, and the right token
  of the whole list.
- For the empty sublist, it uses the right token of the last child as a left
  token, and the right token of the whole list. Note that this case is only for
  empty sublists, which means there always was a previous child for the last
  right token. This logic is not used if the top-level list is empty, in which
  case the left and right token from the call are used directly.