### PR TITLE
Tokenizer variant

### DIFF
--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2Benchmark.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2Benchmark.java
@@ -33,12 +33,13 @@ import org.spoofax.jsglr2.stack.collections.ForActorStacksRepresentation;
 import org.spoofax.jsglr2.states.IStateFactory;
 import org.spoofax.jsglr2.states.StateFactory;
 import org.spoofax.jsglr2.testset.TestSetReader;
+import org.spoofax.jsglr2.tokens.TokenizerVariant;
 import org.spoofax.terms.ParseError;
 
 public abstract class JSGLR2Benchmark<Input> extends BaseBenchmark<Input> {
 
     protected IParser<?> parser; // Just parsing
-    protected JSGLR2Implementation<?, ?> jsglr2; // Parsing and imploding (including tokenization)
+    protected JSGLR2Implementation<?, ?, ?> jsglr2; // Parsing, imploding, and tokenization
 
     public JSGLR2Benchmark(TestSetReader<Input> testSetReader) {
         super(testSetReader);
@@ -69,7 +70,7 @@ public abstract class JSGLR2Benchmark<Input> extends BaseBenchmark<Input> {
         // variant.parseTable.productionToGotoRepresentation).read(testSetReader.getParseTableTerm());
 
         parser = JSGLR2Variants.getParser(parseTable, variant.parser);
-        jsglr2 = (JSGLR2Implementation<?, ?>) JSGLR2Variants.getJSGLR2(parseTable, variant.jsglr2);
+        jsglr2 = (JSGLR2Implementation<?, ?, ?>) JSGLR2Variants.getJSGLR2(parseTable, variant.jsglr2);
     }
 
     //@formatter:off
@@ -78,48 +79,49 @@ public abstract class JSGLR2Benchmark<Input> extends BaseBenchmark<Input> {
 
     static ParserVariant naiveParserVariant = new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic);
     
-    static ImploderVariant imploderVariant = ImploderVariant.CombinedRecursive;
+    static ImploderVariant imploderVariant = ImploderVariant.TokenizedRecursive;
+    static TokenizerVariant tokenizerVariant = TokenizerVariant.Null;
     
     static List<IntegrationVariant> benchmarkParseVariants = Arrays.asList(
         // Variants for parse table variants
-        new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),                        naiveParserVariant, imploderVariant),
-        new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.JavaHashMap),                    naiveParserVariant, imploderVariant),
-        new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted, ProductionToGotoRepresentation.ForLoop),                        naiveParserVariant, imploderVariant),
-        new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted, ProductionToGotoRepresentation.JavaHashMap),                    naiveParserVariant, imploderVariant),
+        new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),                        naiveParserVariant, imploderVariant, tokenizerVariant),
+        new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.JavaHashMap),                    naiveParserVariant, imploderVariant, tokenizerVariant),
+        new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted, ProductionToGotoRepresentation.ForLoop),                        naiveParserVariant, imploderVariant, tokenizerVariant),
+        new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted, ProductionToGotoRepresentation.JavaHashMap),                    naiveParserVariant, imploderVariant, tokenizerVariant),
         
         // Variants for parser variants
         // - Stack collections
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList,        ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayListHashMap, ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.LinkedHashMap,    ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList,        ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayListHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.LinkedHashMap,    ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList,        ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayListHashMap, ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.LinkedHashMap,    ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList,        ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayListHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.LinkedHashMap,    ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Basic, ParseForestConstruction.Full, StackRepresentation.Basic, Reducing.Basic), imploderVariant, tokenizerVariant),
         
         // - Data structures
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Basic,  Reducing.Basic), imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Hybrid, Reducing.Basic), imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.Basic,  Reducing.Basic), imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.Hybrid, Reducing.Basic), imploderVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Basic,  Reducing.Basic), imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Hybrid, Reducing.Basic), imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.Basic,  Reducing.Basic), imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.Hybrid, Reducing.Basic), imploderVariant, tokenizerVariant),
 
         // - Elkhound
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound, Reducing.Basic),    imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound, Reducing.Elkhound), imploderVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound, Reducing.Basic),    imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound, Reducing.Elkhound), imploderVariant, tokenizerVariant),
         
         // - Parse forest construction
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.Hybrid, Reducing.Basic), imploderVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.Hybrid, Reducing.Basic), imploderVariant, tokenizerVariant),
 
         // - Best
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.HybridElkhound, Reducing.Elkhound), imploderVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.HybridElkhound, Reducing.Elkhound), imploderVariant, tokenizerVariant),
 
         // - Naive
