### PR TITLE
Improve diffing

### DIFF
--- a/org.spoofax.jsglr2/pom.xml
+++ b/org.spoofax.jsglr2/pom.xml
@@ -52,6 +52,44 @@
             <version>${metaborg-version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>5.3.1.201904271842-r</version>
+            <!-- Because only the org.eclipse.jgit.diff package is used (which has no dependencies),
+            all unnecessary dependencies of JGit are excluded. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.jcraft</groupId>
+                    <artifactId>jsch</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.jcraft</groupId>
+                    <artifactId>jzlib</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.googlecode.javaewah</groupId>
+                    <artifactId>JavaEWAH</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpg-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
     <developers>

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/EditorUpdate.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/EditorUpdate.java
@@ -3,14 +3,26 @@ package org.spoofax.jsglr2.incremental;
 import java.util.Objects;
 
 public class EditorUpdate {
+
+    public enum Type {
+        DELETION, INSERTION, REPLACEMENT
+    }
+
     public final int deletedStart;
     public final int deletedEnd;
     public final String inserted;
+    public final Type type; // Redundant information that is calculated based on other fields, just for convenience
 
     public EditorUpdate(int deletedStart, int deletedEnd, String inserted) {
         this.deletedStart = deletedStart;
         this.deletedEnd = deletedEnd;
         this.inserted = inserted;
+        if(deletedStart == deletedEnd)
+            type = Type.INSERTION;
+        else if(inserted.length() == 0)
+            type = Type.DELETION;
+        else
+            type = Type.REPLACEMENT;
     }
 
     @Override public boolean equals(Object o) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParse.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParse.java
@@ -1,19 +1,16 @@
 package org.spoofax.jsglr2.incremental;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 import org.metaborg.parsetable.actions.IGoto;
 import org.metaborg.sdf2table.parsetable.query.ActionsForCharacterSeparated;
 import org.metaborg.sdf2table.parsetable.query.ActionsPerCharacterClass;
 import org.metaborg.sdf2table.parsetable.query.ProductionToGotoForLoop;
 import org.spoofax.jsglr2.JSGLR2Variants;
+import org.spoofax.jsglr2.incremental.diff.ProcessUpdates;
 import org.spoofax.jsglr2.incremental.lookaheadstack.EagerLookaheadStack;
 import org.spoofax.jsglr2.incremental.lookaheadstack.ILookaheadStack;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
-import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForestManager;
-import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.ParseFactory;
 import org.spoofax.jsglr2.parser.observing.ParserObserving;
@@ -27,31 +24,30 @@ import org.spoofax.jsglr2.states.State;
 public class IncrementalParse<StackNode extends IStackNode> extends AbstractParse<IncrementalParseForest, StackNode> {
 
     // TODO this should not be public, but still end up in the IncrementalParseForestManager
-    public boolean multipleStates;
+    public boolean multipleStates = false;
     ILookaheadStack lookahead;
 
-    private IncrementalParseForestManager parseForestManager = new IncrementalParseForestManager();
-    public static State NO_STATE = new State(-1, new ActionsForCharacterSeparated(new ActionsPerCharacterClass[0]),
-        new ProductionToGotoForLoop(new IGoto[0]));
+    private final ProcessUpdates<StackNode> processUpdates = new ProcessUpdates<>(this);
+    public static final State NO_STATE = new State(-1,
+        new ActionsForCharacterSeparated(new ActionsPerCharacterClass[0]), new ProductionToGotoForLoop(new IGoto[0]));
 
     public IncrementalParse(List<EditorUpdate> editorUpdates, IncrementalParseForest previous, String inputString,
         String filename, IActiveStacksFactory activeStacksFactory, IForActorStacksFactory forActorStacksFactory,
         ParserObserving<IncrementalParseForest, StackNode> observing) {
 
         super(inputString, filename, activeStacksFactory, forActorStacksFactory, observing);
-        initParse(processUpdates(editorUpdates, previous), inputString);
+        initParse(processUpdates.processUpdates(previous, editorUpdates), inputString);
     }
 
     public IncrementalParse(String inputString, String filename, IActiveStacksFactory activeStacksFactory,
         IForActorStacksFactory forActorStacksFactory, ParserObserving<IncrementalParseForest, StackNode> observing) {
 
         super(inputString, filename, activeStacksFactory, forActorStacksFactory, observing);
-        initParse(getParseNodeFromString(inputString), inputString);
+        initParse(processUpdates.getParseNodeFromString(inputString), inputString);
     }
 
     private void initParse(IncrementalParseForest updatedTree, String inputString) {
         this.lookahead = new EagerLookaheadStack(updatedTree, inputString); // TODO switch types between Lazy and Eager
-        this.multipleStates = false;
         this.currentChar = lookahead.actionQueryCharacter();
     }
 
@@ -91,77 +87,6 @@ public class IncrementalParse<StackNode extends IStackNode> extends AbstractPars
         currentOffset += lookahead.get().width();
         lookahead.popLookahead();
         currentChar = lookahead.actionQueryCharacter();
-    }
-
-    // Recursively processes the tree until the update site has been found
-    private IncrementalParseForest processUpdates(List<EditorUpdate> editorUpdates, IncrementalParseForest previous) {
-        // TODO for all editor updates (currently only checking first update)
-        EditorUpdate editorUpdate = editorUpdates.get(0);
-        // If everything is deleted, then just return the inserted string
-        if(editorUpdate.deletedStart == 0 && editorUpdate.deletedEnd == previous.width())
-            return getParseNodeFromString(editorUpdate.inserted);
-        return processUpdates(previous, 0, editorUpdate.deletedStart, editorUpdate.deletedEnd, editorUpdate.inserted);
-    }
-
-    private IncrementalParseForest processUpdates(IncrementalParseForest currentForest, int currentOffset,
-        int deletedStartOffset, int deletedEndOffset, String inserted) {
-        if(currentForest.isTerminal()) {
-            // If there is nothing to delete
-            if(deletedStartOffset == deletedEndOffset) {
-                // Insert-after strategy (can also be applied in the general case, but gives less subtree re-use)
-                // If insert position is begin of string, prepend to first character
-                if(deletedStartOffset == 0 && currentOffset == deletedEndOffset)
-                    return newParseNodeFromChildren(getParseNodeFromString(inserted), currentForest);
-                // If insert position is NOT begin of string, append to previous character
-                if(deletedStartOffset != 0 && currentOffset == deletedStartOffset - 1)
-                    return newParseNodeFromChildren(currentForest, getParseNodeFromString(inserted));
-                // If none of the cases applies, just return original character node
-                return currentForest;
-            }
-            // In-place replace strategy
-            // Replace first deleted character with the inserted string
-            if(deletedStartOffset == currentOffset)
-                return getParseNodeFromString(inserted);
-            // Delete all other characters
-            if(deletedStartOffset < currentOffset && currentOffset < deletedEndOffset)
-                return null;
-            // If none of the cases applies, just return original character node
-            return currentForest;
-        }
-        // Use a shallow copy of the current children, else the old children array will be modified
-        IncrementalParseForest[] parseForests =
-            ((IncrementalParseNode) currentForest).getFirstDerivation().parseForests().clone();
-        for(int i = 0; i < parseForests.length; i++) {
-            IncrementalParseForest parseForest = parseForests[i];
-            int nextOffset = currentOffset + parseForest.width(); // == start offset of right sibling subtree
-            // Optimization: if current subtree falls completely within [deletedStart + 1, deletedEnd], delete it
-            if(deletedStartOffset < currentOffset && nextOffset <= deletedEndOffset)
-                parseForests[i] = null;
-            // If current subtree overlaps with the to-be-deleted range, recurse
-            else if(deletedStartOffset <= nextOffset && currentOffset <= deletedEndOffset)
-                parseForests[i] =
-                    processUpdates(parseForest, currentOffset, deletedStartOffset, deletedEndOffset, inserted);
-            currentOffset = nextOffset;
-        }
-        return newParseNodeFromChildren(parseForests);
-    }
-
-    private IncrementalParseNode newParseNodeFromChildren(IncrementalParseForest... newChildren) {
-        IncrementalParseForest[] filtered =
-            Arrays.stream(newChildren).filter(Objects::nonNull).toArray(IncrementalParseForest[]::new);
-        if(filtered.length == 0)
-            return null;
-        return parseForestManager.createChangedParseNode(this, filtered);
-    }
-
-    private IncrementalParseNode getParseNodeFromString(String inputString) {
-        IncrementalParseForest[] parseForests = parseForestManager.parseForestsArray(inputString.length());
-
-        char[] chars = inputString.toCharArray();
-        for(int i = 0; i < chars.length; i++) {
-            parseForests[i] = parseForestManager.createCharacterNode(this, chars[i]);
-        }
-        return parseForestManager.createChangedParseNode(this, parseForests);
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiff.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiff.java
@@ -1,0 +1,74 @@
+package org.spoofax.jsglr2.incremental.diff;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jgit.diff.*;
+import org.eclipse.jgit.util.IntList;
+import org.spoofax.jsglr2.incremental.EditorUpdate;
+
+public class JGitHistogramDiff implements IStringDiff {
+
+    private final HistogramDiff diff = new HistogramDiff();
+
+    @Override public List<EditorUpdate> diff(String oldString, String newString) {
+        // By default, RawText is split per line.
+        // By passing a `lineMap` which is a list that contains all integers from 0 to length, this is avoided.
+        RawText oldText = new RawText(oldString.getBytes(), new IncrementingIntList(oldString.length()));
+        RawText newText = new RawText(newString.getBytes(), new IncrementingIntList(newString.length()));
+
+        EditList edits = diff.diff(RawTextComparator.DEFAULT, oldText, newText);
+        List<EditorUpdate> updates = new ArrayList<>(edits.size());
+        for(Edit edit : edits) {
+            updates.add(new EditorUpdate(edit.getBeginA(), edit.getEndA(),
+                newString.substring(edit.getBeginB(), edit.getEndB())));
+        }
+        return updates;
+    }
+
+    /**
+     * This list always contains (size + 2) integers: namely Integer.MIN_VALUE followed by the sequence 0 up to and
+     * including size. This class avoids storing an entire list of integers because the entries in the list are trivial
+     * to compute when queried.
+     */
+    static class IncrementingIntList extends IntList {
+        private final int size;
+
+        IncrementingIntList(int size) {
+            this.size = size;
+        }
+
+        @Override public void add(int n) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public boolean contains(int value) {
+            return value == Integer.MIN_VALUE || 0 <= value && value <= size;
+        }
+
+        @Override public void fillTo(int toIndex, int val) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public int get(int i) {
+            if(i == 0)
+                return Integer.MIN_VALUE;
+            if(i >= size())
+                throw new IndexOutOfBoundsException();
+            return i - 1;
+        }
+
+        @Override public void set(int index, int n) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public int size() {
+            return size + 2;
+        }
+
+        @Override public String toString() {
+            return "[" + Integer.MIN_VALUE + ", 0, 1, ..., " + size + "]";
+        }
+    }
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdates.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdates.java
@@ -1,0 +1,152 @@
+package org.spoofax.jsglr2.incremental.diff;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import org.spoofax.jsglr2.incremental.EditorUpdate;
+import org.spoofax.jsglr2.incremental.IncrementalParse;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForestManager;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.stack.IStackNode;
+
+public class ProcessUpdates<StackNode extends IStackNode> {
+
+    private final IncrementalParse<StackNode> incrementalParse;
+    private final IncrementalParseForestManager parseForestManager = new IncrementalParseForestManager();
+
+    public ProcessUpdates(IncrementalParse<StackNode> incrementalParse) {
+        this.incrementalParse = incrementalParse;
+    }
+
+    public IncrementalParseForest processUpdates(IncrementalParseForest previous, EditorUpdate... editorUpdates) {
+        return processUpdates(previous, Arrays.asList(editorUpdates));
+    }
+
+    /**
+     * Recursively processes the tree until the update site has been found. General strategy:
+     *
+     * <ul>
+     * <li>If the update is a replacement (a, b, new) with a != b: replace character a with the new string and delete
+     * characters [a+1, b>
+     * <li>If the update is an insertion (a, a, new), and
+     * <ul>
+     * <li>the insertion is at the first character: replace first character with (new, first)
+     * <li>the insertion is anywhere else: replace character a with (a, new)
+     * </ul>
+     * <li>If the update is a deletion (a, b, ""): just delete everything in range [a, b>
+     * </ul>
+     * 
+     * The slightly reasonable assumption has been made that any two consecutive updates never "touch" each other
+     * (meaning that first.end == second.start). This method will still work for two consecutive replacements, but no
+     * guarantees are made for a consecutive insertion/deletion.
+     */
+    public IncrementalParseForest processUpdates(IncrementalParseForest previous, List<EditorUpdate> editorUpdates) {
+        // Optimization: f everything is deleted, then return a tree created from the inserted string
+        if(editorUpdates.size() == 1) {
+            EditorUpdate editorUpdate = editorUpdates.get(0);
+            if(editorUpdate.deletedStart == 0 && editorUpdate.deletedEnd == previous.width()) {
+                return getParseNodeFromString(editorUpdate.inserted);
+            }
+        }
+
+        LinkedList<EditorUpdate> linkedUpdates = new LinkedList<>(editorUpdates);
+        return processUpdates(previous, 0, linkedUpdates);
+    }
+
+    private IncrementalParseForest processUpdates(IncrementalParseForest currentForest, int currentOffset,
+        LinkedList<EditorUpdate> updates) {
+        if(currentForest.isTerminal()) {
+            EditorUpdate update = updates.getFirst();
+            int deletedStartOffset = update.deletedStart;
+            int deletedEndOffset = update.deletedEnd;
+            String inserted = update.inserted;
+
+            // If there is nothing to delete (it is an insertion)
+            if(deletedStartOffset == deletedEndOffset) {
+                // If insert position is begin of string, prepend to first character
+                if(deletedStartOffset == 0 && currentOffset == deletedEndOffset) {
+                    updates.removeFirst();
+                    return newParseNodeFromChildren(getParseNodeFromString(inserted), currentForest);
+                }
+                // If insert position is NOT begin of string, append to current character
+                if(deletedStartOffset != 0 && currentOffset == deletedStartOffset - 1) {
+                    updates.removeFirst();
+                    return newParseNodeFromChildren(currentForest, getParseNodeFromString(inserted));
+                }
+                // If none of the cases applies, just return original character node
+                return currentForest;
+            }
+            // Replace first deleted character with the inserted string (if any)
+            if(deletedStartOffset == currentOffset && inserted.length() > 0) {
+                if(currentOffset == deletedEndOffset - 1)
+                    updates.removeFirst();
+                return getParseNodeFromString(inserted);
+            }
+            // Else, delete all characters within deletion range
+            if(deletedStartOffset <= currentOffset && currentOffset < deletedEndOffset) {
+                if(currentOffset == deletedEndOffset - 1)
+                    updates.removeFirst();
+                return null;
+            }
+            // If none of the cases applies, just return original character node
+            return currentForest;
+        }
+        // Use a shallow copy of the current children, else the old children array will be modified
+        IncrementalParseForest[] parseForests =
+            ((IncrementalParseNode) currentForest).getFirstDerivation().parseForests().clone();
+        for(int i = 0; i < parseForests.length; i++) {
+            if(updates.isEmpty())
+                break;
+            // If the current subtree is after the previous to-be-deleted range, move to next update
+            if(currentOffset >= updates.getFirst().deletedEnd && currentOffset > 0)
+                updates.removeFirst();
+            if(updates.isEmpty())
+                break;
+
+            EditorUpdate update = updates.getFirst();
+            int deletedStartOffset = update.deletedStart;
+            int deletedEndOffset = update.deletedEnd;
+            String inserted = update.inserted;
+            // TODO store update type (insertion/deletion/replacement) in EditorUpdate
+            boolean isReplacement = inserted.length() > 0 && deletedStartOffset < deletedEndOffset;
+
+            IncrementalParseForest parseForest = parseForests[i];
+            int nextOffset = currentOffset + parseForest.width(); // == start offset of right sibling subtree
+
+            // Optimization: if current subtree starts exactly at deletedStart and it spans the subtree, replace it
+            if(deletedStartOffset == currentOffset && currentOffset < nextOffset && nextOffset <= deletedEndOffset
+                && isReplacement)
+                parseForests[i] = getParseNodeFromString(inserted);
+            // Optimization: if current subtree is a subrange within [deletedStart, deletedEnd], delete it
+            else if(deletedStartOffset <= currentOffset && nextOffset <= deletedEndOffset && isReplacement)
+                parseForests[i] = null;
+            // If current subtree (partially) overlaps with the to-be-deleted range, recurse
+            else if(deletedStartOffset <= nextOffset && currentOffset <= deletedEndOffset)
+                parseForests[i] = processUpdates(parseForest, currentOffset, updates);
+
+            currentOffset = nextOffset;
+        }
+        return newParseNodeFromChildren(parseForests);
+    }
+
+    private IncrementalParseNode newParseNodeFromChildren(IncrementalParseForest... newChildren) {
+        IncrementalParseForest[] filtered =
+            Arrays.stream(newChildren).filter(Objects::nonNull).toArray(IncrementalParseForest[]::new);
+        if(filtered.length == 0)
+            return null;
+        return parseForestManager.createChangedParseNode(incrementalParse, filtered);
+    }
+
+    public IncrementalParseNode getParseNodeFromString(String inputString) {
+        IncrementalParseForest[] parseForests = parseForestManager.parseForestsArray(inputString.length());
+
+        char[] chars = inputString.toCharArray();
+        for(int i = 0; i < chars.length; i++) {
+            parseForests[i] = parseForestManager.createCharacterNode(incrementalParse, chars[i]);
+        }
+        return parseForestManager.createChangedParseNode(incrementalParse, parseForests);
+    }
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/SingleDiff.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/SingleDiff.java
@@ -14,7 +14,7 @@ public class SingleDiff implements IStringDiff {
         int begin = 0, endOld = oldString.length() - 1, endNew = newString.length() - 1;
         while(begin <= endOld && begin <= endNew && oldString.charAt(begin) == newString.charAt(begin))
             begin++;
-        while(endOld > begin && endNew > begin && oldString.charAt(endOld) == newString.charAt(endNew)) {
+        while(endOld >= begin && endNew >= begin && oldString.charAt(endOld) == newString.charAt(endNew)) {
             endOld--;
             endNew--;
         }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/SingleDiff.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/SingleDiff.java
@@ -9,6 +9,7 @@ import org.spoofax.jsglr2.incremental.EditorUpdate;
  * Always returns a single EditorUpdate between the first and last change.
  */
 public class SingleDiff implements IStringDiff {
+
     @Override public List<EditorUpdate> diff(String oldString, String newString) {
         int begin = 0, endOld = oldString.length() - 1, endNew = newString.length() - 1;
         while(begin <= endOld && begin <= endNew && oldString.charAt(begin) == newString.charAt(begin))
@@ -19,4 +20,5 @@ public class SingleDiff implements IStringDiff {
         }
         return Collections.singletonList(new EditorUpdate(begin, endOld + 1, newString.substring(begin, endNew + 1)));
     }
+
 }

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiffTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiffTest.java
@@ -14,6 +14,9 @@ public class JGitHistogramDiffTest {
         assertEquals(asList(new EditorUpdate(2, 4, "fghij")), diff.diff("abcde", "abfghije"));
         assertEquals(asList(), diff.diff("abcde", "abcde"));
         assertEquals(asList(new EditorUpdate(0, 5, "fghij")), diff.diff("abcde", "fghij"));
+        assertEquals(asList(new EditorUpdate(0, 0, "xyz")), diff.diff("abcde", "xyzabcde"));
+        assertEquals(asList(new EditorUpdate(5, 5, "xyz")), diff.diff("abcde", "abcdexyz"));
+        assertEquals(asList(new EditorUpdate(3, 4, "*")), diff.diff("x+x+x", "x+x*x"));
         assertEquals(asList(new EditorUpdate(1, 3, "uvw"), new EditorUpdate(12, 12, "xyz")),
             diff.diff("abcde\nfghij\nklmno", "auvwde\nfghij\nxyzklmno"));
     }

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiffTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiffTest.java
@@ -1,0 +1,21 @@
+package org.spoofax.jsglr2.incremental.diff;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.spoofax.jsglr2.incremental.EditorUpdate;
+
+public class JGitHistogramDiffTest {
+
+    private final JGitHistogramDiff diff = new JGitHistogramDiff();
+
+    @Test public void testDiff() {
+        assertEquals(asList(new EditorUpdate(2, 4, "fghij")), diff.diff("abcde", "abfghije"));
+        assertEquals(asList(), diff.diff("abcde", "abcde"));
+        assertEquals(asList(new EditorUpdate(0, 5, "fghij")), diff.diff("abcde", "fghij"));
+        assertEquals(asList(new EditorUpdate(1, 3, "uvw"), new EditorUpdate(12, 12, "xyz")),
+            diff.diff("abcde\nfghij\nklmno", "auvwde\nfghij\nxyzklmno"));
+    }
+
+}

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdatesTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdatesTest.java
@@ -1,0 +1,143 @@
+package org.spoofax.jsglr2.incremental.diff;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.spoofax.jsglr2.incremental.EditorUpdate;
+import org.spoofax.jsglr2.incremental.IncrementalParse;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.parser.observing.ParserObserving;
+import org.spoofax.jsglr2.stack.collections.ActiveStacksFactory;
+import org.spoofax.jsglr2.stack.collections.ForActorStacksFactory;
+
+public class ProcessUpdatesTest {
+
+    private final ProcessUpdates<?> processUpdates = new ProcessUpdates<>(new IncrementalParse<>("", "",
+        new ActiveStacksFactory(), new ForActorStacksFactory(), new ParserObserving<>()));
+
+    @Test public void testDeleteSubtree() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3), node(4, 5));
+
+        IncrementalParseNode expected = node(node(0, 1), node(4, 5));
+
+        testUpdate(previous, expected, new EditorUpdate(2, 4, ""));
+    }
+
+    @Test public void testPrepend() {
+        IncrementalParseNode previous = node(node(0), node(1, 2));
+
+        IncrementalParseNode expected = node(node(node(4, 5), node(0)), node(1, 2));
+
+        testUpdate(previous, expected, new EditorUpdate(0, 0, "\4\5"));
+    }
+
+    @Test public void testPrependBeforeEmpty() {
+        IncrementalParseNode previous = node(node(), node(0), node(1, 2));
+
+        IncrementalParseNode expected = node(node(node(4, 5), node(0)), node(1, 2));
+
+        testUpdate(previous, expected, new EditorUpdate(0, 0, "\4\5"));
+    }
+
+    @Test public void testAppend() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3));
+
+        IncrementalParseNode expected = node(node(0, 1), node(node(2), node(node(3), node(4, 5))));
+
+        testUpdate(previous, expected, new EditorUpdate(4, 4, "\4\5"));
+    }
+
+    @Test public void testAppendBeforeEmpty() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3), node());
+
+        IncrementalParseNode expected = node(node(0, 1), node(node(2), node(node(3), node(4, 5))), node());
+
+        testUpdate(previous, expected, new EditorUpdate(4, 4, "\4\5"));
+    }
+
+    @Test public void testInsert() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3));
+
+        IncrementalParseNode expected = node(node(node(0), node(node(1), node(4, 5))), node(2, 3));
+
+        testUpdate(previous, expected, new EditorUpdate(2, 2, "\4\5"));
+    }
+
+    @Test public void testReplace() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3));
+
+        IncrementalParseNode expected = node(node(node(0), node(4, 5)), node(2, 3));
+
+        testUpdate(previous, expected, new EditorUpdate(1, 2, "\4\5"));
+    }
+
+    @Test public void testReplaceFirst() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3));
+
+        IncrementalParseNode expected = node(node(node(4, 5, 6), node(1)), node(2, 3));
+
+        testUpdate(previous, expected, new EditorUpdate(0, 1, "\4\5\6"));
+    }
+
+    @Test public void testReplaceFirstAfterEmpty() {
+        IncrementalParseNode previous = node(node(), node(0, 1), node(2, 3));
+
+        IncrementalParseNode expected = node(node(node(4, 5, 6), node(1)), node(2, 3));
+
+        testUpdate(previous, expected, new EditorUpdate(0, 1, "\4\5\6"));
+    }
+
+    @Test public void testReplaceEnd() {
+        IncrementalParseNode previous = node(node(node(0, 1), node(2)), node(3));
+
+        IncrementalParseNode expected = node(node(node(0, 1), node(4, 5, 6)));
+
+        testUpdate(previous, expected, new EditorUpdate(2, 4, "\4\5\6"));
+    }
+
+    @Test public void testReplaceMultipleWithGap() {
+        IncrementalParseNode previous = node(node(node(0, 1), node(2)), node(3));
+
+        IncrementalParseNode expected =
+            node(node(node(node(0), node(4, 5)), node(2)), node(6, 7));
+
+        testUpdate(previous, expected, new EditorUpdate(1, 2, "\4\5"), new EditorUpdate(3, 4, "\6\7"));
+    }
+
+    @Test public void testReplaceMultipleWithoutGap() {
+        IncrementalParseNode previous = node(node(node(0, 1), node(2)), node(3));
+
+        IncrementalParseNode expected =
+                node(node(node(node(0), node(4, 5)), node(6, 7)), node(3));
+
+        testUpdate(previous, expected, new EditorUpdate(1, 2, "\4\5"), new EditorUpdate(2, 3, "\6\7"));
+    }
+
+
+    private void testUpdate(IncrementalParseNode previous, IncrementalParseNode expected, EditorUpdate... updates) {
+        assertEquals(expected.toString(), processUpdates.processUpdates(previous, updates).toString());
+    }
+
+    private static IncrementalCharacterNode node(int i) {
+        return new IncrementalCharacterNode(i);
+    }
+
+    private static IncrementalParseNode node(int... characters) {
+        IncrementalParseForest[] children = new IncrementalParseForest[characters.length];
+        for(int i = 0; i < characters.length; i++) {
+            children[i] = node(characters[i]);
+        }
+        return new IncrementalParseNode(children);
+    }
+
+    private static IncrementalParseNode node(IncrementalParseForest... children) {
+        return new IncrementalParseNode(children);
+    }
+
+    private static IncrementalParseNode node() {
+        return new IncrementalParseNode();
+    }
+
+}

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/SingleDiffTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/SingleDiffTest.java
@@ -13,7 +13,10 @@ public class SingleDiffTest {
         assertEquals(new EditorUpdate(2, 4, "fghij"), diff.diff("abcde", "abfghije").get(0));
         assertEquals(new EditorUpdate(5, 5, ""), diff.diff("abcde", "abcde").get(0));
         assertEquals(new EditorUpdate(0, 5, "fghij"), diff.diff("abcde", "fghij").get(0));
-        assertEquals(new EditorUpdate(1, 12, "uvw\nfghij\nxyz"),
+        assertEquals(new EditorUpdate(0, 0, "xyz"), diff.diff("abcde", "xyzabcde").get(0));
+        assertEquals(new EditorUpdate(5, 5, "xyz"), diff.diff("abcde", "abcdexyz").get(0));
+        assertEquals(new EditorUpdate(3, 4, "*"), diff.diff("x+x+x", "x+x*x").get(0));
+        assertEquals(new EditorUpdate(1, 12, "uvwde\nfghij\nxyz"),
             diff.diff("abcde\nfghij\nklmno", "auvwde\nfghij\nxyzklmno").get(0));
     }
 

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/SingleDiffTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/SingleDiffTest.java
@@ -7,9 +7,14 @@ import org.spoofax.jsglr2.incremental.EditorUpdate;
 
 public class SingleDiffTest {
 
+    private final SingleDiff diff = new SingleDiff();
+
     @Test public void testDiff() {
-        assertEquals(new EditorUpdate(2, 4, "fghij"), new SingleDiff().diff("abcde", "abfghije").get(0));
-        assertEquals(new EditorUpdate(5, 5, ""), new SingleDiff().diff("abcde", "abcde").get(0));
-        assertEquals(new EditorUpdate(0, 5, "fghij"), new SingleDiff().diff("abcde", "fghij").get(0));
+        assertEquals(new EditorUpdate(2, 4, "fghij"), diff.diff("abcde", "abfghije").get(0));
+        assertEquals(new EditorUpdate(5, 5, ""), diff.diff("abcde", "abcde").get(0));
+        assertEquals(new EditorUpdate(0, 5, "fghij"), diff.diff("abcde", "fghij").get(0));
+        assertEquals(new EditorUpdate(1, 12, "uvw\nfghij\nxyz"),
+            diff.diff("abcde\nfghij\nklmno", "auvwde\nfghij\nxyzklmno").get(0));
     }
+
 }


### PR DESCRIPTION
This PR improves the calculating of the text diff and applying that to the parse forest in several ways.

- Processing `EditorUpdate`s has been moved from several methods in `IncrementalParse` to its own class called `ProcessUpdates`.
- A new diffing algorithm has been added, taken from [JGit](http://download.eclipse.org/jgit/site/5.3.0.201903130848-r/org.eclipse.jgit/apidocs/index.html?org/eclipse/jgit/diff/HistogramDiff.html).
  - This diffing algorithm allows multiple changes in one file to be identified.
  - A small adapter has been written around this algorithm to make it return a list of `EditorUpdate`s.
- `ProcessUpdates` will now correctly apply a list of `EditorUpdate`s to the old parse forest, instead of looking only at the first update.
- Some tests have been added to verify that it all works correctly.