### PR TITLE
Optimize lookahead stack

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParse.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParse.java
@@ -39,18 +39,18 @@ public class IncrementalParse<StackNode extends IStackNode> extends AbstractPars
         ParserObserving<IncrementalParseForest, StackNode> observing) {
 
         super(inputString, filename, activeStacksFactory, forActorStacksFactory, observing);
-        initParse(processUpdates(editorUpdates, previous));
+        initParse(processUpdates(editorUpdates, previous), inputString);
     }
 
     public IncrementalParse(String inputString, String filename, IActiveStacksFactory activeStacksFactory,
         IForActorStacksFactory forActorStacksFactory, ParserObserving<IncrementalParseForest, StackNode> observing) {
 
         super(inputString, filename, activeStacksFactory, forActorStacksFactory, observing);
-        initParse(getParseNodeFromString(inputString));
+        initParse(getParseNodeFromString(inputString), inputString);
     }
 
-    private void initParse(IncrementalParseForest updatedTree) {
-        this.lookahead = new EagerLookaheadStack(updatedTree); // TODO switch types between Lazy and Eager
+    private void initParse(IncrementalParseForest updatedTree, String inputString) {
+        this.lookahead = new EagerLookaheadStack(updatedTree, inputString); // TODO switch types between Lazy and Eager
         this.multipleStates = false;
         this.currentChar = lookahead.actionQueryCharacter();
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/EagerLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/EagerLookaheadStack.java
@@ -24,8 +24,7 @@ public class EagerLookaheadStack implements ILookaheadStack {
      */
     public EagerLookaheadStack(IncrementalParseForest root, String inputString) {
         stack.push(IncrementalCharacterNode.EOF_NODE);
-        if(root.width() > 0)
-            stack.push(root);
+        stack.push(root);
 
         this.inputString = inputString;
         this.inputLength = inputString.length();

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/EagerLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/EagerLookaheadStack.java
@@ -1,5 +1,7 @@
 package org.spoofax.jsglr2.incremental.lookaheadstack;
 
+import static org.metaborg.characterclasses.CharacterClassFactory.EOF_INT;
+
 import java.util.Stack;
 
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
@@ -9,14 +11,28 @@ import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 public class EagerLookaheadStack implements ILookaheadStack {
     /**
      * The stack contains all subtrees that are yet to be popped. The top of the stack also contains the subtree that
-     * has been returned last time. The stack initially only contains EOF and the root (
+     * has been returned last time. The stack initially only contains EOF and the root.
      */
     private final Stack<IncrementalParseForest> stack = new Stack<>();
+    private final String inputString;
+    private final int inputLength;
+    private int position = 0;
 
-    public EagerLookaheadStack(IncrementalParseForest root) {
+    /**
+     * @param inputString
+     *            should be equal to the yield of the root.
+     */
+    public EagerLookaheadStack(IncrementalParseForest root, String inputString) {
         stack.push(IncrementalCharacterNode.EOF_NODE);
         if(root.width() > 0)
             stack.push(root);
+
+        this.inputString = inputString;
+        this.inputLength = inputString.length();
+    }
+
+    public EagerLookaheadStack(IncrementalParseForest root) {
+        this(root, root.getYield());
     }
 
     @Override public void leftBreakdown() {
@@ -35,29 +51,21 @@ public class EagerLookaheadStack implements ILookaheadStack {
     }
 
     @Override public void popLookahead() {
-        stack.pop();
+        position += stack.pop().width();
     }
 
     @Override public int actionQueryCharacter() {
-        for(int i = stack.size() - 1; i >= 0; i--) {
-            if(stack.get(i).width() <= 0)
-                continue;
-            return stack.get(i).getYield(1).charAt(0);
-        }
-        return -1; // Should only happen when stack is empty, as EOF is always on the stack before that
+        if(position < inputLength)
+            return inputString.charAt(position);
+        if(position == inputLength)
+            return EOF_INT;
+        else
+            return -1;
     }
 
     @Override public String actionQueryLookahead(int length) {
-        int width = length + 1;
-        StringBuilder sb = new StringBuilder(width);
-        int stackIndex = stack.size() - 1;
-        while(width > 0 && stackIndex >= 0) {
-            IncrementalParseForest parseForest = stack.get(stackIndex);
-            sb.append(parseForest.width() <= width ? parseForest.getYield() : parseForest.getYield(width));
-            width -= parseForest.width();
-            stackIndex--;
-        }
-        return sb.substring(1);
+        return inputString.substring(position + 1, Math.min(position + 1 + length, inputLength))
+            + (position + 1 + length > inputLength ? (char) EOF_INT : "");
     }
 
     @Override public IncrementalParseForest get() {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/LazyLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/LazyLookaheadStack.java
@@ -1,5 +1,7 @@
 package org.spoofax.jsglr2.incremental.lookaheadstack;
 
+import static org.metaborg.characterclasses.CharacterClassFactory.EOF_INT;
+
 import java.util.Stack;
 
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
@@ -13,9 +15,16 @@ public class LazyLookaheadStack implements ILookaheadStack {
      * initialized, a mock root is created and pushed to the stack.
      */
     private final Stack<StackTuple> stack = new Stack<>();
+    private final String inputString;
+    private final int inputLength;
+    private int position = 0;
     private IncrementalParseForest last;
 
-    public LazyLookaheadStack(IncrementalParseForest root) {
+    /**
+     * @param inputString
+     *            should be equal to the yield of the root.
+     */
+    public LazyLookaheadStack(IncrementalParseForest root, String inputString) {
         IncrementalParseNode ultraRoot = new IncrementalParseNode(root, IncrementalCharacterNode.EOF_NODE);
         if(root.width() > 0) {
             stack.push(new StackTuple(ultraRoot, 0));
@@ -24,6 +33,13 @@ public class LazyLookaheadStack implements ILookaheadStack {
             stack.push(new StackTuple(ultraRoot, 1));
             last = IncrementalCharacterNode.EOF_NODE;
         }
+
+        this.inputString = inputString;
+        this.inputLength = inputString.length();
+    }
+
+    public LazyLookaheadStack(IncrementalParseForest root) {
+        this(root, root.getYield());
     }
 
     @Override public IncrementalParseForest get() {
@@ -44,6 +60,7 @@ public class LazyLookaheadStack implements ILookaheadStack {
     }
 
     @Override public void popLookahead() {
+        position += last.width();
         if(stack.isEmpty())
             last = null;
         StackTuple res = stack.pop();
@@ -70,11 +87,17 @@ public class LazyLookaheadStack implements ILookaheadStack {
     }
 
     @Override public int actionQueryCharacter() {
-        return 'a'; // TODO this is a pain in the nose. Hardcoded test result :see_no_evil:
+        if(position < inputLength)
+            return inputString.charAt(position);
+        if(position == inputLength)
+            return EOF_INT;
+        else
+            return -1;
     }
 
     @Override public String actionQueryLookahead(int length) {
-        return ("bcd" + (char) 256).substring(0, Math.min(4, length)); // TODO this is a pain in the nose
+        return inputString.substring(position + 1, Math.min(position + 1 + length, inputLength))
+            + (position + 1 + length > inputLength ? (char) EOF_INT : "");
     }
 
     private final class StackTuple {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/LazyLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/LazyLookaheadStack.java
@@ -26,14 +26,9 @@ public class LazyLookaheadStack implements ILookaheadStack {
      */
     public LazyLookaheadStack(IncrementalParseForest root, String inputString) {
         IncrementalParseNode ultraRoot = new IncrementalParseNode(root, IncrementalCharacterNode.EOF_NODE);
-        if(root.width() > 0) {
-            stack.push(new StackTuple(ultraRoot, 0));
-            last = root;
-        } else {
-            stack.push(new StackTuple(ultraRoot, 1));
-            last = IncrementalCharacterNode.EOF_NODE;
-        }
+        stack.push(new StackTuple(ultraRoot, 0));
 
+        this.last = root;
         this.inputString = inputString;
         this.inputLength = inputString.length();
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseForest.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseForest.java
@@ -27,7 +27,20 @@ public abstract class IncrementalParseForest implements IParseForest {
 
     abstract protected void prettyPrint(TreePrettyPrinter printer);
 
+    /**
+     * Warning: calling this method for every node in the parse tree is very memory-inefficient. If you need parts of
+     * the input string, you're better off saving the input string and calling `charAt` or `substring` on that.
+     * 
+     * @return The yield of this parse forest node.
+     */
     public abstract String getYield();
 
+    /**
+     * Slightly optimized by only traversing the parts of the tree that are necessary to calculate the requested yield.
+     * 
+     * @param length
+     *            The length of the string to return.
+     * @return The first `length` characters of the yield of this parse forest node.
+     */
     public abstract String getYield(int length);
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseForest.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseForest.java
@@ -30,14 +30,14 @@ public abstract class IncrementalParseForest implements IParseForest {
     /**
      * Warning: calling this method for every node in the parse tree is very memory-inefficient. If you need parts of
      * the input string, you're better off saving the input string and calling `charAt` or `substring` on that.
-     * 
+     *
      * @return The yield of this parse forest node.
      */
     public abstract String getYield();
 
     /**
      * Slightly optimized by only traversing the parts of the tree that are necessary to calculate the requested yield.
-     * 
+     *
      * @param length
      *            The length of the string to return.
      * @return The first `length` characters of the yield of this parse forest node.

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/lookaheadstack/AbstractLookaheadStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/lookaheadstack/AbstractLookaheadStackTest.java
@@ -23,6 +23,21 @@ public abstract class AbstractLookaheadStackTest {
         assertPoppingRoot(root);
     }
 
+    @Test public void testThreeChildrenNoYield() {
+        IncrementalParseNode node1 = new IncrementalParseNode();
+        IncrementalParseNode node2 = new IncrementalParseNode();
+        IncrementalParseNode node3 = new IncrementalParseNode();
+        IncrementalParseNode root = new IncrementalParseNode(node1, node2, node3);
+
+        ILookaheadStack stack = getStack(root);
+        assertLeftBreakdown(node1, stack);
+        assertPopLookahead(node2, stack);
+        assertLeftBreakdown(node3, stack);
+        assertPoppingEOF(stack);
+
+        assertPoppingRoot(root);
+    }
+
     @Test public void testThreeChildren() {
         IncrementalCharacterNode node1 = new IncrementalCharacterNode(97);
         IncrementalCharacterNode node2 = new IncrementalCharacterNode(98);

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/lookaheadstack/EagerLookaheadStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/lookaheadstack/EagerLookaheadStackTest.java
@@ -3,7 +3,9 @@ package org.spoofax.jsglr2.incremental.lookaheadstack;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 
 public class EagerLookaheadStackTest extends AbstractLookaheadStackTest {
+
     @Override protected ILookaheadStack getStack(IncrementalParseNode root) {
         return new EagerLookaheadStack(root);
     }
+
 }

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/lookaheadstack/LazyLookaheadStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/lookaheadstack/LazyLookaheadStackTest.java
@@ -3,7 +3,9 @@ package org.spoofax.jsglr2.incremental.lookaheadstack;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 
 public class LazyLookaheadStackTest extends AbstractLookaheadStackTest {
+
     @Override protected ILookaheadStack getStack(IncrementalParseNode root) {
         return new LazyLookaheadStack(root);
     }
+
 }


### PR DESCRIPTION
While benchmarking, I found out that the current implementation of the lookahead stack is very memory-inefficient. It used to walk the parse forest nodes that are on the stack in order to calculate the lookahead character(s), using `StringBuilder`s to which the contents of the leaves (`CharacterNode`s) of the forests.

Now, the lookahead stacks make use of the input string. The lookahead stacks will keep track of their current position in the input/forest, making the querying of the current character a matter of calling `charAt`, and querying of lookahead a matter of calling `substring`.

This also finishes up the implementation for the `LazyLookaheadStack`, because I never took the effort to walk this more complicated stack in order to calculate the lookahead. Now, this can be done using the input string, that can be directly used.

Finally, I've made a small change to how trees with null yield are handled. In theory, if nothing would have changed in the input, a tree with null yield can still be re-used. It used to be the case that the constructor of the lookahead stacks would directly skip this null-yield tree, but not anymore.