-        new IntegrationVariant(naiveTableVariant, naiveParserVariant, imploderVariant)
+        new IntegrationVariant(naiveTableVariant, naiveParserVariant, imploderVariant, tokenizerVariant)
     );
     
     static List<IntegrationVariant> benchmarkParseAndImplodeVariants = Arrays.asList(
-        new IntegrationVariant(naiveTableVariant, naiveParserVariant, imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.Hybrid, Reducing.Basic), imploderVariant),
-        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.HybridElkhound, Reducing.Elkhound), imploderVariant)
+        new IntegrationVariant(naiveTableVariant, naiveParserVariant, imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.Hybrid, Reducing.Basic), imploderVariant, tokenizerVariant),
+        new IntegrationVariant(bestParseTableVariant, new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.HybridElkhound, Reducing.Elkhound), imploderVariant, tokenizerVariant)
     );
     //@formatter:on
 

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2Benchmark.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2Benchmark.java
@@ -11,7 +11,7 @@ import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.infra.Blackhole;
-import org.spoofax.jsglr2.JSGLR2;
+import org.spoofax.jsglr2.JSGLR2Implementation;
 import org.spoofax.jsglr2.JSGLR2Variants;
 import org.spoofax.jsglr2.JSGLR2Variants.ParserVariant;
 import org.spoofax.jsglr2.actions.ActionsFactory;
@@ -38,7 +38,7 @@ import org.spoofax.terms.ParseError;
 public abstract class JSGLR2Benchmark<Input> extends BaseBenchmark<Input> {
 
     protected IParser<?> parser; // Just parsing
-    protected JSGLR2<?> jsglr2; // Parsing and imploding (including tokenization)
+    protected JSGLR2Implementation<?, ?> jsglr2; // Parsing and imploding (including tokenization)
 
     public JSGLR2Benchmark(TestSetReader<Input> testSetReader) {
         super(testSetReader);
@@ -69,7 +69,7 @@ public abstract class JSGLR2Benchmark<Input> extends BaseBenchmark<Input> {
         // variant.parseTable.productionToGotoRepresentation).read(testSetReader.getParseTableTerm());
 
         parser = JSGLR2Variants.getParser(parseTable, variant.parser);
-        jsglr2 = JSGLR2Variants.getJSGLR2(parseTable, variant.jsglr2);
+        jsglr2 = (JSGLR2Implementation<?, ?>) JSGLR2Variants.getJSGLR2(parseTable, variant.jsglr2);
     }
 
     //@formatter:off

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParseTable.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParseTable.java
@@ -5,7 +5,6 @@ import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
 import org.openjdk.jmh.annotations.Param;
 import org.spoofax.jsglr2.JSGLR2Variants.ParserVariant;
 import org.spoofax.jsglr2.benchmark.BenchmarkStringInputTestSetReader;
-import org.spoofax.jsglr2.imploder.ImploderVariant;
 import org.spoofax.jsglr2.integration.IntegrationVariant;
 import org.spoofax.jsglr2.integration.ParseTableVariant;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
@@ -47,10 +46,10 @@ public abstract class JSGLR2BenchmarkParseTable extends JSGLR2Benchmark<StringIn
             new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation),
             new ParserVariant(activeStacksRepresentation, forActorStacksRepresentation, parseForestRepresentation,
                 parseForestConstruction, stackRepresentation, reducing),
-            ImploderVariant.CombinedRecursive);
+            imploderVariant, tokenizerVariant);
         System.out.println("JSGLR2 PT Var: " + variant.name());
         if(variant.equals(new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted,
-            ProductionToGotoRepresentation.JavaHashMap), naiveParserVariant, ImploderVariant.CombinedRecursive)))
+            ProductionToGotoRepresentation.JavaHashMap), naiveParserVariant, imploderVariant, tokenizerVariant)))
             throw new IllegalStateException("naive variant is only benchmarked once");
         else
             return variant;

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParsing.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParsing.java
@@ -5,7 +5,6 @@ import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
 import org.openjdk.jmh.annotations.Param;
 import org.spoofax.jsglr2.JSGLR2Variants.ParserVariant;
 import org.spoofax.jsglr2.benchmark.BenchmarkStringInputTestSetReader;
-import org.spoofax.jsglr2.imploder.ImploderVariant;
 import org.spoofax.jsglr2.integration.IntegrationVariant;
 import org.spoofax.jsglr2.integration.ParseTableVariant;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
@@ -48,7 +47,7 @@ public abstract class JSGLR2BenchmarkParsing extends JSGLR2Benchmark<StringInput
             new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation),
             new ParserVariant(activeStacksRepresentation, forActorStacksRepresentation, parseForestRepresentation,
                 parseForestConstruction, stackRepresentation, reducing),
-            ImploderVariant.CombinedRecursive);
+            imploderVariant, tokenizerVariant);
     }
 
     @Override protected boolean implode() {

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParsingAndImploding.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkParsingAndImploding.java
@@ -5,7 +5,6 @@ import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
 import org.openjdk.jmh.annotations.Param;
 import org.spoofax.jsglr2.JSGLR2Variants.ParserVariant;
 import org.spoofax.jsglr2.benchmark.BenchmarkStringInputTestSetReader;
-import org.spoofax.jsglr2.imploder.ImploderVariant;
 import org.spoofax.jsglr2.integration.IntegrationVariant;
 import org.spoofax.jsglr2.integration.ParseTableVariant;
 import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
@@ -50,7 +49,7 @@ public abstract class JSGLR2BenchmarkParsingAndImploding extends JSGLR2Benchmark
             new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation),
             new ParserVariant(activeStacksRepresentation, forActorStacksRepresentation, parseForestRepresentation,
                 parseForestConstruction, stackRepresentation, reducing),
-            ImploderVariant.CombinedRecursive);
+            imploderVariant, tokenizerVariant);
     }
 
     @Override protected boolean implode() {

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/IntegrationVariant.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/IntegrationVariant.java
@@ -13,19 +13,22 @@ import org.spoofax.jsglr2.reducing.Reducing;
 import org.spoofax.jsglr2.stack.StackRepresentation;
 import org.spoofax.jsglr2.stack.collections.ActiveStacksRepresentation;
 import org.spoofax.jsglr2.stack.collections.ForActorStacksRepresentation;
+import org.spoofax.jsglr2.tokens.TokenizerVariant;
 
 public class IntegrationVariant {
     public final ParseTableVariant parseTable;
     public final JSGLR2Variants.Variant jsglr2;
     public final JSGLR2Variants.ParserVariant parser;
     public final ImploderVariant imploder;
+    public final TokenizerVariant tokenizer;
 
     public IntegrationVariant(ParseTableVariant parseTableVariant, JSGLR2Variants.ParserVariant parserVariant,
-        ImploderVariant imploderVariant) {
+        ImploderVariant imploderVariant, TokenizerVariant tokenizer) {
         this.parseTable = parseTableVariant;
-        this.jsglr2 = new JSGLR2Variants.Variant(parserVariant, imploderVariant);
+        this.jsglr2 = new JSGLR2Variants.Variant(parserVariant, imploderVariant, tokenizer);
         this.parser = parserVariant;
         this.imploder = imploderVariant;
+        this.tokenizer = tokenizer;
     }
 
     public IntegrationVariant(ParseTableVariant parseTableVariant, JSGLR2Variants.Variant jsglr2Variant) {
@@ -33,10 +36,11 @@ public class IntegrationVariant {
         this.jsglr2 = jsglr2Variant;
         this.parser = jsglr2Variant.parser;
         this.imploder = jsglr2Variant.imploder;
+        this.tokenizer = jsglr2Variant.tokenizer;
     }
 
     public String name() {
-        return parseTable.name() + "/" + parser.name() + "/Imploder:" + imploder.name();
+        return parseTable.name() + "//" + jsglr2.name();
     }
 
     @Override public boolean equals(Object o) {
@@ -49,19 +53,19 @@ public class IntegrationVariant {
 
         IntegrationVariant that = (IntegrationVariant) o;
 
-        return parseTable.equals(that.parseTable) && parser.equals(that.parser) && imploder.equals(that.imploder);
+        return parseTable.equals(that.parseTable) && jsglr2.equals(that.jsglr2);
     }
 
     public static List<IntegrationVariant> testVariants() {
         //@formatter:off
         return Arrays.asList(
-            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.ArrayList,     ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Basic,          Reducing.Basic), ImploderVariant.CombinedRecursive),
-            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted, ProductionToGotoRepresentation.JavaHashMap), new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.ArrayList,     ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Basic,          Reducing.Basic), ImploderVariant.CombinedRecursive),
-            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.Hybrid,         Reducing.Basic), ImploderVariant.CombinedRecursive),
-            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound, Reducing.Elkhound), ImploderVariant.CombinedRecursive),/*
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.ArrayList,     ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Basic,          Reducing.Basic),    ImploderVariant.TokenizedRecursive,   TokenizerVariant.Null),
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.DisjointSorted, ProductionToGotoRepresentation.JavaHashMap), new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.ArrayList,     ForActorStacksRepresentation.ArrayDeque,    ParseForestRepresentation.Basic,  ParseForestConstruction.Full, StackRepresentation.Basic,          Reducing.Basic),    ImploderVariant.TokenizedRecursive,   TokenizerVariant.Null),
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.Hybrid,         Reducing.Basic),    ImploderVariant.TokenizedRecursive,   TokenizerVariant.Null),
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound, Reducing.Elkhound), ImploderVariant.TokenizedRecursive,   TokenizerVariant.Null),/*
             new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.Hybrid,         Reducing.Basic)),
             new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Hybrid, ParseForestConstruction.Optimized, StackRepresentation.HybridElkhound, Reducing.Elkhound)),*/
-            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Incremental, ParseForestConstruction.Full,      StackRepresentation.Hybrid, Reducing.Basic), ImploderVariant.SeparateRecursiveIncremental)
+            new IntegrationVariant(new ParseTableVariant(ActionsForCharacterRepresentation.Separated,      ProductionToGotoRepresentation.ForLoop),     new JSGLR2Variants.ParserVariant(ActiveStacksRepresentation.LinkedHashMap, ForActorStacksRepresentation.LinkedHashMap, ParseForestRepresentation.Incremental, ParseForestConstruction.Full, StackRepresentation.Hybrid,    Reducing.Basic),    ImploderVariant.RecursiveIncremental, TokenizerVariant.Recursive)
         );
         //@formatter:on
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2.java
@@ -17,34 +17,35 @@ import org.spoofax.jsglr2.stack.StackRepresentation;
 import org.spoofax.jsglr2.stack.collections.ActiveStacksRepresentation;
 import org.spoofax.jsglr2.stack.collections.ForActorStacksRepresentation;
 import org.spoofax.jsglr2.states.StateFactory;
+import org.spoofax.jsglr2.tokens.TokenizerVariant;
 
 public interface JSGLR2<AbstractSyntaxTree> {
     static JSGLR2<IStrategoTerm> standard(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
             new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.Hybrid, ParseForestConstruction.Full, StackRepresentation.HybridElkhound,
-                Reducing.Elkhound), ImploderVariant.CombinedRecursive));
+                Reducing.Elkhound), ImploderVariant.TokenizedRecursive, TokenizerVariant.Null));
     }
 
     static JSGLR2<IStrategoTerm> dataDependent(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
             new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.DataDependent, ParseForestConstruction.Full, StackRepresentation.Basic,
-                Reducing.DataDependent), ImploderVariant.CombinedRecursive));
+                Reducing.DataDependent), ImploderVariant.TokenizedRecursive, TokenizerVariant.Null));
     }
 
     static JSGLR2<IStrategoTerm> layoutSensitive(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
             new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.LayoutSensitive, ParseForestConstruction.Full, StackRepresentation.Basic,
-                Reducing.DataDependent), ImploderVariant.CombinedRecursive));
+                Reducing.DataDependent), ImploderVariant.TokenizedRecursive, TokenizerVariant.Null));
     }
 
     static JSGLR2<IStrategoTerm> incremental(IParseTable parseTable) {
         return JSGLR2Variants.getJSGLR2(parseTable,
             new Variant(new ParserVariant(ActiveStacksRepresentation.ArrayList, ForActorStacksRepresentation.ArrayDeque,
                 ParseForestRepresentation.Incremental, ParseForestConstruction.Full, StackRepresentation.Basic,
-                Reducing.Basic), ImploderVariant.SeparateRecursiveIncremental));
+                Reducing.Basic), ImploderVariant.RecursiveIncremental, TokenizerVariant.Recursive));
     }
 
     static JSGLR2<IStrategoTerm> standard(IStrategoTerm parseTableTerm) throws ParseTableReadException {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Implementation.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Implementation.java
@@ -9,10 +9,11 @@ import org.spoofax.jsglr2.parser.result.ParseFailure;
 import org.spoofax.jsglr2.parser.result.ParseResult;
 import org.spoofax.jsglr2.parser.result.ParseSuccess;
 
-class JSGLR2Implementation<ParseForest extends IParseForest, AbstractSyntaxTree> implements JSGLR2<AbstractSyntaxTree> {
+public class JSGLR2Implementation<ParseForest extends IParseForest, AbstractSyntaxTree>
+    implements JSGLR2<AbstractSyntaxTree> {
 
-    private final IParser<ParseForest> parser;
-    private final IImploder<ParseForest, AbstractSyntaxTree> imploder;
+    public final IParser<ParseForest> parser;
+    public final IImploder<ParseForest, AbstractSyntaxTree> imploder;
 
     JSGLR2Implementation(IParser<ParseForest> parser, IImploder<ParseForest, AbstractSyntaxTree> imploder) {
         this.parser = parser;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Implementation.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Implementation.java
@@ -1,7 +1,8 @@
 package org.spoofax.jsglr2;
 
 import org.spoofax.jsglr2.imploder.IImploder;
-import org.spoofax.jsglr2.imploder.ImplodeResult;
+import org.spoofax.jsglr2.imploder.ITokenizer;
+import org.spoofax.jsglr2.imploder.TokenizeResult;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.IParser;
 import org.spoofax.jsglr2.parser.ParseException;
@@ -9,15 +10,18 @@ import org.spoofax.jsglr2.parser.result.ParseFailure;
 import org.spoofax.jsglr2.parser.result.ParseResult;
 import org.spoofax.jsglr2.parser.result.ParseSuccess;
 
-public class JSGLR2Implementation<ParseForest extends IParseForest, AbstractSyntaxTree>
+public class JSGLR2Implementation<ParseForest extends IParseForest, ImplodeResult, AbstractSyntaxTree>
     implements JSGLR2<AbstractSyntaxTree> {
 
     public final IParser<ParseForest> parser;
-    public final IImploder<ParseForest, AbstractSyntaxTree> imploder;
+    public final IImploder<ParseForest, ImplodeResult> imploder;
+    public final ITokenizer<ImplodeResult, AbstractSyntaxTree> tokenizer;
 
-    JSGLR2Implementation(IParser<ParseForest> parser, IImploder<ParseForest, AbstractSyntaxTree> imploder) {
+    JSGLR2Implementation(IParser<ParseForest> parser, IImploder<ParseForest, ImplodeResult> imploder,
+        ITokenizer<ImplodeResult, AbstractSyntaxTree> tokenizer) {
         this.parser = parser;
         this.imploder = imploder;
+        this.tokenizer = tokenizer;
     }
 
     @Override public JSGLR2Result<AbstractSyntaxTree> parseUnsafeResult(String input, String filename,
@@ -28,9 +32,11 @@ public class JSGLR2Implementation<ParseForest extends IParseForest, AbstractSynt
         if(parseResult.isSuccess) {
             ParseSuccess<ParseForest> success = (ParseSuccess<ParseForest>) parseResult;
 
-            ImplodeResult<AbstractSyntaxTree> implodeResult = imploder.implode(input, filename, success.parseResult);
+            ImplodeResult implodeResult = imploder.implode(input, filename, success.parseResult);
 
-            return new JSGLR2Result<>(implodeResult);
+            TokenizeResult<AbstractSyntaxTree> tokenizeResult = tokenizer.tokenize(input, filename, implodeResult);
+
+            return new JSGLR2Result<>(tokenizeResult);
         } else {
             ParseFailure<ParseForest> failure = (ParseFailure<ParseForest>) parseResult;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Result.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Result.java
@@ -1,6 +1,6 @@
 package org.spoofax.jsglr2;
 
-import org.spoofax.jsglr2.imploder.ImplodeResult;
+import org.spoofax.jsglr2.imploder.TokenizeResult;
 import org.spoofax.jsglr2.tokens.Tokens;
 
 public final class JSGLR2Result<AbstractSyntaxTree> {
@@ -21,13 +21,13 @@ public final class JSGLR2Result<AbstractSyntaxTree> {
     /**
      * Constructs a result in the case that the parse succeeded.
      * 
-     * @param implodeResult
-     *            The implode result.
+     * @param tokenizeResult
+     *            The result from the tokenizer.
      */
-    JSGLR2Result(ImplodeResult<AbstractSyntaxTree> implodeResult) {
+    JSGLR2Result(TokenizeResult<AbstractSyntaxTree> tokenizeResult) {
         this.isSuccess = true;
-        this.tokens = implodeResult.tokens;
-        this.ast = implodeResult.ast;
+        this.tokens = tokenizeResult.tokens;
+        this.ast = tokenizeResult.ast;
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IImploder.java
@@ -2,8 +2,8 @@ package org.spoofax.jsglr2.imploder;
 
 import org.spoofax.jsglr2.parseforest.IParseForest;
 
-public interface IImploder<ParseForest extends IParseForest, AbstractSyntaxTree> {
+public interface IImploder<ParseForest extends IParseForest, Result> {
 
-    ImplodeResult<AbstractSyntaxTree> implode(String input, String filename, ParseForest parseForest);
+    Result implode(String input, String filename, ParseForest parseForest);
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/ITokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/ITokenizer.java
@@ -1,15 +1,7 @@
 package org.spoofax.jsglr2.imploder;
 
-import org.spoofax.jsglr2.tokens.Tokens;
+public interface ITokenizer<ImplodeResult, AbstractSyntaxTree> {
 
-public interface ITokenizer<AbstractSyntaxTree> {
-
-    AbstractSyntaxTree tokenize(Tokens tokens, TreeImploder.SubTree<AbstractSyntaxTree> tree);
-
-    default ImplodeResult<AbstractSyntaxTree> tokenize(String input, String filename,
-        TreeImploder.SubTree<AbstractSyntaxTree> tree) {
-        Tokens tokens = new Tokens(input, filename);
-        return new ImplodeResult<>(tokens, tokenize(tokens, tree));
-    }
+    TokenizeResult<AbstractSyntaxTree> tokenize(String input, String filename, ImplodeResult tree);
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/ImploderVariant.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/ImploderVariant.java
@@ -1,5 +1,5 @@
 package org.spoofax.jsglr2.imploder;
 
 public enum ImploderVariant {
-    CombinedRecursive, SeparateRecursive, SeparateRecursiveIncremental, SeparateIterative
+    TokenizedRecursive, Recursive, RecursiveIncremental, Iterative
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeStrategoTermImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeStrategoTermImploder.java
@@ -14,8 +14,8 @@ public class IterativeStrategoTermImploder
 //@formatter:on
     extends IterativeTreeImploder<ParseForest, ParseNode, Derivation, IStrategoTerm> {
 
-    public IterativeStrategoTermImploder(ITokenizer<IStrategoTerm> tokenizer) {
-        super(new StrategoTermTreeFactory(), tokenizer);
+    public IterativeStrategoTermImploder() {
+        super(new StrategoTermTreeFactory());
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeImploder.java
@@ -26,8 +26,8 @@ public class IterativeTreeImploder
 //@formatter:on
     extends TreeImploder<ParseForest, ParseNode, Derivation, Tree> {
 
-    public IterativeTreeImploder(ITreeFactory<Tree> treeFactory, ITokenizer<Tree> tokenizer) {
-        super(treeFactory, tokenizer);
+    public IterativeTreeImploder(ITreeFactory<Tree> treeFactory) {
+        super(treeFactory);
     }
 
     private class PseudoNode {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/NullStrategoImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/NullStrategoImploder.java
@@ -3,10 +3,11 @@ package org.spoofax.jsglr2.imploder;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 
-public class NullStrategoImploder<ParseForest extends IParseForest> implements IImploder<ParseForest, IStrategoTerm> {
+public class NullStrategoImploder<ParseForest extends IParseForest>
+    implements IImploder<ParseForest, TokenizeResult<IStrategoTerm>> {
 
-    @Override public ImplodeResult<IStrategoTerm> implode(String input, String filename, ParseForest forest) {
-        return null;
+    @Override public TokenizeResult<IStrategoTerm> implode(String input, String filename, ParseForest forest) {
+        return new TokenizeResult<>(null, null);
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/StrategoTermImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/StrategoTermImploder.java
@@ -14,8 +14,8 @@ public class StrategoTermImploder
 //@formatter:on
     extends TreeImploder<ParseForest, ParseNode, Derivation, IStrategoTerm> {
 
-    public StrategoTermImploder(StrategoTermTokenizer tokenizer) {
-        super(new StrategoTermTreeFactory(), tokenizer);
+    public StrategoTermImploder() {
+        super(new StrategoTermTreeFactory());
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizeResult.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizeResult.java
@@ -2,12 +2,12 @@ package org.spoofax.jsglr2.imploder;
 
 import org.spoofax.jsglr2.tokens.Tokens;
 
-public class ImplodeResult<AbstractSyntaxTree> {
+public class TokenizeResult<AbstractSyntaxTree> {
 
     public final Tokens tokens;
     public final AbstractSyntaxTree ast;
 
-    public ImplodeResult(Tokens tokens, AbstractSyntaxTree ast) {
+    public TokenizeResult(Tokens tokens, AbstractSyntaxTree ast) {
         this.tokens = tokens;
         this.ast = ast;
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizedTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizedTreeImploder.java
@@ -21,7 +21,7 @@ public abstract class TokenizedTreeImploder
     Derivation  extends IDerivation<ParseForest>,
     Tree>
 //@formatter:on
-    implements IImploder<ParseForest, Tree> {
+    implements IImploder<ParseForest, TokenizeResult<Tree>> {
 
     protected final ITokenizedTreeFactory<Tree> treeFactory;
 
@@ -29,7 +29,7 @@ public abstract class TokenizedTreeImploder
         this.treeFactory = treeFactory;
     }
 
-    @Override public ImplodeResult<Tree> implode(String input, String filename, ParseForest parseForest) {
+    @Override public TokenizeResult<Tree> implode(String input, String filename, ParseForest parseForest) {
         @SuppressWarnings("unchecked") ParseNode topParseNode = (ParseNode) parseForest;
 
         Tokens tokens = new Tokens(input, filename);
@@ -44,7 +44,7 @@ public abstract class TokenizedTreeImploder
         tokenTreeBinding(tokens.startToken(), tree.tree);
         tokenTreeBinding(tokens.endToken(), tree.tree);
 
-        return new ImplodeResult<>(tokens, tree.tree);
+        return new TokenizeResult<>(tokens, tree.tree);
     }
 
     static class SubTree<Tree> {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeImploder.java
@@ -16,22 +16,18 @@ public class TreeImploder
     Derivation  extends IDerivation<ParseForest>,
     Tree>
 //@formatter:on
-    implements IImploder<ParseForest, Tree> {
+    implements IImploder<ParseForest, TreeImploder.SubTree<Tree>> {
 
     protected final ITreeFactory<Tree> treeFactory;
-    protected ITokenizer<Tree> tokenizer;
 
-    public TreeImploder(ITreeFactory<Tree> treeFactory, ITokenizer<Tree> tokenizer) {
+    public TreeImploder(ITreeFactory<Tree> treeFactory) {
         this.treeFactory = treeFactory;
-        this.tokenizer = tokenizer;
     }
 
-    @Override public ImplodeResult<Tree> implode(String input, String filename, ParseForest parseForest) {
+    @Override public SubTree<Tree> implode(String input, String filename, ParseForest parseForest) {
         @SuppressWarnings("unchecked") ParseNode topParseNode = (ParseNode) parseForest;
 
-        SubTree<Tree> tree = implodeParseNode(input, topParseNode, 0);
-
-        return tokenizer.tokenize(input, filename, tree);
+        return implodeParseNode(input, topParseNode, 0);
     }
 
     protected SubTree<Tree> implodeParseNode(String inputString, ParseNode parseNode, int startOffset) {
@@ -160,7 +156,7 @@ public class TreeImploder
             return treeFactory.createTuple(production.sort(), childASTs);
     }
 
-    protected static class SubTree<Tree> {
+    public static class SubTree<Tree> {
 
         public final Tree tree;
         public final List<SubTree<Tree>> children;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeImploder.java
@@ -3,7 +3,6 @@ package org.spoofax.jsglr2.imploder;
 import java.util.*;
 
 import org.metaborg.parsetable.IProduction;
-import org.metaborg.util.iterators.Iterables2;
 import org.spoofax.jsglr2.imploder.treefactory.ITreeFactory;
 import org.spoofax.jsglr2.layoutsensitive.LayoutSensitiveParseNode;
 import org.spoofax.jsglr2.parseforest.IDerivation;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
@@ -4,7 +4,7 @@ import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.tokens.Tokens;
 
-public abstract class TreeTokenizer<Tree> implements ITokenizer<Tree> {
+public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.SubTree<Tree>, Tree> {
     class SubTree {
         Tree tree;
         IToken leftToken;
@@ -24,7 +24,13 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<Tree> {
 
     }
 
-    @Override public Tree tokenize(Tokens tokens, TreeImploder.SubTree<Tree> tree) {
+    @Override
+    public TokenizeResult<Tree> tokenize(String input, String filename, TreeImploder.SubTree<Tree> tree) {
+        Tokens tokens = new Tokens(input, filename);
+        return new TokenizeResult<>(tokens, tokenize(tokens, tree));
+    }
+
+    protected Tree tokenize(Tokens tokens, TreeImploder.SubTree<Tree> tree) {
         tokens.makeStartToken();
         tokenTreeBinding(tokens.startToken(), tree.tree);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalStrategoTermImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalStrategoTermImploder.java
@@ -1,7 +1,6 @@
 package org.spoofax.jsglr2.imploder.incremental;
 
 import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.jsglr2.imploder.StrategoTermTokenizer;
 import org.spoofax.jsglr2.imploder.treefactory.StrategoTermTreeFactory;
 import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
@@ -15,8 +14,8 @@ public class IncrementalStrategoTermImploder
 //@formatter:on
     extends IncrementalTreeImploder<ParseForest, ParseNode, Derivation, IStrategoTerm> {
 
-    public IncrementalStrategoTermImploder(StrategoTermTokenizer tokenizer) {
-        super(new StrategoTermTreeFactory(), tokenizer);
+    public IncrementalStrategoTermImploder() {
+        super(new StrategoTermTreeFactory());
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalTreeImploder.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.metaborg.parsetable.IProduction;
-import org.spoofax.jsglr2.imploder.ITokenizer;
-import org.spoofax.jsglr2.imploder.ImplodeResult;
 import org.spoofax.jsglr2.imploder.TreeImploder;
 import org.spoofax.jsglr2.imploder.treefactory.ITreeFactory;
 import org.spoofax.jsglr2.parseforest.IDerivation;
@@ -26,11 +24,11 @@ public abstract class IncrementalTreeImploder
     private Map<String, ParseNode> inputCache = new HashMap<>();
     private Map<String, SubTree<Tree>> outputCache = new HashMap<>();
 
-    public IncrementalTreeImploder(ITreeFactory<Tree> treeFactory, ITokenizer<Tree> tokenizer) {
-        super(treeFactory, tokenizer);
+    public IncrementalTreeImploder(ITreeFactory<Tree> treeFactory) {
+        super(treeFactory);
     }
 
-    @Override public ImplodeResult<Tree> implode(String inputString, String filename, ParseForest parseForest) {
+    @Override public SubTree<Tree> implode(String inputString, String filename, ParseForest parseForest) {
         @SuppressWarnings("unchecked") ParseNode topParseNode = (ParseNode) parseForest;
 
         final SubTree<Tree> tree;
@@ -44,7 +42,7 @@ public abstract class IncrementalTreeImploder
             outputCache.put(filename, tree);
         }
 
-        return tokenizer.tokenize(inputString, filename, tree);
+        return tree;
     }
 
     private SubTree<Tree> implodeParseNode(String inputString, ParseNode parseNode, ParseNode oldNode,

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/NullTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/NullTokenizer.java
@@ -1,0 +1,12 @@
+package org.spoofax.jsglr2.tokens;
+
+import org.spoofax.jsglr2.imploder.ITokenizer;
+import org.spoofax.jsglr2.imploder.TokenizeResult;
+
+public class NullTokenizer<Tree> implements ITokenizer<TokenizeResult<Tree>, Tree> {
+
+    @Override public TokenizeResult<Tree> tokenize(String input, String filename, TokenizeResult<Tree> tree) {
+        return tree;
+    }
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/TokenizerVariant.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/TokenizerVariant.java
@@ -1,0 +1,5 @@
+package org.spoofax.jsglr2.tokens;
+
+public enum TokenizerVariant {
+    Null, Recursive, Iterative
+}


### PR DESCRIPTION
This PR adds a separate enum `TokenizerVariant`, instead of having the different tokenizer variants hidden in the imploder variants.
This will allow for separate benchmarking for imploding and tokenizing.

Old situation:
- `IImploder<ParseForest, Tree>` returned an `ImplodeResult<Tree>`, containing a `Tokens` object and a `Tree` object (the AST).
- The `TokenizedTreeImploder` could directly return an `ImplodeResult<Tree>`, as it built the AST and tokens at the same time.
- The separated imploders and tokenizers had to be composed together in order to make this work.

New situation:
- The class `ImplodeResult<Tree>` has been renamed to `TokenizeResult<Tree>`, as the imploder does not necessarily return a `Tokens` object anymore.
- `IImploder<ParseForest, ImplodeResult>` returns an `ImplodeResult`.
- `ITokenizer<ImplodeResult, Tree>` takes an `ImplodeResult` as input and returns a ` TokenizeResult<Tree>`.
- The `TokenizedTreeImploder` has not changed behaviour, modulo the rename of the result class.
- The new, separated imploders now have a `TreeImploder.SubTree<Tree>` as `ImplodeResult`.
- The new, separated tokenizers now take a `TreeImploder.SubTree<Tree>` as input and produce a `TokenizeResult<Tree>`.

Other changes:
- There is a new tokenizer variant `Null`, which:
  - Just passes on the `TokenizeResult` from the preceding imploder in the case of combined imploding/tokenization or in the case where no tree is built at all
  - Just uses the tree output from the imploder and sets the `tokens` field to `null` in the case of the separated imploders
- The `JSGLR2Implementation` class has been made public, else the separate components could not be called from the benchmark