### PR TITLE
Improve diffing

### DIFF
--- a/org.spoofax.jsglr2/pom.xml
+++ b/org.spoofax.jsglr2/pom.xml
@@ -52,44 +52,6 @@
             <version>${metaborg-version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.3.1.201904271842-r</version>
-            <!-- Because only the org.eclipse.jgit.diff package is used (which has no dependencies),
-            all unnecessary dependencies of JGit are excluded. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>com.jcraft</groupId>
-                    <artifactId>jsch</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.jcraft</groupId>
-                    <artifactId>jzlib</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.googlecode.javaewah</groupId>
-                    <artifactId>JavaEWAH</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcpg-jdk15on</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcpkix-jdk15on</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
     </dependencies>
 
     <developers>

--- a/org.spoofax.jsglr2/pom.xml
+++ b/org.spoofax.jsglr2/pom.xml
@@ -52,6 +52,44 @@
             <version>${metaborg-version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>5.3.1.201904271842-r</version>
+            <!-- Because only the org.eclipse.jgit.diff package is used (which has no dependencies),
+            all unnecessary dependencies of JGit are excluded. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.jcraft</groupId>
+                    <artifactId>jsch</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.jcraft</groupId>
+                    <artifactId>jzlib</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.googlecode.javaewah</groupId>
+                    <artifactId>JavaEWAH</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpg-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
     <developers>

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/EditorUpdate.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/EditorUpdate.java
@@ -3,14 +3,26 @@ package org.spoofax.jsglr2.incremental;
 import java.util.Objects;
 
 public class EditorUpdate {
+
+    public enum Type {
+        DELETION, INSERTION, REPLACEMENT
+    }
+
     public final int deletedStart;
     public final int deletedEnd;
     public final String inserted;
+    public final Type type; // Redundant information that is calculated based on other fields, just for convenience
 
     public EditorUpdate(int deletedStart, int deletedEnd, String inserted) {
         this.deletedStart = deletedStart;
         this.deletedEnd = deletedEnd;
         this.inserted = inserted;
+        if(deletedStart == deletedEnd)
+            type = Type.INSERTION;
+        else if(inserted.length() == 0)
+            type = Type.DELETION;
+        else
+            type = Type.REPLACEMENT;
     }
 
     @Override public boolean equals(Object o) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParse.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParse.java
@@ -1,19 +1,16 @@
 package org.spoofax.jsglr2.incremental;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 import org.metaborg.parsetable.actions.IGoto;
 import org.metaborg.sdf2table.parsetable.query.ActionsForCharacterSeparated;
 import org.metaborg.sdf2table.parsetable.query.ActionsPerCharacterClass;
 import org.metaborg.sdf2table.parsetable.query.ProductionToGotoForLoop;
 import org.spoofax.jsglr2.JSGLR2Variants;
+import org.spoofax.jsglr2.incremental.diff.ProcessUpdates;
 import org.spoofax.jsglr2.incremental.lookaheadstack.EagerLookaheadStack;
 import org.spoofax.jsglr2.incremental.lookaheadstack.ILookaheadStack;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
-import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForestManager;
-import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.ParseFactory;
 import org.spoofax.jsglr2.parser.observing.ParserObserving;
@@ -27,31 +24,30 @@ import org.spoofax.jsglr2.states.State;
 public class IncrementalParse<StackNode extends IStackNode> extends AbstractParse<IncrementalParseForest, StackNode> {
 
     // TODO this should not be public, but still end up in the IncrementalParseForestManager
-    public boolean multipleStates;
+    public boolean multipleStates = false;
     ILookaheadStack lookahead;
 
-    private IncrementalParseForestManager parseForestManager = new IncrementalParseForestManager();
-    public static State NO_STATE = new State(-1, new ActionsForCharacterSeparated(new ActionsPerCharacterClass[0]),
-        new ProductionToGotoForLoop(new IGoto[0]));
+    private final ProcessUpdates<StackNode> processUpdates = new ProcessUpdates<>(this);
+    public static final State NO_STATE = new State(-1,
+        new ActionsForCharacterSeparated(new ActionsPerCharacterClass[0]), new ProductionToGotoForLoop(new IGoto[0]));
 
     public IncrementalParse(List<EditorUpdate> editorUpdates, IncrementalParseForest previous, String inputString,
         String filename, IActiveStacksFactory activeStacksFactory, IForActorStacksFactory forActorStacksFactory,
         ParserObserving<IncrementalParseForest, StackNode> observing) {
 
         super(inputString, filename, activeStacksFactory, forActorStacksFactory, observing);
-        initParse(processUpdates(editorUpdates, previous), inputString);
+        initParse(processUpdates.processUpdates(previous, editorUpdates), inputString);
     }
 
     public IncrementalParse(String inputString, String filename, IActiveStacksFactory activeStacksFactory,
         IForActorStacksFactory forActorStacksFactory, ParserObserving<IncrementalParseForest, StackNode> observing) {
 
         super(inputString, filename, activeStacksFactory, forActorStacksFactory, observing);
-        initParse(getParseNodeFromString(inputString), inputString);
+        initParse(processUpdates.getParseNodeFromString(inputString), inputString);
     }
 
     private void initParse(IncrementalParseForest updatedTree, String inputString) {
         this.lookahead = new EagerLookaheadStack(updatedTree, inputString); // TODO switch types between Lazy and Eager
-        this.multipleStates = false;
         this.currentChar = lookahead.actionQueryCharacter();
     }
 
@@ -91,77 +87,6 @@ public class IncrementalParse<StackNode extends IStackNode> extends AbstractPars
         currentOffset += lookahead.get().width();
         lookahead.popLookahead();
         currentChar = lookahead.actionQueryCharacter();
-    }
-
-    // Recursively processes the tree until the update site has been found
-    private IncrementalParseForest processUpdates(List<EditorUpdate> editorUpdates, IncrementalParseForest previous) {
-        // TODO for all editor updates (currently only checking first update)
-        EditorUpdate editorUpdate = editorUpdates.get(0);
-        // If everything is deleted, then just return the inserted string
-        if(editorUpdate.deletedStart == 0 && editorUpdate.deletedEnd == previous.width())
-            return getParseNodeFromString(editorUpdate.inserted);
-        return processUpdates(previous, 0, editorUpdate.deletedStart, editorUpdate.deletedEnd, editorUpdate.inserted);
-    }
-
-    private IncrementalParseForest processUpdates(IncrementalParseForest currentForest, int currentOffset,
-        int deletedStartOffset, int deletedEndOffset, String inserted) {
-        if(currentForest.isTerminal()) {
-            // If there is nothing to delete
-            if(deletedStartOffset == deletedEndOffset) {
-                // Insert-after strategy (can also be applied in the general case, but gives less subtree re-use)
-                // If insert position is begin of string, prepend to first character
-                if(deletedStartOffset == 0 && currentOffset == deletedEndOffset)
-                    return newParseNodeFromChildren(getParseNodeFromString(inserted), currentForest);
-                // If insert position is NOT begin of string, append to previous character
-                if(deletedStartOffset != 0 && currentOffset == deletedStartOffset - 1)
-                    return newParseNodeFromChildren(currentForest, getParseNodeFromString(inserted));
-                // If none of the cases applies, just return original character node
-                return currentForest;
-            }
-            // In-place replace strategy
-            // Replace first deleted character with the inserted string
-            if(deletedStartOffset == currentOffset)
-                return getParseNodeFromString(inserted);
-            // Delete all other characters
-            if(deletedStartOffset < currentOffset && currentOffset < deletedEndOffset)
-                return null;
-            // If none of the cases applies, just return original character node
-            return currentForest;
-        }
-        // Use a shallow copy of the current children, else the old children array will be modified
-        IncrementalParseForest[] parseForests =
-            ((IncrementalParseNode) currentForest).getFirstDerivation().parseForests().clone();
-        for(int i = 0; i < parseForests.length; i++) {
-            IncrementalParseForest parseForest = parseForests[i];
-            int nextOffset = currentOffset + parseForest.width(); // == start offset of right sibling subtree
-            // Optimization: if current subtree falls completely within [deletedStart + 1, deletedEnd], delete it
-            if(deletedStartOffset < currentOffset && nextOffset <= deletedEndOffset)
-                parseForests[i] = null;
-            // If current subtree overlaps with the to-be-deleted range, recurse
-            else if(deletedStartOffset <= nextOffset && currentOffset <= deletedEndOffset)
-                parseForests[i] =
-                    processUpdates(parseForest, currentOffset, deletedStartOffset, deletedEndOffset, inserted);
-            currentOffset = nextOffset;
-        }
-        return newParseNodeFromChildren(parseForests);
-    }
-
-    private IncrementalParseNode newParseNodeFromChildren(IncrementalParseForest... newChildren) {
-        IncrementalParseForest[] filtered =
-            Arrays.stream(newChildren).filter(Objects::nonNull).toArray(IncrementalParseForest[]::new);
-        if(filtered.length == 0)
-            return null;
-        return parseForestManager.createChangedParseNode(this, filtered);
-    }
-
-    private IncrementalParseNode getParseNodeFromString(String inputString) {
-        IncrementalParseForest[] parseForests = parseForestManager.parseForestsArray(inputString.length());
-
-        char[] chars = inputString.toCharArray();
-        for(int i = 0; i < chars.length; i++) {
-            parseForests[i] = parseForestManager.createCharacterNode(this, chars[i]);
-        }
-        return parseForestManager.createChangedParseNode(this, parseForests);
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParser.java
@@ -52,8 +52,7 @@ public class IncrementalParser
 
         super(parseFactory, parseTable, stackManager, parseForestManager, reduceManagerFactory);
         this.incrementalParseFactory = incrementalParseFactory;
-        // TODO different diffing types, probably based on:
-        // https://en.wikipedia.org/wiki/Longest_common_subsequence_problem
+        // TODO parametrize parser on diff algorithm for benchmarking
         this.diff = new JGitHistogramDiff();
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParser.java
@@ -1,14 +1,11 @@
 package org.spoofax.jsglr2.incremental;
 
-
-import static com.google.common.collect.Iterables.isEmpty;
 import static com.google.common.collect.Iterables.size;
 import static org.metaborg.util.iterators.Iterables2.stream;
 import static org.spoofax.jsglr2.incremental.IncrementalParse.NO_STATE;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,9 +13,9 @@ import org.metaborg.parsetable.IParseTable;
 import org.metaborg.parsetable.actions.ActionType;
 import org.metaborg.parsetable.actions.IAction;
 import org.metaborg.parsetable.actions.IReduce;
-import org.metaborg.parsetable.actions.IShift;
 import org.spoofax.jsglr2.incremental.actions.GotoShift;
-import org.spoofax.jsglr2.incremental.diff.SingleDiff;
+import org.spoofax.jsglr2.incremental.diff.IStringDiff;
+import org.spoofax.jsglr2.incremental.diff.JGitHistogramDiff;
 import org.spoofax.jsglr2.incremental.lookaheadstack.ILookaheadStack;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalDerivation;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
@@ -46,7 +43,7 @@ public class IncrementalParser
     private final IncrementalParseFactory<StackNode, Parse> incrementalParseFactory;
     private final HashMap<String, IncrementalParseForest> cache = new HashMap<>();
     private final HashMap<String, String> oldString = new HashMap<>();
-    private final SingleDiff diff;
+    private final IStringDiff diff;
 
     public IncrementalParser(ParseFactory<IncrementalParseForest, StackNode, Parse> parseFactory,
         IncrementalParseFactory<StackNode, Parse> incrementalParseFactory, IParseTable parseTable,
@@ -57,7 +54,7 @@ public class IncrementalParser
         this.incrementalParseFactory = incrementalParseFactory;
         // TODO different diffing types, probably based on:
         // https://en.wikipedia.org/wiki/Longest_common_subsequence_problem
-        this.diff = new SingleDiff();
+        this.diff = new JGitHistogramDiff();
     }
 
     @Override protected Parse getParse(String inputString, String filename) {
@@ -81,9 +78,9 @@ public class IncrementalParser
         Iterable<IAction> actions = getActions(stack, parse);
         // Break down lookahead until it is a terminal or until there is something to be shifted
         // Break down lookahead if it has no state or if there are no actions for it
-        // TODO Maybe: break down lookahead if parse.multipleStates?
+        // Break down lookahead if there is more then one action for it
         while(!parse.lookahead.get().isTerminal()
-            && (lookaheadHasNoState(parse.lookahead) || isEmpty(actions) && parse.forShifter.isEmpty())) {
+            && (lookaheadHasNoState(parse.lookahead) || size(actions) != 1 && parse.forShifter.isEmpty())) {
             parse.lookahead.leftBreakdown();
             actions = getActions(stack, parse);
         }
@@ -113,13 +110,13 @@ public class IncrementalParser
             return actions;
         } else {
             // Split in shift and reduce actions
-            List<IShift> shiftActions = stream(actions).filter(a -> a.actionType() == ActionType.SHIFT)
-                .map(a -> ((IShift) a)).collect(Collectors.toList());
+            List<IAction> shiftActions =
+                stream(actions).filter(a -> a.actionType() == ActionType.SHIFT).collect(Collectors.toList());
 
             // By default, only the reduce actions are returned
-            LinkedList<IAction> result = stream(actions)
+            List<IAction> result = stream(actions)
                 .filter(a -> a.actionType() == ActionType.REDUCE || a.actionType() == ActionType.REDUCE_LOOKAHEAD)
-                .map(a -> ((IReduce) a)).collect(Collectors.toCollection(LinkedList::new));
+                .collect(Collectors.toList());
 
             IncrementalParseNode lookaheadNode = (IncrementalParseNode) lookahead;
 
@@ -140,8 +137,8 @@ public class IncrementalParser
             // If lookahead has null yield and the production of lookahead matches the state of the GotoShift,
             // there is a duplicate action that can be removed (this is an optimization to avoid multipleStates == true)
             if(!lookaheadNode.isAmbiguous() && lookaheadNode.width() == 0 && result.size() == 2 && hasGotoShift
-                && nullReduceMatchesGotoShift(stack, (IReduce) result.getFirst(), (GotoShift) result.getLast())) {
-                result.removeFirst(); // Removes the unnecessary reduce action
+                && nullReduceMatchesGotoShift(stack, (IReduce) result.get(0), (GotoShift) result.get(1))) {
+                result.remove(0); // Removes the unnecessary reduce action
             }
 
             return result;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiff.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiff.java
@@ -1,0 +1,74 @@
+package org.spoofax.jsglr2.incremental.diff;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jgit.diff.*;
+import org.eclipse.jgit.util.IntList;
+import org.spoofax.jsglr2.incremental.EditorUpdate;
+
+public class JGitHistogramDiff implements IStringDiff {
+
+    private final HistogramDiff diff = new HistogramDiff();
+
+    @Override public List<EditorUpdate> diff(String oldString, String newString) {
+        // By default, RawText is split per line.
+        // By passing a `lineMap` which is a list that contains all integers from 0 to length, this is avoided.
+        RawText oldText = new RawText(oldString.getBytes(), new IncrementingIntList(oldString.length()));
+        RawText newText = new RawText(newString.getBytes(), new IncrementingIntList(newString.length()));
+
+        EditList edits = diff.diff(RawTextComparator.DEFAULT, oldText, newText);
+        List<EditorUpdate> updates = new ArrayList<>(edits.size());
+        for(Edit edit : edits) {
+            updates.add(new EditorUpdate(edit.getBeginA(), edit.getEndA(),
+                newString.substring(edit.getBeginB(), edit.getEndB())));
+        }
+        return updates;
+    }
+
+    /**
+     * This list always contains (size + 2) integers: namely Integer.MIN_VALUE followed by the sequence 0 up to and
+     * including size. This class avoids storing an entire list of integers because the entries in the list are trivial
+     * to compute when queried.
+     */
+    static class IncrementingIntList extends IntList {
+        private final int size;
+
+        IncrementingIntList(int size) {
+            this.size = size;
+        }
+
+        @Override public void add(int n) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public boolean contains(int value) {
+            return value == Integer.MIN_VALUE || 0 <= value && value <= size;
+        }
+
+        @Override public void fillTo(int toIndex, int val) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public int get(int i) {
+            if(i == 0)
+                return Integer.MIN_VALUE;
+            if(i >= size())
+                throw new IndexOutOfBoundsException();
+            return i - 1;
+        }
+
+        @Override public void set(int index, int n) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public int size() {
+            return size + 2;
+        }
+
+        @Override public String toString() {
+            return "[" + Integer.MIN_VALUE + ", 0, 1, ..., " + size + "]";
+        }
+    }
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiff.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiff.java
@@ -3,10 +3,10 @@ package org.spoofax.jsglr2.incremental.diff;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.jgit.diff.*;
-import org.eclipse.jgit.util.IntList;
 import org.spoofax.jsglr2.incremental.EditorUpdate;
+import org.spoofax.jsglr2.incremental.diff.jgit.*;
 
+// TODO the JGit HistogramDiff algorithm can be simplified because we are only using it in one very specific way
 public class JGitHistogramDiff implements IStringDiff {
 
     private final HistogramDiff diff = new HistogramDiff();
@@ -35,6 +35,7 @@ public class JGitHistogramDiff implements IStringDiff {
         private final int size;
 
         IncrementingIntList(int size) {
+            super(0);
             this.size = size;
         }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdates.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdates.java
@@ -1,0 +1,152 @@
+package org.spoofax.jsglr2.incremental.diff;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import org.spoofax.jsglr2.incremental.EditorUpdate;
+import org.spoofax.jsglr2.incremental.IncrementalParse;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForestManager;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.stack.IStackNode;
+
+public class ProcessUpdates<StackNode extends IStackNode> {
+
+    private final IncrementalParse<StackNode> incrementalParse;
+    private final IncrementalParseForestManager parseForestManager = new IncrementalParseForestManager();
+
+    public ProcessUpdates(IncrementalParse<StackNode> incrementalParse) {
+        this.incrementalParse = incrementalParse;
+    }
+
+    public IncrementalParseForest processUpdates(IncrementalParseForest previous, EditorUpdate... editorUpdates) {
+        return processUpdates(previous, Arrays.asList(editorUpdates));
+    }
+
+    /**
+     * Recursively processes the tree until the update site has been found. General strategy:
+     *
+     * <ul>
+     * <li>If the update is a replacement (a, b, new) with a != b: replace character a with the new string and delete
+     * characters [a+1, b>
+     * <li>If the update is an insertion (a, a, new), and
+     * <ul>
+     * <li>the insertion is at the first character: replace first character with (new, first)
+     * <li>the insertion is anywhere else: replace character a with (a, new)
+     * </ul>
+     * <li>If the update is a deletion (a, b, ""): just delete everything in range [a, b>
+     * </ul>
+     * 
+     * The slightly reasonable assumption has been made that any two consecutive updates never "touch" each other
+     * (meaning that first.end == second.start). This method will still work for two consecutive replacements, but no
+     * guarantees are made for a consecutive insertion/deletion.
+     */
+    public IncrementalParseForest processUpdates(IncrementalParseForest previous, List<EditorUpdate> editorUpdates) {
+        // Optimization: f everything is deleted, then return a tree created from the inserted string
+        if(editorUpdates.size() == 1) {
+            EditorUpdate editorUpdate = editorUpdates.get(0);
+            if(editorUpdate.deletedStart == 0 && editorUpdate.deletedEnd == previous.width()) {
+                return getParseNodeFromString(editorUpdate.inserted);
+            }
+        }
+
+        LinkedList<EditorUpdate> linkedUpdates = new LinkedList<>(editorUpdates);
+        return processUpdates(previous, 0, linkedUpdates);
+    }
+
+    private IncrementalParseForest processUpdates(IncrementalParseForest currentForest, int currentOffset,
+        LinkedList<EditorUpdate> updates) {
+        if(currentForest.isTerminal()) {
+            EditorUpdate update = updates.getFirst();
+            int deletedStartOffset = update.deletedStart;
+            int deletedEndOffset = update.deletedEnd;
+            String inserted = update.inserted;
+
+            // If there is nothing to delete (it is an insertion)
+            if(deletedStartOffset == deletedEndOffset) {
+                // If insert position is begin of string, prepend to first character
+                if(deletedStartOffset == 0 && currentOffset == deletedEndOffset) {
+                    updates.removeFirst();
+                    return newParseNodeFromChildren(getParseNodeFromString(inserted), currentForest);
+                }
+                // If insert position is NOT begin of string, append to current character
+                if(deletedStartOffset != 0 && currentOffset == deletedStartOffset - 1) {
+                    updates.removeFirst();
+                    return newParseNodeFromChildren(currentForest, getParseNodeFromString(inserted));
+                }
+                // If none of the cases applies, just return original character node
+                return currentForest;
+            }
+            // Replace first deleted character with the inserted string (if any)
+            if(deletedStartOffset == currentOffset && inserted.length() > 0) {
+                if(currentOffset == deletedEndOffset - 1)
+                    updates.removeFirst();
+                return getParseNodeFromString(inserted);
+            }
+            // Else, delete all characters within deletion range
+            if(deletedStartOffset <= currentOffset && currentOffset < deletedEndOffset) {
+                if(currentOffset == deletedEndOffset - 1)
+                    updates.removeFirst();
+                return null;
+            }
+            // If none of the cases applies, just return original character node
+            return currentForest;
+        }
+        // Use a shallow copy of the current children, else the old children array will be modified
+        IncrementalParseForest[] parseForests =
+            ((IncrementalParseNode) currentForest).getFirstDerivation().parseForests().clone();
+        for(int i = 0; i < parseForests.length; i++) {
+            if(updates.isEmpty())
+                break;
+            // If the current subtree is after the previous to-be-deleted range, move to next update
+            if(currentOffset >= updates.getFirst().deletedEnd && currentOffset > 0)
+                updates.removeFirst();
+            if(updates.isEmpty())
+                break;
+
+            EditorUpdate update = updates.getFirst();
+            int deletedStartOffset = update.deletedStart;
+            int deletedEndOffset = update.deletedEnd;
+            String inserted = update.inserted;
+            // TODO store update type (insertion/deletion/replacement) in EditorUpdate
+            boolean isReplacement = inserted.length() > 0 && deletedStartOffset < deletedEndOffset;
+
+            IncrementalParseForest parseForest = parseForests[i];
+            int nextOffset = currentOffset + parseForest.width(); // == start offset of right sibling subtree
+
+            // Optimization: if current subtree starts exactly at deletedStart and it spans the subtree, replace it
+            if(deletedStartOffset == currentOffset && currentOffset < nextOffset && nextOffset <= deletedEndOffset
+                && isReplacement)
+                parseForests[i] = getParseNodeFromString(inserted);
+            // Optimization: if current subtree is a subrange within [deletedStart, deletedEnd], delete it
+            else if(deletedStartOffset <= currentOffset && nextOffset <= deletedEndOffset && isReplacement)
+                parseForests[i] = null;
+            // If current subtree (partially) overlaps with the to-be-deleted range, recurse
+            else if(deletedStartOffset <= nextOffset && currentOffset <= deletedEndOffset)
+                parseForests[i] = processUpdates(parseForest, currentOffset, updates);
+
+            currentOffset = nextOffset;
+        }
+        return newParseNodeFromChildren(parseForests);
+    }
+
+    private IncrementalParseNode newParseNodeFromChildren(IncrementalParseForest... newChildren) {
+        IncrementalParseForest[] filtered =
+            Arrays.stream(newChildren).filter(Objects::nonNull).toArray(IncrementalParseForest[]::new);
+        if(filtered.length == 0)
+            return null;
+        return parseForestManager.createChangedParseNode(incrementalParse, filtered);
+    }
+
+    public IncrementalParseNode getParseNodeFromString(String inputString) {
+        IncrementalParseForest[] parseForests = parseForestManager.parseForestsArray(inputString.length());
+
+        char[] chars = inputString.toCharArray();
+        for(int i = 0; i < chars.length; i++) {
+            parseForests[i] = parseForestManager.createCharacterNode(incrementalParse, chars[i]);
+        }
+        return parseForestManager.createChangedParseNode(incrementalParse, parseForests);
+    }
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/SingleDiff.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/SingleDiff.java
@@ -14,7 +14,7 @@ public class SingleDiff implements IStringDiff {
         int begin = 0, endOld = oldString.length() - 1, endNew = newString.length() - 1;
         while(begin <= endOld && begin <= endNew && oldString.charAt(begin) == newString.charAt(begin))
             begin++;
-        while(endOld > begin && endNew > begin && oldString.charAt(endOld) == newString.charAt(endNew)) {
+        while(endOld >= begin && endNew >= begin && oldString.charAt(endOld) == newString.charAt(endNew)) {
             endOld--;
             endNew--;
         }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/SingleDiff.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/SingleDiff.java
@@ -9,6 +9,7 @@ import org.spoofax.jsglr2.incremental.EditorUpdate;
  * Always returns a single EditorUpdate between the first and last change.
  */
 public class SingleDiff implements IStringDiff {
+
     @Override public List<EditorUpdate> diff(String oldString, String newString) {
         int begin = 0, endOld = oldString.length() - 1, endNew = newString.length() - 1;
         while(begin <= endOld && begin <= endNew && oldString.charAt(begin) == newString.charAt(begin))
@@ -19,4 +20,5 @@ public class SingleDiff implements IStringDiff {
         }
         return Collections.singletonList(new EditorUpdate(begin, endOld + 1, newString.substring(begin, endNew + 1)));
     }
+
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/DiffAlgorithm.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/DiffAlgorithm.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Compares two {@link Sequence}s to create an
+ * {@link EditList} of changes.
+ * <p>
+ * An algorithm's {@code diff} method must be callable from concurrent threads
+ * without data collisions. This permits some algorithms to use a singleton
+ * pattern, with concurrent invocations using the same singleton. Other
+ * algorithms may support parameterization, in which case the caller can create
+ * a unique instance per thread.
+ */
+public abstract class DiffAlgorithm {
+	/**
+	 * Supported diff algorithm
+	 */
+	public enum SupportedAlgorithm {
+		/**
+		 * Myers diff algorithm
+		 */
+		MYERS,
+
+		/**
+		 * Histogram diff algorithm
+		 */
+		HISTOGRAM
+	}
+
+	/**
+	 * Get diff algorithm
+	 *
+	 * @param alg
+	 *            the diff algorithm for which an implementation should be
+	 *            returned
+	 * @return an implementation of the specified diff algorithm
+	 */
+	public static DiffAlgorithm getAlgorithm(SupportedAlgorithm alg) {
+		switch (alg) {
+		case MYERS:
+			return MyersDiff.INSTANCE;
+		case HISTOGRAM:
+			return new HistogramDiff();
+		default:
+			throw new IllegalArgumentException();
+		}
+	}
+
+	/**
+	 * Compare two sequences and identify a list of edits between them.
+	 *
+	 * @param cmp
+	 *            the comparator supplying the element equivalence function.
+	 * @param a
+	 *            the first (also known as old or pre-image) sequence. Edits
+	 *            returned by this algorithm will reference indexes using the
+	 *            'A' side: {@link Edit#getBeginA()},
+	 *            {@link Edit#getEndA()}.
+	 * @param b
+	 *            the second (also known as new or post-image) sequence. Edits
+	 *            returned by this algorithm will reference indexes using the
+	 *            'B' side: {@link Edit#getBeginB()},
+	 *            {@link Edit#getEndB()}.
+	 * @return a modifiable edit list comparing the two sequences. If empty, the
+	 *         sequences are identical according to {@code cmp}'s rules. The
+	 *         result list is never null.
+	 */
+	public <S extends Sequence> EditList diff(
+			SequenceComparator<? super S> cmp, S a, S b) {
+		Edit region = cmp.reduceCommonStartEnd(a, b, coverEdit(a, b));
+
+		switch (region.getType()) {
+		case INSERT:
+		case DELETE:
+			return EditList.singleton(region);
+
+		case REPLACE: {
+			if (region.getLengthA() == 1 && region.getLengthB() == 1)
+				return EditList.singleton(region);
+
+			SubsequenceComparator<S> cs = new SubsequenceComparator<>(cmp);
+			Subsequence<S> as = Subsequence.a(a, region);
+			Subsequence<S> bs = Subsequence.b(b, region);
+			EditList e = Subsequence.toBase(diffNonCommon(cs, as, bs), as, bs);
+			return normalize(cmp, e, a, b);
+		}
+
+		case EMPTY:
+			return new EditList(0);
+
+		default:
+			throw new IllegalStateException();
+		}
+	}
+
+	private static <S extends Sequence> Edit coverEdit(S a, S b) {
+		return new Edit(0, a.size(), 0, b.size());
+	}
+
+	/**
+	 * Reorganize an {@link EditList} for better diff consistency.
+	 * <p>
+	 * {@code DiffAlgorithms} may return {@link Edit.Type#INSERT} or
+	 * {@link Edit.Type#DELETE} edits that can be "shifted". For
+	 * example, the deleted section
+	 * <pre>
+	 * -a
+	 * -b
+	 * -c
+	 *  a
+	 *  b
+	 *  c
+	 * </pre>
+	 * can be shifted down by 1, 2 or 3 locations.
+	 * <p>
+	 * To avoid later merge issues, we shift such edits to a
+	 * consistent location. {@code normalize} uses a simple strategy of
+	 * shifting such edits to their latest possible location.
+	 * <p>
+	 * This strategy may not always produce an aesthetically pleasing
+	 * diff. For instance, it works well with
+	 * <pre>
+	 *  function1 {
+	 *   ...
+	 *  }
+	 *
+	 * +function2 {
+	 * + ...
+	 * +}
+	 * +
+	 * function3 {
+	 * ...
+	 * }
+	 * </pre>
+	 * but less so for
+	 * <pre>
+	 *  #
+	 *  # comment1
+	 *  #
+	 *  function1() {
+	 *  }
+	 *
+	 *  #
+	 * +# comment3
+	 * +#
+	 * +function3() {
+	 * +}
+	 * +
+	 * +#
+	 *  # comment2
+	 *  #
+	 *  function2() {
+	 *  }
+	 * </pre>
+	 * <a href="https://github.com/mhagger/diff-slider-tools">More
+	 * sophisticated strategies</a> are possible, say by calculating a
+	 * suitable "aesthetic cost" for each possible position and using
+	 * the lowest cost, but {@code normalize} just shifts edits
+	 * to the end as much as possible.
+	 *
+	 * @param <S>
+	 *            type of sequence being compared.
+	 * @param cmp
+	 *            the comparator supplying the element equivalence function.
+	 * @param e
+	 *            a modifiable edit list comparing the provided sequences.
+	 * @param a
+	 *            the first (also known as old or pre-image) sequence.
+	 * @param b
+	 *            the second (also known as new or post-image) sequence.
+	 * @return a modifiable edit list with edit regions shifted to their
+	 *         latest possible location. The result list is never null.
+	 * @since 4.7
+	 */
+	private static <S extends Sequence> EditList normalize(
+		SequenceComparator<? super S> cmp, EditList e, S a, S b) {
+		Edit prev = null;
+		for (int i = e.size() - 1; i >= 0; i--) {
+			Edit cur = e.get(i);
+			Edit.Type curType = cur.getType();
+
+			int maxA = (prev == null) ? a.size() : prev.beginA;
+			int maxB = (prev == null) ? b.size() : prev.beginB;
+
+			if (curType == Edit.Type.INSERT) {
+				while (cur.endA < maxA && cur.endB < maxB
+					&& cmp.equals(b, cur.beginB, b, cur.endB)) {
+					cur.shift(1);
+				}
+			} else if (curType == Edit.Type.DELETE) {
+				while (cur.endA < maxA && cur.endB < maxB
+					&& cmp.equals(a, cur.beginA, a, cur.endA)) {
+					cur.shift(1);
+				}
+			}
+			prev = cur;
+		}
+		return e;
+	}
+
+	/**
+	 * Compare two sequences and identify a list of edits between them.
+	 *
+	 * This method should be invoked only after the two sequences have been
+	 * proven to have no common starting or ending elements. The expected
+	 * elimination of common starting and ending elements is automatically
+	 * performed by the {@link #diff(SequenceComparator, Sequence, Sequence)}
+	 * method, which invokes this method using
+	 * {@link Subsequence}s.
+	 *
+	 * @param cmp
+	 *            the comparator supplying the element equivalence function.
+	 * @param a
+	 *            the first (also known as old or pre-image) sequence. Edits
+	 *            returned by this algorithm will reference indexes using the
+	 *            'A' side: {@link Edit#getBeginA()},
+	 *            {@link Edit#getEndA()}.
+	 * @param b
+	 *            the second (also known as new or post-image) sequence. Edits
+	 *            returned by this algorithm will reference indexes using the
+	 *            'B' side: {@link Edit#getBeginB()},
+	 *            {@link Edit#getEndB()}.
+	 * @return a modifiable edit list comparing the two sequences.
+	 */
+	public abstract <S extends Sequence> EditList diffNonCommon(
+			SequenceComparator<? super S> cmp, S a, S b);
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/Edit.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/Edit.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2008-2009, Johannes E. Schindelin <johannes.schindelin@gmx.de>
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * A modified region detected between two versions of roughly the same content.
+ * <p>
+ * An edit covers the modified region only. It does not cover a common region.
+ * <p>
+ * Regions should be specified using 0 based notation, so add 1 to the start and
+ * end marks for line numbers in a file.
+ * <p>
+ * An edit where {@code beginA == endA && beginB < endB} is an insert edit, that
+ * is sequence B inserted the elements in region <code>[beginB, endB)</code> at
+ * <code>beginA</code>.
+ * <p>
+ * An edit where {@code beginA < endA && beginB == endB} is a delete edit, that
+ * is sequence B has removed the elements between <code>[beginA, endA)</code>.
+ * <p>
+ * An edit where {@code beginA < endA && beginB < endB} is a replace edit, that
+ * is sequence B has replaced the range of elements between
+ * <code>[beginA, endA)</code> with those found in <code>[beginB, endB)</code>.
+ */
+public class Edit {
+	/** Type of edit */
+	public static enum Type {
+		/** Sequence B has inserted the region. */
+		INSERT,
+
+		/** Sequence B has removed the region. */
+		DELETE,
+
+		/** Sequence B has replaced the region with different content. */
+		REPLACE,
+
+		/** Sequence A and B have zero length, describing nothing. */
+		EMPTY;
+	}
+
+	int beginA;
+
+	int endA;
+
+	int beginB;
+
+	int endB;
+
+	/**
+	 * Create a new empty edit.
+	 *
+	 * @param as
+	 *            beginA: start and end of region in sequence A; 0 based.
+	 * @param bs
+	 *            beginB: start and end of region in sequence B; 0 based.
+	 */
+	public Edit(int as, int bs) {
+		this(as, as, bs, bs);
+	}
+
+	/**
+	 * Create a new edit.
+	 *
+	 * @param as
+	 *            beginA: start of region in sequence A; 0 based.
+	 * @param ae
+	 *            endA: end of region in sequence A; must be &gt;= as.
+	 * @param bs
+	 *            beginB: start of region in sequence B; 0 based.
+	 * @param be
+	 *            endB: end of region in sequence B; must be &gt; = bs.
+	 */
+	public Edit(int as, int ae, int bs, int be) {
+		beginA = as;
+		endA = ae;
+
+		beginB = bs;
+		endB = be;
+	}
+
+	/**
+	 * Get type
+	 *
+	 * @return the type of this region
+	 */
+	public final Type getType() {
+		if (beginA < endA) {
+			if (beginB < endB)
+				return Type.REPLACE;
+			else /* if (beginB == endB) */
+				return Type.DELETE;
+
+		} else /* if (beginA == endA) */{
+			if (beginB < endB)
+				return Type.INSERT;
+			else /* if (beginB == endB) */
+				return Type.EMPTY;
+		}
+	}
+
+	/**
+	 * Whether edit is empty
+	 *
+	 * @return {@code true} if the edit is empty (lengths of both a and b is
+	 *         zero)
+	 */
+	public final boolean isEmpty() {
+		return beginA == endA && beginB == endB;
+	}
+
+	/**
+	 * Get start point in sequence A
+	 *
+	 * @return start point in sequence A
+	 */
+	public final int getBeginA() {
+		return beginA;
+	}
+
+	/**
+	 * Get end point in sequence A
+	 *
+	 * @return end point in sequence A
+	 */
+	public final int getEndA() {
+		return endA;
+	}
+
+	/**
+	 * Get start point in sequence B
+	 *
+	 * @return start point in sequence B
+	 */
+	public final int getBeginB() {
+		return beginB;
+	}
+
+	/**
+	 * Get end point in sequence B
+	 *
+	 * @return end point in sequence B
+	 */
+	public final int getEndB() {
+		return endB;
+	}
+
+	/**
+	 * Get length of the region in A
+	 *
+	 * @return length of the region in A
+	 */
+	public final int getLengthA() {
+		return endA - beginA;
+	}
+
+	/**
+	 * Get length of the region in B
+	 *
+	 * @return return length of the region in B
+	 */
+	public final int getLengthB() {
+		return endB - beginB;
+	}
+
+	/**
+	 * Move the edit region by the specified amount.
+	 *
+	 * @param amount
+	 *            the region is shifted by this amount, and can be positive or
+	 *            negative.
+	 * @since 4.8
+	 */
+	public final void shift(int amount) {
+		beginA += amount;
+		endA += amount;
+		beginB += amount;
+		endB += amount;
+	}
+
+	/**
+	 * Construct a new edit representing the region before cut.
+	 *
+	 * @param cut
+	 *            the cut point. The beginning A and B points are used as the
+	 *            end points of the returned edit.
+	 * @return an edit representing the slice of {@code this} edit that occurs
+	 *         before {@code cut} starts.
+	 */
+	public final Edit before(Edit cut) {
+		return new Edit(beginA, cut.beginA, beginB, cut.beginB);
+	}
+
+	/**
+	 * Construct a new edit representing the region after cut.
+	 *
+	 * @param cut
+	 *            the cut point. The ending A and B points are used as the
+	 *            starting points of the returned edit.
+	 * @return an edit representing the slice of {@code this} edit that occurs
+	 *         after {@code cut} ends.
+	 */
+	public final Edit after(Edit cut) {
+		return new Edit(cut.endA, endA, cut.endB, endB);
+	}
+
+	/**
+	 * Increase {@link #getEndA()} by 1.
+	 */
+	public void extendA() {
+		endA++;
+	}
+
+	/**
+	 * Increase {@link #getEndB()} by 1.
+	 */
+	public void extendB() {
+		endB++;
+	}
+
+	/**
+	 * Swap A and B, so the edit goes the other direction.
+	 */
+	public void swap() {
+		final int sBegin = beginA;
+		final int sEnd = endA;
+
+		beginA = beginB;
+		endA = endB;
+
+		beginB = sBegin;
+		endB = sEnd;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public int hashCode() {
+		return beginA ^ endA;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof Edit) {
+			final Edit e = (Edit) o;
+			return this.beginA == e.beginA && this.endA == e.endA
+					&& this.beginB == e.beginB && this.endB == e.endB;
+		}
+		return false;
+	}
+
+	/** {@inheritDoc} */
+	@SuppressWarnings("nls")
+	@Override
+	public String toString() {
+		final Type t = getType();
+		return t + "(" + beginA + "-" + endA + "," + beginB + "-" + endB + ")";
+	}
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/EditList.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/EditList.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2009, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+import java.util.ArrayList;
+
+/**
+ * Specialized list of {@link org.eclipse.jgit.diff.Edit}s in a document.
+ */
+public class EditList extends ArrayList<Edit> {
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Construct an edit list containing a single edit.
+	 *
+	 * @param edit
+	 *            the edit to return in the list.
+	 * @return list containing only {@code edit}.
+	 */
+	public static EditList singleton(Edit edit) {
+		EditList res = new EditList(1);
+		res.add(edit);
+		return res;
+	}
+
+	/**
+	 * Create a new, empty edit list.
+	 */
+	public EditList() {
+		super(16);
+	}
+
+	/**
+	 * Create an empty edit list with the specified capacity.
+	 *
+	 * @param capacity
+	 *            the initial capacity of the edit list. If additional edits are
+	 *            added to the list, it will be grown to support them.
+	 */
+	public EditList(int capacity) {
+		super(capacity);
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public String toString() {
+		return "EditList" + super.toString(); //$NON-NLS-1$
+	}
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/HashedSequence.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/HashedSequence.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Wraps a {@link org.eclipse.jgit.diff.Sequence} to assign hash codes to
+ * elements.
+ * <p>
+ * This sequence acts as a proxy for the real sequence, caching element hash
+ * codes so they don't need to be recomputed each time. Sequences of this type
+ * must be used with a {@link org.eclipse.jgit.diff.HashedSequenceComparator}.
+ * <p>
+ * To construct an instance of this type use
+ * {@link org.eclipse.jgit.diff.HashedSequencePair}.
+ *
+ * @param <S>
+ *            the base sequence type.
+ */
+public final class HashedSequence<S extends Sequence> extends Sequence {
+	final S base;
+
+	final int[] hashes;
+
+	HashedSequence(S base, int[] hashes) {
+		this.base = base;
+		this.hashes = hashes;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public int size() {
+		return base.size();
+	}
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/HashedSequenceComparator.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/HashedSequenceComparator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Wrap another comparator for use with
+ * {@link org.eclipse.jgit.diff.HashedSequence}.
+ * <p>
+ * This comparator acts as a proxy for the real comparator, evaluating the
+ * cached hash code before testing the underlying comparator's equality.
+ * Comparators of this type must be used with a
+ * {@link org.eclipse.jgit.diff.HashedSequence}.
+ * <p>
+ * To construct an instance of this type use
+ * {@link org.eclipse.jgit.diff.HashedSequencePair}.
+ *
+ * @param <S>
+ *            the base sequence type.
+ */
+public final class HashedSequenceComparator<S extends Sequence> extends
+		SequenceComparator<HashedSequence<S>> {
+	private final SequenceComparator<? super S> cmp;
+
+	HashedSequenceComparator(SequenceComparator<? super S> cmp) {
+		this.cmp = cmp;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public boolean equals(HashedSequence<S> a, int ai, //
+			HashedSequence<S> b, int bi) {
+		return a.hashes[ai] == b.hashes[bi]
+				&& cmp.equals(a.base, ai, b.base, bi);
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public int hash(HashedSequence<S> seq, int ptr) {
+		return seq.hashes[ptr];
+	}
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/HashedSequencePair.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/HashedSequencePair.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Wraps two {@link org.eclipse.jgit.diff.Sequence} instances to cache their
+ * element hash codes.
+ * <p>
+ * This pair wraps two sequences that contain cached hash codes for the input
+ * sequences.
+ *
+ * @param <S>
+ *            the base sequence type.
+ */
+public class HashedSequencePair<S extends Sequence> {
+	private final SequenceComparator<? super S> cmp;
+
+	private final S baseA;
+
+	private final S baseB;
+
+	private HashedSequence<S> cachedA;
+
+	private HashedSequence<S> cachedB;
+
+	/**
+	 * Construct a pair to provide fast hash codes.
+	 *
+	 * @param cmp
+	 *            the base comparator for the sequence elements.
+	 * @param a
+	 *            the A sequence.
+	 * @param b
+	 *            the B sequence.
+	 */
+	public HashedSequencePair(SequenceComparator<? super S> cmp, S a, S b) {
+		this.cmp = cmp;
+		this.baseA = a;
+		this.baseB = b;
+	}
+
+	/**
+	 * Get comparator
+	 *
+	 * @return obtain a comparator that uses the cached hash codes
+	 */
+	public HashedSequenceComparator<S> getComparator() {
+		return new HashedSequenceComparator<>(cmp);
+	}
+
+	/**
+	 * Get A
+	 *
+	 * @return wrapper around A that includes cached hash codes
+	 */
+	public HashedSequence<S> getA() {
+		if (cachedA == null)
+			cachedA = wrap(baseA);
+		return cachedA;
+	}
+
+	/**
+	 * Get B
+	 *
+	 * @return wrapper around B that includes cached hash codes
+	 */
+	public HashedSequence<S> getB() {
+		if (cachedB == null)
+			cachedB = wrap(baseB);
+		return cachedB;
+	}
+
+	private HashedSequence<S> wrap(S base) {
+		final int end = base.size();
+		final int[] hashes = new int[end];
+		for (int ptr = 0; ptr < end; ptr++)
+			hashes[ptr] = cmp.hash(base, ptr);
+		return new HashedSequence<>(base, hashes);
+	}
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/HistogramDiff.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/HistogramDiff.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An extended form of Bram Cohen's patience diff algorithm.
+ * <p>
+ * This implementation was derived by using the 4 rules that are outlined in
+ * Bram Cohen's <a href="http://bramcohen.livejournal.com/73318.html">blog</a>,
+ * and then was further extended to support low-occurrence common elements.
+ * <p>
+ * The basic idea of the algorithm is to create a histogram of occurrences for
+ * each element of sequence A. Each element of sequence B is then considered in
+ * turn. If the element also exists in sequence A, and has a lower occurrence
+ * count, the positions are considered as a candidate for the longest common
+ * subsequence (LCS). After scanning of B is complete the LCS that has the
+ * lowest number of occurrences is chosen as a split point. The region is split
+ * around the LCS, and the algorithm is recursively applied to the sections
+ * before and after the LCS.
+ * <p>
+ * By always selecting a LCS position with the lowest occurrence count, this
+ * algorithm behaves exactly like Bram Cohen's patience diff whenever there is a
+ * unique common element available between the two sequences. When no unique
+ * elements exist, the lowest occurrence element is chosen instead. This offers
+ * more readable diffs than simply falling back on the standard Myers' O(ND)
+ * algorithm would produce.
+ * <p>
+ * To prevent the algorithm from having an O(N^2) running time, an upper limit
+ * on the number of unique elements in a histogram bucket is configured by
+ * {@link #setMaxChainLength(int)}. If sequence A has more than this many
+ * elements that hash into the same hash bucket, the algorithm passes the region
+ * to {@link #setFallbackAlgorithm(DiffAlgorithm)}. If no fallback algorithm is
+ * configured, the region is emitted as a replace edit.
+ * <p>
+ * During scanning of sequence B, any element of A that occurs more than
+ * {@link #setMaxChainLength(int)} times is never considered for an LCS match
+ * position, even if it is common between the two sequences. This limits the
+ * number of locations in sequence A that must be considered to find the LCS,
+ * and helps maintain a lower running time bound.
+ * <p>
+ * So long as {@link #setMaxChainLength(int)} is a small constant (such as 64),
+ * the algorithm runs in O(N * D) time, where N is the sum of the input lengths
+ * and D is the number of edits in the resulting EditList. If the supplied
+ * {@link SequenceComparator} has a good
+ * hash function, this implementation typically out-performs
+ * {@link MyersDiff}, even though its
+ * theoretical running time is the same.
+ * <p>
+ * This implementation has an internal limitation that prevents it from handling
+ * sequences with more than 268,435,456 (2^28) elements.
+ */
+public class HistogramDiff extends LowLevelDiffAlgorithm {
+	/** Algorithm to use when there are too many element occurrences. */
+	DiffAlgorithm fallback = MyersDiff.INSTANCE;
+
+	/**
+	 * Maximum number of positions to consider for a given element hash.
+	 *
+	 * All elements with the same hash are stored into a single chain. The chain
+	 * size is capped to ensure search is linear time at O(len_A + len_B) rather
+	 * than quadratic at O(len_A * len_B).
+	 */
+	int maxChainLength = 64;
+
+	/**
+	 * Set the algorithm used when there are too many element occurrences.
+	 *
+	 * @param alg
+	 *            the secondary algorithm. If null the region will be denoted as
+	 *            a single REPLACE block.
+	 */
+	public void setFallbackAlgorithm(DiffAlgorithm alg) {
+		fallback = alg;
+	}
+
+	/**
+	 * Maximum number of positions to consider for a given element hash.
+	 *
+	 * All elements with the same hash are stored into a single chain. The chain
+	 * size is capped to ensure search is linear time at O(len_A + len_B) rather
+	 * than quadratic at O(len_A * len_B).
+	 *
+	 * @param maxLen
+	 *            new maximum length.
+	 */
+	public void setMaxChainLength(int maxLen) {
+		maxChainLength = maxLen;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public <S extends Sequence> void diffNonCommon(EditList edits,
+			HashedSequenceComparator<S> cmp, HashedSequence<S> a,
+			HashedSequence<S> b, Edit region) {
+		new State<>(edits, cmp, a, b).diffRegion(region);
+	}
+
+	private class State<S extends Sequence> {
+		private final HashedSequenceComparator<S> cmp;
+		private final HashedSequence<S> a;
+		private final HashedSequence<S> b;
+		private final List<Edit> queue = new ArrayList<>();
+
+		/** Result edits we have determined that must be made to convert a to b. */
+		final EditList edits;
+
+		State(EditList edits, HashedSequenceComparator<S> cmp,
+				HashedSequence<S> a, HashedSequence<S> b) {
+			this.cmp = cmp;
+			this.a = a;
+			this.b = b;
+			this.edits = edits;
+		}
+
+		void diffRegion(Edit r) {
+			diffReplace(r);
+			while (!queue.isEmpty())
+				diff(queue.remove(queue.size() - 1));
+		}
+
+		private void diffReplace(Edit r) {
+			Edit lcs = new HistogramDiffIndex<>(maxChainLength, cmp, a, b, r)
+					.findLongestCommonSequence();
+			if (lcs != null) {
+				// If we were given an edit, we can prove a result here.
+				//
+				if (lcs.isEmpty()) {
+					// An empty edit indicates there is nothing in common.
+					// Replace the entire region.
+					//
+					edits.add(r);
+				} else {
+					queue.add(r.after(lcs));
+					queue.add(r.before(lcs));
+				}
+
+			} else if (fallback instanceof LowLevelDiffAlgorithm) {
+				LowLevelDiffAlgorithm fb = (LowLevelDiffAlgorithm) fallback;
+				fb.diffNonCommon(edits, cmp, a, b, r);
+
+			} else if (fallback != null) {
+				SubsequenceComparator<HashedSequence<S>> cs = subcmp();
+				Subsequence<HashedSequence<S>> as = Subsequence.a(a, r);
+				Subsequence<HashedSequence<S>> bs = Subsequence.b(b, r);
+
+				EditList res = fallback.diffNonCommon(cs, as, bs);
+				edits.addAll(Subsequence.toBase(res, as, bs));
+
+			} else {
+				edits.add(r);
+			}
+		}
+
+		private void diff(Edit r) {
+			switch (r.getType()) {
+			case INSERT:
+			case DELETE:
+				edits.add(r);
+				break;
+
+			case REPLACE:
+				if (r.getLengthA() == 1 && r.getLengthB() == 1)
+					edits.add(r);
+				else
+					diffReplace(r);
+				break;
+
+			case EMPTY:
+			default:
+				throw new IllegalStateException();
+			}
+		}
+
+		private SubsequenceComparator<HashedSequence<S>> subcmp() {
+			return new SubsequenceComparator<>(cmp);
+		}
+	}
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/HistogramDiffIndex.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/HistogramDiffIndex.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Support {@link HistogramDiff} by computing occurrence counts of elements.
+ * <p>
+ * Each element in the range being considered is put into a hash table, tracking
+ * the number of times that distinct element appears in the sequence. Once all
+ * elements have been inserted from sequence A, each element of sequence B is
+ * probed in the hash table and the longest common subsequence with the lowest
+ * occurrence count in A is used as the result.
+ *
+ * @param <S>
+ *            type of the base sequence.
+ */
+final class HistogramDiffIndex<S extends Sequence> {
+	private static final int REC_NEXT_SHIFT = 28 + 8;
+
+	private static final int REC_PTR_SHIFT = 8;
+
+	private static final int REC_PTR_MASK = (1 << 28) - 1;
+
+	private static final int REC_CNT_MASK = (1 << 8) - 1;
+
+	private static final int MAX_PTR = REC_PTR_MASK;
+
+	private static final int MAX_CNT = (1 << 8) - 1;
+
+	private final int maxChainLength;
+
+	private final HashedSequenceComparator<S> cmp;
+
+	private final HashedSequence<S> a;
+
+	private final HashedSequence<S> b;
+
+	private final Edit region;
+
+	/** Keyed by {@link #hash(HashedSequence, int)} for {@link #recs} index. */
+	private final int[] table;
+
+	/** Number of low bits to discard from a key to index {@link #table}. */
+	private final int keyShift;
+
+	/**
+	 * Describes a unique element in sequence A.
+	 *
+	 * The records in this table are actually 3-tuples of:
+	 * <ul>
+	 * <li>index of next record in this table that has same hash code</li>
+	 * <li>index of first element in this occurrence chain</li>
+	 * <li>occurrence count for this element (length of locs list)</li>
+	 * </ul>
+	 *
+	 * The occurrence count is capped at {@link #MAX_CNT}, as the field is only
+	 * a few bits wide. Elements that occur more frequently will have their
+	 * count capped.
+	 */
+	private long[] recs;
+
+	/** Number of elements in {@link #recs}; also is the unique element count. */
+	private int recCnt;
+
+	/**
+	 * For {@code ptr}, {@code next[ptr - ptrShift]} has subsequent index.
+	 *
+	 * For the sequence element {@code ptr}, the value stored at location
+	 * {@code next[ptr - ptrShift]} is the next occurrence of the exact same
+	 * element in the sequence.
+	 *
+	 * Chains always run from the lowest index to the largest index. Therefore
+	 * the array will store {@code next[1] = 2}, but never {@code next[2] = 1}.
+	 * This allows a chain to terminate with {@code 0}, as {@code 0} would never
+	 * be a valid next element.
+	 *
+	 * The array is sized to be {@code region.getLengthA()} and element indexes
+	 * are converted to array indexes by subtracting {@link #ptrShift}, which is
+	 * just a cached version of {@code region.beginA}.
+	 */
+	private int[] next;
+
+	/**
+	 * For element {@code ptr} in A, index of the record in {@link #recs} array.
+	 *
+	 * The record at {@code recs[recIdx[ptr - ptrShift]]} is the record
+	 * describing all occurrences of the element appearing in sequence A at
+	 * position {@code ptr}. The record is needed to get the occurrence count of
+	 * the element, or to locate all other occurrences of that element within
+	 * sequence A. This index provides constant-time access to the record, and
+	 * avoids needing to scan the hash chain.
+	 */
+	private int[] recIdx;
+
+	/** Value to subtract from element indexes to key {@link #next} array. */
+	private int ptrShift;
+
+	private Edit lcs;
+
+	private int cnt;
+
+	private boolean hasCommon;
+
+	HistogramDiffIndex(int maxChainLength, HashedSequenceComparator<S> cmp,
+			HashedSequence<S> a, HashedSequence<S> b, Edit r) {
+		this.maxChainLength = maxChainLength;
+		this.cmp = cmp;
+		this.a = a;
+		this.b = b;
+		this.region = r;
+
+		if (region.endA >= MAX_PTR)
+			throw new IllegalArgumentException("sequenceTooLargeForDiffAlgorithm");
+
+		final int sz = r.getLengthA();
+		final int tableBits = tableBits(sz);
+		table = new int[1 << tableBits];
+		keyShift = 32 - tableBits;
+		ptrShift = r.beginA;
+
+		recs = new long[Math.max(4, sz >>> 3)];
+		next = new int[sz];
+		recIdx = new int[sz];
+	}
+
+	Edit findLongestCommonSequence() {
+		if (!scanA())
+			return null;
+
+		lcs = new Edit(0, 0);
+		cnt = maxChainLength + 1;
+
+		for (int bPtr = region.beginB; bPtr < region.endB;)
+			bPtr = tryLongestCommonSequence(bPtr);
+
+		return hasCommon && maxChainLength < cnt ? null : lcs;
+	}
+
+	private boolean scanA() {
+		// Scan the elements backwards, inserting them into the hash table
+		// as we go. Going in reverse places the earliest occurrence of any
+		// element at the start of the chain, so we consider earlier matches
+		// before later matches.
+		//
+		SCAN: for (int ptr = region.endA - 1; region.beginA <= ptr; ptr--) {
+			final int tIdx = hash(a, ptr);
+
+			int chainLen = 0;
+			for (int rIdx = table[tIdx]; rIdx != 0;) {
+				final long rec = recs[rIdx];
+				if (cmp.equals(a, recPtr(rec), a, ptr)) {
+					// ptr is identical to another element. Insert it onto
+					// the front of the existing element chain.
+					//
+					int newCnt = recCnt(rec) + 1;
+					if (MAX_CNT < newCnt)
+						newCnt = MAX_CNT;
+					recs[rIdx] = recCreate(recNext(rec), ptr, newCnt);
+					next[ptr - ptrShift] = recPtr(rec);
+					recIdx[ptr - ptrShift] = rIdx;
+					continue SCAN;
+				}
+
+				rIdx = recNext(rec);
+				chainLen++;
+			}
+
+			if (chainLen == maxChainLength)
+				return false;
+
+			// This is the first time we have ever seen this particular
+			// element in the sequence. Construct a new chain for it.
+			//
+			final int rIdx = ++recCnt;
+			if (rIdx == recs.length) {
+				int sz = Math.min(recs.length << 1, 1 + region.getLengthA());
+				long[] n = new long[sz];
+				System.arraycopy(recs, 0, n, 0, recs.length);
+				recs = n;
+			}
+
+			recs[rIdx] = recCreate(table[tIdx], ptr, 1);
+			recIdx[ptr - ptrShift] = rIdx;
+			table[tIdx] = rIdx;
+		}
+		return true;
+	}
+
+	private int tryLongestCommonSequence(int bPtr) {
+		int bNext = bPtr + 1;
+		int rIdx = table[hash(b, bPtr)];
+		for (long rec; rIdx != 0; rIdx = recNext(rec)) {
+			rec = recs[rIdx];
+
+			// If there are more occurrences in A, don't use this chain.
+			if (recCnt(rec) > cnt) {
+				if (!hasCommon)
+					hasCommon = cmp.equals(a, recPtr(rec), b, bPtr);
+				continue;
+			}
+
+			int as = recPtr(rec);
+			if (!cmp.equals(a, as, b, bPtr))
+				continue;
+
+			hasCommon = true;
+			TRY_LOCATIONS: for (;;) {
+				int np = next[as - ptrShift];
+				int bs = bPtr;
+				int ae = as + 1;
+				int be = bs + 1;
+				int rc = recCnt(rec);
+
+				while (region.beginA < as && region.beginB < bs
+						&& cmp.equals(a, as - 1, b, bs - 1)) {
+					as--;
+					bs--;
+					if (1 < rc)
+						rc = Math.min(rc, recCnt(recs[recIdx[as - ptrShift]]));
+				}
+				while (ae < region.endA && be < region.endB
+						&& cmp.equals(a, ae, b, be)) {
+					if (1 < rc)
+						rc = Math.min(rc, recCnt(recs[recIdx[ae - ptrShift]]));
+					ae++;
+					be++;
+				}
+
+				if (bNext < be)
+					bNext = be;
+				if (lcs.getLengthA() < ae - as || rc < cnt) {
+					// If this region is the longest, or there are less
+					// occurrences of it in A, its now our LCS.
+					//
+					lcs.beginA = as;
+					lcs.beginB = bs;
+					lcs.endA = ae;
+					lcs.endB = be;
+					cnt = rc;
+				}
+
+				// Because we added elements in reverse order index 0
+				// cannot possibly be the next position. Its the first
+				// element of the sequence and thus would have been the
+				// value of as at the start of the TRY_LOCATIONS loop.
+				//
+				if (np == 0)
+					break TRY_LOCATIONS;
+
+				while (np < ae) {
+					// The next location to consider was actually within
+					// the LCS we examined above. Don't reconsider it.
+					//
+					np = next[np - ptrShift];
+					if (np == 0)
+						break TRY_LOCATIONS;
+				}
+
+				as = np;
+			}
+		}
+		return bNext;
+	}
+
+	private int hash(HashedSequence<S> s, int idx) {
+		return (cmp.hash(s, idx) * 0x9e370001 /* mix bits */) >>> keyShift;
+	}
+
+	private static long recCreate(int next, int ptr, int cnt) {
+		return ((long) next << REC_NEXT_SHIFT) //
+				| ((long) ptr << REC_PTR_SHIFT) //
+				| cnt;
+	}
+
+	private static int recNext(long rec) {
+		return (int) (rec >>> REC_NEXT_SHIFT);
+	}
+
+	private static int recPtr(long rec) {
+		return ((int) (rec >>> REC_PTR_SHIFT)) & REC_PTR_MASK;
+	}
+
+	private static int recCnt(long rec) {
+		return ((int) rec) & REC_CNT_MASK;
+	}
+
+	private static int tableBits(int sz) {
+		int bits = 31 - Integer.numberOfLeadingZeros(sz);
+		if (bits == 0)
+			bits = 1;
+		if (1 << bits < sz)
+			bits++;
+		return bits;
+	}
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/IntList.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/IntList.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2008, Google Inc.
+ * Copyright (C) 2009, Johannes Schindelin <johannes.schindelin@gmx.de>
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * A more efficient List&lt;Integer&gt; using a primitive integer array.
+ */
+public class IntList {
+    private int[] entries;
+
+    private int count;
+
+    /**
+     * Create an empty list with a default capacity.
+     */
+    public IntList() {
+        this(10);
+    }
+
+    /**
+     * Create an empty list with the specified capacity.
+     *
+     * @param capacity
+     *            number of entries the list can initially hold.
+     */
+    public IntList(int capacity) {
+        entries = new int[capacity];
+    }
+
+    /**
+     * Get number of entries in this list.
+     *
+     * @return number of entries in this list.
+     */
+    public int size() {
+        return count;
+    }
+
+    /**
+     * Check if an entry appears in this collection.
+     *
+     * @param value
+     *            the value to search for.
+     * @return true of {@code value} appears in this list.
+     * @since 4.9
+     */
+    public boolean contains(int value) {
+        for (int i = 0; i < count; i++)
+            if (entries[i] == value)
+                return true;
+        return false;
+    }
+
+    /**
+     * Get the value at the specified index
+     *
+     * @param i
+     *            index to read, must be in the range [0, {@link #size()}).
+     * @return the number at the specified index
+     * @throws java.lang.ArrayIndexOutOfBoundsException
+     *             the index outside the valid range
+     */
+    public int get(int i) {
+        if (count <= i)
+            throw new ArrayIndexOutOfBoundsException(i);
+        return entries[i];
+    }
+
+    /**
+     * Empty this list
+     */
+    public void clear() {
+        count = 0;
+    }
+
+    /**
+     * Add an entry to the end of the list.
+     *
+     * @param n
+     *            the number to add.
+     */
+    public void add(int n) {
+        if (count == entries.length)
+            grow();
+        entries[count++] = n;
+    }
+
+    /**
+     * Assign an entry in the list.
+     *
+     * @param index
+     *            index to set, must be in the range [0, {@link #size()}).
+     * @param n
+     *            value to store at the position.
+     */
+    public void set(int index, int n) {
+        if (count < index)
+            throw new ArrayIndexOutOfBoundsException(index);
+        else if (count == index)
+            add(n);
+        else
+            entries[index] = n;
+    }
+
+    /**
+     * Pad the list with entries.
+     *
+     * @param toIndex
+     *            index position to stop filling at. 0 inserts no filler. 1
+     *            ensures the list has a size of 1, adding <code>val</code> if
+     *            the list is currently empty.
+     * @param val
+     *            value to insert into padded positions.
+     */
+    public void fillTo(int toIndex, int val) {
+        while (count < toIndex)
+            add(val);
+    }
+
+    private void grow() {
+        final int[] n = new int[(entries.length + 16) * 3 / 2];
+        System.arraycopy(entries, 0, n, 0, count);
+        entries = n;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        final StringBuilder r = new StringBuilder();
+        r.append('[');
+        for (int i = 0; i < count; i++) {
+            if (i > 0)
+                r.append(", "); //$NON-NLS-1$
+            r.append(entries[i]);
+        }
+        r.append(']');
+        return r.toString();
+    }
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/LongList.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/LongList.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2009, Christian Halstrick <christian.halstrick@sap.com>
+ * Copyright (C) 2009, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+import java.util.Arrays;
+
+/**
+ * A more efficient List&lt;Long&gt; using a primitive long array.
+ */
+public class LongList {
+    private long[] entries;
+
+    private int count;
+
+    /**
+     * Create an empty list with a default capacity.
+     */
+    public LongList() {
+        this(10);
+    }
+
+    /**
+     * Create an empty list with the specified capacity.
+     *
+     * @param capacity
+     *            number of entries the list can initially hold.
+     */
+    public LongList(int capacity) {
+        entries = new long[capacity];
+    }
+
+    /**
+     * Get number of entries in this list
+     *
+     * @return number of entries in this list
+     */
+    public int size() {
+        return count;
+    }
+
+    /**
+     * Get the value at the specified index
+     *
+     * @param i
+     *            index to read, must be in the range [0, {@link #size()}).
+     * @return the number at the specified index
+     * @throws java.lang.ArrayIndexOutOfBoundsException
+     *             the index outside the valid range
+     */
+    public long get(int i) {
+        if (count <= i)
+            throw new ArrayIndexOutOfBoundsException(i);
+        return entries[i];
+    }
+
+    /**
+     * Determine if an entry appears in this collection.
+     *
+     * @param value
+     *            the value to search for.
+     * @return true of {@code value} appears in this list.
+     */
+    public boolean contains(long value) {
+        for (int i = 0; i < count; i++)
+            if (entries[i] == value)
+                return true;
+        return false;
+    }
+
+    /**
+     * Clear this list
+     */
+    public void clear() {
+        count = 0;
+    }
+
+    /**
+     * Add an entry to the end of the list.
+     *
+     * @param n
+     *            the number to add.
+     */
+    public void add(long n) {
+        if (count == entries.length)
+            grow();
+        entries[count++] = n;
+    }
+
+    /**
+     * Assign an entry in the list.
+     *
+     * @param index
+     *            index to set, must be in the range [0, {@link #size()}).
+     * @param n
+     *            value to store at the position.
+     */
+    public void set(int index, long n) {
+        if (count < index)
+            throw new ArrayIndexOutOfBoundsException(index);
+        else if (count == index)
+            add(n);
+        else
+            entries[index] = n;
+    }
+
+    /**
+     * Pad the list with entries.
+     *
+     * @param toIndex
+     *            index position to stop filling at. 0 inserts no filler. 1
+     *            ensures the list has a size of 1, adding <code>val</code> if
+     *            the list is currently empty.
+     * @param val
+     *            value to insert into padded positions.
+     */
+    public void fillTo(int toIndex, long val) {
+        while (count < toIndex)
+            add(val);
+    }
+
+    /**
+     * Sort the list of longs according to their natural ordering.
+     */
+    public void sort() {
+        Arrays.sort(entries, 0, count);
+    }
+
+    private void grow() {
+        final long[] n = new long[(entries.length + 16) * 3 / 2];
+        System.arraycopy(entries, 0, n, 0, count);
+        entries = n;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        final StringBuilder r = new StringBuilder();
+        r.append('[');
+        for (int i = 0; i < count; i++) {
+            if (i > 0)
+                r.append(", "); //$NON-NLS-1$
+            r.append(entries[i]);
+        }
+        r.append(']');
+        return r.toString();
+    }
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/LowLevelDiffAlgorithm.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/LowLevelDiffAlgorithm.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Compares two sequences primarily based upon hash codes.
+ */
+public abstract class LowLevelDiffAlgorithm extends DiffAlgorithm {
+	/** {@inheritDoc} */
+	@Override
+	public <S extends Sequence> EditList diffNonCommon(
+			SequenceComparator<? super S> cmp, S a, S b) {
+		HashedSequencePair<S> p = new HashedSequencePair<>(cmp, a, b);
+		HashedSequenceComparator<S> hc = p.getComparator();
+		HashedSequence<S> ha = p.getA();
+		HashedSequence<S> hb = p.getB();
+		p = null;
+
+		EditList res = new EditList();
+		Edit region = new Edit(0, a.size(), 0, b.size());
+		diffNonCommon(res, hc, ha, hb, region);
+		return res;
+	}
+
+	/**
+	 * Compare two sequences and identify a list of edits between them.
+	 *
+	 * This method should be invoked only after the two sequences have been
+	 * proven to have no common starting or ending elements. The expected
+	 * elimination of common starting and ending elements is automatically
+	 * performed by the {@link #diff(SequenceComparator, Sequence, Sequence)}
+	 * method, which invokes this method using
+	 * {@link Subsequence}s.
+	 *
+	 * @param edits
+	 *            result list to append the region's edits onto.
+	 * @param cmp
+	 *            the comparator supplying the element equivalence function.
+	 * @param a
+	 *            the first (also known as old or pre-image) sequence. Edits
+	 *            returned by this algorithm will reference indexes using the
+	 *            'A' side: {@link Edit#getBeginA()},
+	 *            {@link Edit#getEndA()}.
+	 * @param b
+	 *            the second (also known as new or post-image) sequence. Edits
+	 *            returned by this algorithm will reference indexes using the
+	 *            'B' side: {@link Edit#getBeginB()},
+	 *            {@link Edit#getEndB()}.
+	 * @param region
+	 *            the region being compared within the two sequences.
+	 */
+	public abstract <S extends Sequence> void diffNonCommon(EditList edits,
+			HashedSequenceComparator<S> cmp, HashedSequence<S> a,
+			HashedSequence<S> b, Edit region);
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/MyersDiff.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/MyersDiff.java
@@ -1,0 +1,543 @@
+/*
+ * Copyright (C) 2008-2009, Johannes E. Schindelin <johannes.schindelin@gmx.de>
+ * Copyright (C) 2009, Johannes Schindelin <johannes.schindelin@gmx.de>
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Diff algorithm, based on "An O(ND) Difference Algorithm and its Variations",
+ * by Eugene Myers.
+ * <p>
+ * The basic idea is to put the line numbers of text A as columns ("x") and the
+ * lines of text B as rows ("y"). Now you try to find the shortest "edit path"
+ * from the upper left corner to the lower right corner, where you can always go
+ * horizontally or vertically, but diagonally from (x,y) to (x+1,y+1) only if
+ * line x in text A is identical to line y in text B.
+ * <p>
+ * Myers' fundamental concept is the "furthest reaching D-path on diagonal k": a
+ * D-path is an edit path starting at the upper left corner and containing
+ * exactly D non-diagonal elements ("differences"). The furthest reaching D-path
+ * on diagonal k is the one that contains the most (diagonal) elements which
+ * ends on diagonal k (where k = y - x).
+ * <p>
+ * Example:
+ *
+ * <pre>
+ *    H E L L O   W O R L D
+ *    ____
+ *  L     \___
+ *  O         \___
+ *  W             \________
+ * </pre>
+ * <p>
+ * Since every D-path has exactly D horizontal or vertical elements, it can only
+ * end on the diagonals -D, -D+2, ..., D-2, D.
+ * <p>
+ * Since every furthest reaching D-path contains at least one furthest reaching
+ * (D-1)-path (except for D=0), we can construct them recursively.
+ * <p>
+ * Since we are really interested in the shortest edit path, we can start
+ * looking for a 0-path, then a 1-path, and so on, until we find a path that
+ * ends in the lower right corner.
+ * <p>
+ * To save space, we do not need to store all paths (which has quadratic space
+ * requirements), but generate the D-paths simultaneously from both sides. When
+ * the ends meet, we will have found "the middle" of the path. From the end
+ * points of that diagonal part, we can generate the rest recursively.
+ * <p>
+ * This only requires linear space.
+ * <p>
+ * The overall (runtime) complexity is:
+ *
+ * <pre>
+ *     O(N * D^2 + 2 * N/2 * (D/2)^2 + 4 * N/4 * (D/4)^2 + ...)
+ *     = O(N * D^2 * 5 / 4) = O(N * D^2),
+ * </pre>
+ * <p>
+ * (With each step, we have to find the middle parts of twice as many regions as
+ * before, but the regions (as well as the D) are halved.)
+ * <p>
+ * So the overall runtime complexity stays the same with linear space, albeit
+ * with a larger constant factor.
+ *
+ * @param <S>
+ *            type of sequence.
+ */
+@SuppressWarnings("hiding")
+public class MyersDiff<S extends Sequence> {
+	/** Singleton instance of MyersDiff. */
+	public static final DiffAlgorithm INSTANCE = new LowLevelDiffAlgorithm() {
+		@SuppressWarnings("unused")
+		@Override
+		public <S extends Sequence> void diffNonCommon(EditList edits,
+				HashedSequenceComparator<S> cmp, HashedSequence<S> a,
+				HashedSequence<S> b, Edit region) {
+			new MyersDiff<>(edits, cmp, a, b, region);
+		}
+	};
+
+	/**
+	 * The list of edits found during the last call to
+	 * {@link #calculateEdits(Edit)}
+	 */
+	protected EditList edits;
+
+	/** Comparison function for sequences. */
+	protected HashedSequenceComparator<S> cmp;
+
+	/**
+	 * The first text to be compared. Referred to as "Text A" in the comments
+	 */
+	protected HashedSequence<S> a;
+
+	/**
+	 * The second text to be compared. Referred to as "Text B" in the comments
+	 */
+	protected HashedSequence<S> b;
+
+	private MyersDiff(EditList edits, HashedSequenceComparator<S> cmp,
+			HashedSequence<S> a, HashedSequence<S> b, Edit region) {
+		this.edits = edits;
+		this.cmp = cmp;
+		this.a = a;
+		this.b = b;
+		calculateEdits(region);
+	}
+
+	// TODO: use ThreadLocal for future multi-threaded operations
+	MiddleEdit middle = new MiddleEdit();
+
+	/**
+	 * Entrypoint into the algorithm this class is all about. This method triggers that the
+	 * differences between A and B are calculated in form of a list of edits.
+	 * @param r portion of the sequences to examine.
+	 */
+	private void calculateEdits(Edit r) {
+		middle.initialize(r.beginA, r.endA, r.beginB, r.endB);
+		if (middle.beginA >= middle.endA &&
+				middle.beginB >= middle.endB)
+			return;
+
+		calculateEdits(middle.beginA, middle.endA,
+				middle.beginB, middle.endB);
+	}
+
+	/**
+	 * Calculates the differences between a given part of A against another
+	 * given part of B
+	 *
+	 * @param beginA
+	 *            start of the part of A which should be compared
+	 *            (0&lt;=beginA&lt;sizeof(A))
+	 * @param endA
+	 *            end of the part of A which should be compared
+	 *            (beginA&lt;=endA&lt;sizeof(A))
+	 * @param beginB
+	 *            start of the part of B which should be compared
+	 *            (0&lt;=beginB&lt;sizeof(B))
+	 * @param endB
+	 *            end of the part of B which should be compared
+	 *            (beginB&lt;=endB&lt;sizeof(B))
+	 */
+	protected void calculateEdits(int beginA, int endA,
+			int beginB, int endB) {
+		Edit edit = middle.calculate(beginA, endA, beginB, endB);
+
+		if (beginA < edit.beginA || beginB < edit.beginB) {
+			int k = edit.beginB - edit.beginA;
+			int x = middle.backward.snake(k, edit.beginA);
+			calculateEdits(beginA, x, beginB, k + x);
+		}
+
+		if (edit.getType() != Edit.Type.EMPTY)
+			edits.add(edits.size(), edit);
+
+		// after middle
+		if (endA > edit.endA || endB > edit.endB) {
+			int k = edit.endB - edit.endA;
+			int x = middle.forward.snake(k, edit.endA);
+			calculateEdits(x, endA, k + x, endB);
+		}
+	}
+
+	/**
+	 * A class to help bisecting the sequences a and b to find minimal
+	 * edit paths.
+	 *
+	 * As the arrays are reused for space efficiency, you will need one
+	 * instance per thread.
+	 *
+	 * The entry function is the calculate() method.
+	 */
+	class MiddleEdit {
+		void initialize(int beginA, int endA, int beginB, int endB) {
+			this.beginA = beginA; this.endA = endA;
+			this.beginB = beginB; this.endB = endB;
+
+			// strip common parts on either end
+			int k = beginB - beginA;
+			this.beginA = forward.snake(k, beginA);
+			this.beginB = k + this.beginA;
+
+			k = endB - endA;
+			this.endA = backward.snake(k, endA);
+			this.endB = k + this.endA;
+		}
+
+		/*
+		 * This function calculates the "middle" Edit of the shortest
+		 * edit path between the given subsequences of a and b.
+		 *
+		 * Once a forward path and a backward path meet, we found the
+		 * middle part.  From the last snake end point on both of them,
+		 * we construct the Edit.
+		 *
+		 * It is assumed that there is at least one edit in the range.
+		 */
+		// TODO: measure speed impact when this is synchronized
+		Edit calculate(int beginA, int endA, int beginB, int endB) {
+			if (beginA == endA || beginB == endB)
+				return new Edit(beginA, endA, beginB, endB);
+			this.beginA = beginA; this.endA = endA;
+			this.beginB = beginB; this.endB = endB;
+
+			/*
+			 * Following the conventions in Myers' paper, "k" is
+			 * the difference between the index into "b" and the
+			 * index into "a".
+			 */
+			int minK = beginB - endA;
+			int maxK = endB - beginA;
+
+			forward.initialize(beginB - beginA, beginA, minK, maxK);
+			backward.initialize(endB - endA, endA, minK, maxK);
+
+			for (int d = 1; ; d++)
+				if (forward.calculate(d) ||
+						backward.calculate(d))
+					return edit;
+		}
+
+		/*
+		 * For each d, we need to hold the d-paths for the diagonals
+		 * k = -d, -d + 2, ..., d - 2, d.  These are stored in the
+		 * forward (and backward) array.
+		 *
+		 * As we allow subsequences, too, this needs some refinement:
+		 * the forward paths start on the diagonal forwardK =
+		 * beginB - beginA, and backward paths start on the diagonal
+		 * backwardK = endB - endA.
+		 *
+		 * So, we need to hold the forward d-paths for the diagonals
+		 * k = forwardK - d, forwardK - d + 2, ..., forwardK + d and
+		 * the analogue for the backward d-paths.  This means that
+		 * we can turn (k, d) into the forward array index using this
+		 * formula:
+		 *
+		 *	i = (d + k - forwardK) / 2
+		 *
+		 * There is a further complication: the edit paths should not
+		 * leave the specified subsequences, so k is bounded by
+		 * minK = beginB - endA and maxK = endB - beginA.  However,
+		 * (k - forwardK) _must_ be odd whenever d is odd, and it
+		 * _must_ be even when d is even.
+		 *
+		 * The values in the "forward" and "backward" arrays are
+		 * positions ("x") in the sequence a, to get the corresponding
+		 * positions ("y") in the sequence b, you have to calculate
+		 * the appropriate k and then y:
+		 *
+		 *	k = forwardK - d + i * 2
+		 *	y = k + x
+		 *
+		 * (substitute backwardK for forwardK if you want to get the
+		 * y position for an entry in the "backward" array.
+		 */
+		EditPaths forward = new ForwardEditPaths();
+		EditPaths backward = new BackwardEditPaths();
+
+		/* Some variables which are shared between methods */
+		protected int beginA, endA, beginB, endB;
+		protected Edit edit;
+
+		abstract class EditPaths {
+			private IntList x = new IntList();
+			private LongList snake = new LongList();
+			int beginK, endK, middleK;
+			int prevBeginK, prevEndK;
+			/* if we hit one end early, no need to look further */
+			int minK, maxK; // TODO: better explanation
+
+			final int getIndex(int d, int k) {
+				return (d + k - middleK) / 2;
+			}
+
+			final int getX(int d, int k) {
+				return x.get(getIndex(d, k));
+			}
+
+			final long getSnake(int d, int k) {
+				return snake.get(getIndex(d, k));
+			}
+
+			private int forceKIntoRange(int k) {
+				/* if k is odd, so must be the result */
+				if (k < minK)
+					return minK + ((k ^ minK) & 1);
+				else if (k > maxK)
+					return maxK - ((k ^ maxK) & 1);
+				return k;
+			}
+
+			void initialize(int k, int x, int minK, int maxK) {
+				this.minK = minK;
+				this.maxK = maxK;
+				beginK = endK = middleK = k;
+				this.x.clear();
+				this.x.add(x);
+				snake.clear();
+				snake.add(newSnake(k, x));
+			}
+
+			abstract int snake(int k, int x);
+			abstract int getLeft(int x);
+			abstract int getRight(int x);
+			abstract boolean isBetter(int left, int right);
+			abstract void adjustMinMaxK(int k, int x);
+			abstract boolean meets(int d, int k, int x, long snake);
+
+			final long newSnake(int k, int x) {
+				long y = k + x;
+				long ret = ((long) x) << 32;
+				return ret | y;
+			}
+
+			final int snake2x(long snake) {
+				return (int) (snake >>> 32);
+			}
+
+			final int snake2y(long snake) {
+				return (int) snake;
+			}
+
+			final boolean makeEdit(long snake1, long snake2) {
+				int x1 = snake2x(snake1), x2 = snake2x(snake2);
+				int y1 = snake2y(snake1), y2 = snake2y(snake2);
+				/*
+				 * Check for incompatible partial edit paths:
+				 * when there are ambiguities, we might have
+				 * hit incompatible (i.e. non-overlapping)
+				 * forward/backward paths.
+				 *
+				 * In that case, just pretend that we have
+				 * an empty edit at the end of one snake; this
+				 * will force a decision which path to take
+				 * in the next recursion step.
+				 */
+				if (x1 > x2 || y1 > y2) {
+					x1 = x2;
+					y1 = y2;
+				}
+				edit = new Edit(x1, x2, y1, y2);
+				return true;
+			}
+
+			boolean calculate(int d) {
+				prevBeginK = beginK;
+				prevEndK = endK;
+				beginK = forceKIntoRange(middleK - d);
+				endK = forceKIntoRange(middleK + d);
+				// TODO: handle i more efficiently
+				// TODO: walk snake(k, getX(d, k)) only once per (d, k)
+				// TODO: move end points out of the loop to avoid conditionals inside the loop
+				// go backwards so that we can avoid temp vars
+				for (int k = endK; k >= beginK; k -= 2) {
+					if (Thread.interrupted()) {
+						throw new RuntimeException(new InterruptedException("Diff interrupted"));
+					}
+					int left = -1, right = -1;
+					long leftSnake = -1L, rightSnake = -1L;
+					// TODO: refactor into its own function
+					if (k > prevBeginK) {
+						int i = getIndex(d - 1, k - 1);
+						left = x.get(i);
+						int end = snake(k - 1, left);
+						leftSnake = left != end ?
+							newSnake(k - 1, end) :
+							snake.get(i);
+						if (meets(d, k - 1, end, leftSnake))
+							return true;
+						left = getLeft(end);
+					}
+					if (k < prevEndK) {
+						int i = getIndex(d - 1, k + 1);
+						right = x.get(i);
+						int end = snake(k + 1, right);
+						rightSnake = right != end ?
+							newSnake(k + 1, end) :
+							snake.get(i);
+						if (meets(d, k + 1, end, rightSnake))
+							return true;
+						right = getRight(end);
+					}
+					int newX;
+					long newSnake;
+					if (k >= prevEndK ||
+							(k > prevBeginK &&
+							 isBetter(left, right))) {
+						newX = left;
+						newSnake = leftSnake;
+					}
+					else {
+						newX = right;
+						newSnake = rightSnake;
+					}
+					if (meets(d, k, newX, newSnake))
+						return true;
+					adjustMinMaxK(k, newX);
+					int i = getIndex(d, k);
+					x.set(i, newX);
+					snake.set(i, newSnake);
+				}
+				return false;
+			}
+		}
+
+		class ForwardEditPaths extends EditPaths {
+			@Override
+			final int snake(int k, int x) {
+				for (; x < endA && k + x < endB; x++)
+					if (!cmp.equals(a, x, b, k + x))
+						break;
+				return x;
+			}
+
+			@Override
+			final int getLeft(int x) {
+				return x;
+			}
+
+			@Override
+			final int getRight(int x) {
+				return x + 1;
+			}
+
+			@Override
+			final boolean isBetter(int left, int right) {
+				return left > right;
+			}
+
+			@Override
+			final void adjustMinMaxK(int k, int x) {
+				if (x >= endA || k + x >= endB) {
+					if (k > backward.middleK)
+						maxK = k;
+					else
+						minK = k;
+				}
+			}
+
+			@Override
+			final boolean meets(int d, int k, int x, long snake) {
+				if (k < backward.beginK || k > backward.endK)
+					return false;
+				// TODO: move out of loop
+				if (((d - 1 + k - backward.middleK) % 2) != 0)
+					return false;
+				if (x < backward.getX(d - 1, k))
+					return false;
+				makeEdit(snake, backward.getSnake(d - 1, k));
+				return true;
+			}
+		}
+
+		class BackwardEditPaths extends EditPaths {
+			@Override
+			final int snake(int k, int x) {
+				for (; x > beginA && k + x > beginB; x--)
+					if (!cmp.equals(a, x - 1, b, k + x - 1))
+						break;
+				return x;
+			}
+
+			@Override
+			final int getLeft(int x) {
+				return x - 1;
+			}
+
+			@Override
+			final int getRight(int x) {
+				return x;
+			}
+
+			@Override
+			final boolean isBetter(int left, int right) {
+				return left < right;
+			}
+
+			@Override
+			final void adjustMinMaxK(int k, int x) {
+				if (x <= beginA || k + x <= beginB) {
+					if (k > forward.middleK)
+						maxK = k;
+					else
+						minK = k;
+				}
+			}
+
+			@Override
+			final boolean meets(int d, int k, int x, long snake) {
+				if (k < forward.beginK || k > forward.endK)
+					return false;
+				// TODO: move out of loop
+				if (((d + k - forward.middleK) % 2) != 0)
+					return false;
+				if (x > forward.getX(d, k))
+					return false;
+				makeEdit(forward.getSnake(d, k), snake);
+				return true;
+			}
+		}
+	}
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawCharUtil.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawCharUtil.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Utility class for character functions on raw bytes
+ * <p>
+ * Characters are assumed to be 8-bit US-ASCII.
+ */
+public class RawCharUtil {
+    private static final boolean[] WHITESPACE = new boolean[256];
+
+    static {
+        WHITESPACE['\r'] = true;
+        WHITESPACE['\n'] = true;
+        WHITESPACE['\t'] = true;
+        WHITESPACE[' '] = true;
+    }
+
+    /**
+     * Determine if an 8-bit US-ASCII encoded character is represents whitespace
+     *
+     * @param c
+     *            the 8-bit US-ASCII encoded character
+     * @return true if c represents a whitespace character in 8-bit US-ASCII
+     */
+    public static boolean isWhitespace(byte c) {
+        return WHITESPACE[c & 0xff];
+    }
+
+    /**
+     * Returns the new end point for the byte array passed in after trimming any
+     * trailing whitespace characters, as determined by the isWhitespace()
+     * function. start and end are assumed to be within the bounds of raw.
+     *
+     * @param raw
+     *            the byte array containing the portion to trim whitespace for
+     * @param start
+     *            the start of the section of bytes
+     * @param end
+     *            the end of the section of bytes
+     * @return the new end point
+     */
+    public static int trimTrailingWhitespace(byte[] raw, int start, int end) {
+        int ptr = end - 1;
+        while (start <= ptr && isWhitespace(raw[ptr]))
+            ptr--;
+
+        return ptr + 1;
+    }
+
+    /**
+     * Returns the new start point for the byte array passed in after trimming
+     * any leading whitespace characters, as determined by the isWhitespace()
+     * function. start and end are assumed to be within the bounds of raw.
+     *
+     * @param raw
+     *            the byte array containing the portion to trim whitespace for
+     * @param start
+     *            the start of the section of bytes
+     * @param end
+     *            the end of the section of bytes
+     * @return the new start point
+     */
+    public static int trimLeadingWhitespace(byte[] raw, int start, int end) {
+        while (start < end && isWhitespace(raw[start]))
+            start++;
+
+        return start;
+    }
+
+    private RawCharUtil() {
+        // This will never be called
+    }
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawText.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawText.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2009, Google Inc. Copyright (C) 2008-2009, Johannes E. Schindelin <johannes.schindelin@gmx.de> and
+ * other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Distribution License
+ * v1.0 which accompanies this distribution, is reproduced below, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * A Sequence supporting UNIX formatted text in byte[] format.
+ * <p>
+ * Elements of the sequence are the lines of the file, as delimited by the UNIX newline character ('\n'). The file
+ * content is treated as 8 bit binary text, with no assumptions or requirements on character encoding.
+ * <p>
+ * Note that the first line of the file is element 0, as defined by the Sequence interface API. Traditionally in a text
+ * editor a patch file the first line is line number 1. Callers may need to subtract 1 prior to invoking methods if they
+ * are converting from "line number" to "element index".
+ */
+public class RawText extends Sequence {
+    /** A RawText of length 0 */
+    public static final RawText EMPTY_TEXT = new RawText(new byte[0], new IntList());
+
+    /** Number of bytes to check for heuristics in {@link #isBinary(byte[])} */
+    static final int FIRST_FEW_BYTES = 8000;
+
+    /** The file content for this sequence. */
+    protected final byte[] content;
+
+    /** Map of line number to starting position within {@link #content}. */
+    protected final IntList lines;
+
+    /**
+     * Create a new sequence from the existing content byte array and the line map indicating line boundaries.
+     *
+     * @param input
+     *            the content array. The object retains a reference to this array, so it should be immutable.
+     * @param lineMap
+     *            an array with 1-based offsets for the start of each line. The first and last entries should be
+     *            {@link Integer#MIN_VALUE} and an offset one past the end of the last line, respectively.
+     * @since 5.0
+     */
+    public RawText(byte[] input, IntList lineMap) {
+        content = input;
+        lines = lineMap;
+    }
+
+    /**
+     * @return the raw, unprocessed content read.
+     * @since 4.11
+     */
+    public byte[] getRawContent() {
+        return content;
+    }
+
+    /** @return total number of items in the sequence. */
+    /** {@inheritDoc} */
+    @Override public int size() {
+        // The line map is always 2 entries larger than the number of lines in
+        // the file. Index 0 is padded out/unused. The last index is the total
+        // length of the buffer, and acts as a sentinel.
+        //
+        return lines.size() - 2;
+    }
+
+    /**
+     * Write a specific line to the output stream, without its trailing LF.
+     * <p>
+     * The specified line is copied as-is, with no character encoding translation performed.
+     * <p>
+     * If the specified line ends with an LF ('\n'), the LF is <b>not</b> copied. It is up to the caller to write the
+     * LF, if desired, between output lines.
+     *
+     * @param out
+     *            stream to copy the line data onto.
+     * @param i
+     *            index of the line to extract. Note this is 0-based, so line number 1 is actually index 0.
+     * @throws java.io.IOException
+     *             the stream write operation failed.
+     */
+    public void writeLine(OutputStream out, int i) throws IOException {
+        int start = getStart(i);
+        int end = getEnd(i);
+        if(content[end - 1] == '\n')
+            end--;
+        out.write(content, start, end - start);
+    }
+
+    /**
+     * Determine if the file ends with a LF ('\n').
+     *
+     * @return true if the last line has an LF; false otherwise.
+     */
+    public boolean isMissingNewlineAtEnd() {
+        final int end = lines.get(lines.size() - 1);
+        if(end == 0)
+            return true;
+        return content[end - 1] != '\n';
+    }
+
+    private int getStart(int i) {
+        return lines.get(i + 1);
+    }
+
+    private int getEnd(int i) {
+        return lines.get(i + 2);
+    }
+
+    /**
+     * Determine heuristically whether a byte array represents binary (as opposed to text) content.
+     *
+     * @param raw
+     *            the raw file content.
+     * @return true if raw is likely to be a binary file, false otherwise
+     */
+    public static boolean isBinary(byte[] raw) {
+        return isBinary(raw, raw.length);
+    }
+
+    /**
+     * Determine heuristically whether the bytes contained in a stream represents binary (as opposed to text) content.
+     *
+     * Note: Do not further use this stream after having called this method! The stream may not be fully read and will
+     * be left at an unknown position after consuming an unknown number of bytes. The caller is responsible for closing
+     * the stream.
+     *
+     * @param raw
+     *            input stream containing the raw file content.
+     * @return true if raw is likely to be a binary file, false otherwise
+     * @throws java.io.IOException
+     *             if input stream could not be read
+     */
+    public static boolean isBinary(InputStream raw) throws IOException {
+        final byte[] buffer = new byte[FIRST_FEW_BYTES];
+        int cnt = 0;
+        while(cnt < buffer.length) {
+            final int n = raw.read(buffer, cnt, buffer.length - cnt);
+            if(n == -1)
+                break;
+            cnt += n;
+        }
+        return isBinary(buffer, cnt);
+    }
+
+    /**
+     * Determine heuristically whether a byte array represents binary (as opposed to text) content.
+     *
+     * @param raw
+     *            the raw file content.
+     * @param length
+     *            number of bytes in {@code raw} to evaluate. This should be {@code raw.length} unless {@code raw} was
+     *            over-allocated by the caller.
+     * @return true if raw is likely to be a binary file, false otherwise
+     */
+    public static boolean isBinary(byte[] raw, int length) {
+        // Same heuristic as C Git
+        if(length > FIRST_FEW_BYTES)
+            length = FIRST_FEW_BYTES;
+        for(int ptr = 0; ptr < length; ptr++)
+            if(raw[ptr] == '\0')
+                return true;
+
+        return false;
+    }
+
+    /**
+     * Determine heuristically whether a byte array represents text content using CR-LF as line separator.
+     *
+     * @param raw
+     *            the raw file content.
+     * @return {@code true} if raw is likely to be CR-LF delimited text, {@code false} otherwise
+     * @since 5.3
+     */
+    public static boolean isCrLfText(byte[] raw) {
+        return isCrLfText(raw, raw.length);
+    }
+
+    /**
+     * Determine heuristically whether the bytes contained in a stream represent text content using CR-LF as line
+     * separator.
+     *
+     * Note: Do not further use this stream after having called this method! The stream may not be fully read and will
+     * be left at an unknown position after consuming an unknown number of bytes. The caller is responsible for closing
+     * the stream.
+     *
+     * @param raw
+     *            input stream containing the raw file content.
+     * @return {@code true} if raw is likely to be CR-LF delimited text, {@code false} otherwise
+     * @throws java.io.IOException
+     *             if input stream could not be read
+     * @since 5.3
+     */
+    public static boolean isCrLfText(InputStream raw) throws IOException {
+        byte[] buffer = new byte[FIRST_FEW_BYTES];
+        int cnt = 0;
+        while(cnt < buffer.length) {
+            int n = raw.read(buffer, cnt, buffer.length - cnt);
+            if(n == -1) {
+                break;
+            }
+            cnt += n;
+        }
+        return isCrLfText(buffer, cnt);
+    }
+
+    /**
+     * Determine heuristically whether a byte array represents text content using CR-LF as line separator.
+     *
+     * @param raw
+     *            the raw file content.
+     * @param length
+     *            number of bytes in {@code raw} to evaluate.
+     * @return {@code true} if raw is likely to be CR-LF delimited text, {@code false} otherwise
+     * @since 5.3
+     */
+    public static boolean isCrLfText(byte[] raw, int length) {
+        boolean has_crlf = false;
+        for(int ptr = 0; ptr < length - 1; ptr++) {
+            if(raw[ptr] == '\0') {
+                return false; // binary
+            } else if(raw[ptr] == '\r' && raw[ptr + 1] == '\n') {
+                has_crlf = true;
+            }
+        }
+        return has_crlf;
+    }
+
+    /**
+     * Get the line delimiter for the first line.
+     *
+     * @since 2.0
+     * @return the line delimiter or <code>null</code>
+     */
+    public String getLineDelimiter() {
+        if(size() == 0)
+            return null;
+        int e = getEnd(0);
+        if(content[e - 1] != '\n')
+            return null;
+        if(content.length > 1 && e > 1 && content[e - 2] == '\r')
+            return "\r\n"; //$NON-NLS-1$
+        else
+            return "\n"; //$NON-NLS-1$
+    }
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawTextComparator.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawTextComparator.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright (C) 2009-2010, Google Inc.
+ * Copyright (C) 2008-2009, Johannes E. Schindelin <johannes.schindelin@gmx.de>
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+import static org.spoofax.jsglr2.incremental.diff.jgit.RawCharUtil.*;
+
+/**
+ * Equivalence function for {@link RawText}.
+ */
+public abstract class RawTextComparator extends SequenceComparator<RawText> {
+	/** No special treatment. */
+	public static final RawTextComparator DEFAULT = new RawTextComparator() {
+		@Override
+		public boolean equals(RawText a, int ai, RawText b, int bi) {
+			ai++;
+			bi++;
+
+			int as = a.lines.get(ai);
+			int bs = b.lines.get(bi);
+			final int ae = a.lines.get(ai + 1);
+			final int be = b.lines.get(bi + 1);
+
+			if (ae - as != be - bs)
+				return false;
+
+			while (as < ae) {
+				if (a.content[as++] != b.content[bs++])
+					return false;
+			}
+			return true;
+		}
+
+		@Override
+		protected int hashRegion(byte[] raw, int ptr, int end) {
+			int hash = 5381;
+			for (; ptr < end; ptr++)
+				hash = ((hash << 5) + hash) + (raw[ptr] & 0xff);
+			return hash;
+		}
+	};
+
+	/** Ignores all whitespace. */
+	public static final RawTextComparator WS_IGNORE_ALL = new RawTextComparator() {
+		@Override
+		public boolean equals(RawText a, int ai, RawText b, int bi) {
+			ai++;
+			bi++;
+
+			int as = a.lines.get(ai);
+			int bs = b.lines.get(bi);
+			int ae = a.lines.get(ai + 1);
+			int be = b.lines.get(bi + 1);
+
+			ae = trimTrailingWhitespace(a.content, as, ae);
+			be = trimTrailingWhitespace(b.content, bs, be);
+
+			while (as < ae && bs < be) {
+				byte ac = a.content[as];
+				byte bc = b.content[bs];
+
+				while (as < ae - 1 && isWhitespace(ac)) {
+					as++;
+					ac = a.content[as];
+				}
+
+				while (bs < be - 1 && isWhitespace(bc)) {
+					bs++;
+					bc = b.content[bs];
+				}
+
+				if (ac != bc)
+					return false;
+
+				as++;
+				bs++;
+			}
+
+			return as == ae && bs == be;
+		}
+
+		@Override
+		protected int hashRegion(byte[] raw, int ptr, int end) {
+			int hash = 5381;
+			for (; ptr < end; ptr++) {
+				byte c = raw[ptr];
+				if (!isWhitespace(c))
+					hash = ((hash << 5) + hash) + (c & 0xff);
+			}
+			return hash;
+		}
+	};
+
+	/**
+	 * Ignore leading whitespace.
+	 **/
+	public static final RawTextComparator WS_IGNORE_LEADING = new RawTextComparator() {
+		@Override
+		public boolean equals(RawText a, int ai, RawText b, int bi) {
+			ai++;
+			bi++;
+
+			int as = a.lines.get(ai);
+			int bs = b.lines.get(bi);
+			int ae = a.lines.get(ai + 1);
+			int be = b.lines.get(bi + 1);
+
+			as = trimLeadingWhitespace(a.content, as, ae);
+			bs = trimLeadingWhitespace(b.content, bs, be);
+
+			if (ae - as != be - bs)
+				return false;
+
+			while (as < ae) {
+				if (a.content[as++] != b.content[bs++])
+					return false;
+			}
+			return true;
+		}
+
+		@Override
+		protected int hashRegion(byte[] raw, int ptr, int end) {
+			int hash = 5381;
+			ptr = trimLeadingWhitespace(raw, ptr, end);
+			for (; ptr < end; ptr++)
+				hash = ((hash << 5) + hash) + (raw[ptr] & 0xff);
+			return hash;
+		}
+	};
+
+	/** Ignores trailing whitespace. */
+	public static final RawTextComparator WS_IGNORE_TRAILING = new RawTextComparator() {
+		@Override
+		public boolean equals(RawText a, int ai, RawText b, int bi) {
+			ai++;
+			bi++;
+
+			int as = a.lines.get(ai);
+			int bs = b.lines.get(bi);
+			int ae = a.lines.get(ai + 1);
+			int be = b.lines.get(bi + 1);
+
+			ae = trimTrailingWhitespace(a.content, as, ae);
+			be = trimTrailingWhitespace(b.content, bs, be);
+
+			if (ae - as != be - bs)
+				return false;
+
+			while (as < ae) {
+				if (a.content[as++] != b.content[bs++])
+					return false;
+			}
+			return true;
+		}
+
+		@Override
+		protected int hashRegion(byte[] raw, int ptr, int end) {
+			int hash = 5381;
+			end = trimTrailingWhitespace(raw, ptr, end);
+			for (; ptr < end; ptr++)
+				hash = ((hash << 5) + hash) + (raw[ptr] & 0xff);
+			return hash;
+		}
+	};
+
+	/** Ignores whitespace occurring between non-whitespace characters. */
+	public static final RawTextComparator WS_IGNORE_CHANGE = new RawTextComparator() {
+		@Override
+		public boolean equals(RawText a, int ai, RawText b, int bi) {
+			ai++;
+			bi++;
+
+			int as = a.lines.get(ai);
+			int bs = b.lines.get(bi);
+			int ae = a.lines.get(ai + 1);
+			int be = b.lines.get(bi + 1);
+
+			ae = trimTrailingWhitespace(a.content, as, ae);
+			be = trimTrailingWhitespace(b.content, bs, be);
+
+			while (as < ae && bs < be) {
+				byte ac = a.content[as];
+				byte bc = b.content[bs];
+
+				if (ac != bc)
+					return false;
+
+				if (isWhitespace(ac))
+					as = trimLeadingWhitespace(a.content, as, ae);
+				else
+					as++;
+
+				if (isWhitespace(bc))
+					bs = trimLeadingWhitespace(b.content, bs, be);
+				else
+					bs++;
+			}
+			return as == ae && bs == be;
+		}
+
+		@Override
+		protected int hashRegion(byte[] raw, int ptr, int end) {
+			int hash = 5381;
+			end = trimTrailingWhitespace(raw, ptr, end);
+			while (ptr < end) {
+				byte c = raw[ptr];
+				hash = ((hash << 5) + hash) + (c & 0xff);
+				if (isWhitespace(c))
+					ptr = trimLeadingWhitespace(raw, ptr, end);
+				else
+					ptr++;
+			}
+			return hash;
+		}
+	};
+
+	@Override
+	public int hash(RawText seq, int lno) {
+		final int begin = seq.lines.get(lno + 1);
+		final int end = seq.lines.get(lno + 2);
+		return hashRegion(seq.content, begin, end);
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public Edit reduceCommonStartEnd(RawText a, RawText b, Edit e) {
+		// This is a faster exact match based form that tries to improve
+		// performance for the common case of the header and trailer of
+		// a text file not changing at all. After this fast path we use
+		// the slower path based on the super class' using equals() to
+		// allow for whitespace ignore modes to still work.
+
+		if (e.beginA == e.endA || e.beginB == e.endB)
+			return e;
+
+		byte[] aRaw = a.content;
+		byte[] bRaw = b.content;
+
+		int aPtr = a.lines.get(e.beginA + 1);
+		int bPtr = a.lines.get(e.beginB + 1);
+
+		int aEnd = a.lines.get(e.endA + 1);
+		int bEnd = b.lines.get(e.endB + 1);
+
+		// This can never happen, but the JIT doesn't know that. If we
+		// define this assertion before the tight while loops below it
+		// should be able to skip the array bound checks on access.
+		//
+		if (aPtr < 0 || bPtr < 0 || aEnd > aRaw.length || bEnd > bRaw.length)
+			throw new ArrayIndexOutOfBoundsException();
+
+		while (aPtr < aEnd && bPtr < bEnd && aRaw[aPtr] == bRaw[bPtr]) {
+			aPtr++;
+			bPtr++;
+		}
+
+		while (aPtr < aEnd && bPtr < bEnd && aRaw[aEnd - 1] == bRaw[bEnd - 1]) {
+			aEnd--;
+			bEnd--;
+		}
+
+		e.beginA = findForwardLine(a.lines, e.beginA, aPtr);
+		e.beginB = findForwardLine(b.lines, e.beginB, bPtr);
+
+		e.endA = findReverseLine(a.lines, e.endA, aEnd);
+
+		final boolean partialA = aEnd < a.lines.get(e.endA + 1);
+		if (partialA)
+			bEnd += a.lines.get(e.endA + 1) - aEnd;
+
+		e.endB = findReverseLine(b.lines, e.endB, bEnd);
+
+		if (!partialA && bEnd < b.lines.get(e.endB + 1))
+			e.endA++;
+
+		return super.reduceCommonStartEnd(a, b, e);
+	}
+
+	private static int findForwardLine(IntList lines, int idx, int ptr) {
+		final int end = lines.size() - 2;
+		while (idx < end && lines.get(idx + 2) < ptr)
+			idx++;
+		return idx;
+	}
+
+	private static int findReverseLine(IntList lines, int idx, int ptr) {
+		while (0 < idx && ptr <= lines.get(idx))
+			idx--;
+		return idx;
+	}
+
+	/**
+	 * Compute a hash code for a region.
+	 *
+	 * @param raw
+	 *            the raw file content.
+	 * @param ptr
+	 *            first byte of the region to hash.
+	 * @param end
+	 *            1 past the last byte of the region.
+	 * @return hash code for the region <code>[ptr, end)</code> of raw.
+	 */
+	protected abstract int hashRegion(byte[] raw, int ptr, int end);
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/Sequence.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/Sequence.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * Copyright (C) 2008-2009, Johannes E. Schindelin <johannes.schindelin@gmx.de>
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Arbitrary sequence of elements.
+ * <p>
+ * A sequence of elements is defined to contain elements in the index range
+ * <code>[0, {@link #size()})</code>, like a standard Java List implementation.
+ * Unlike a List, the members of the sequence are not directly obtainable.
+ * <p>
+ * Implementations of Sequence are primarily intended for use in content
+ * difference detection algorithms, to produce an
+ * {@link org.eclipse.jgit.diff.EditList} of {@link org.eclipse.jgit.diff.Edit}
+ * instances describing how two Sequence instances differ.
+ * <p>
+ * To be compared against another Sequence of the same type, a supporting
+ * {@link org.eclipse.jgit.diff.SequenceComparator} must also be supplied.
+ */
+public abstract class Sequence {
+	/** @return total number of items in the sequence. */
+	/**
+	 * Get size
+	 *
+	 * @return size
+	 */
+	public abstract int size();
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/SequenceComparator.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/SequenceComparator.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Equivalence function for a {@link org.eclipse.jgit.diff.Sequence} compared by
+ * difference algorithm.
+ * <p>
+ * Difference algorithms can use a comparator to compare portions of two
+ * sequences and discover the minimal edits required to transform from one
+ * sequence to the other sequence.
+ * <p>
+ * Indexes within a sequence are zero-based.
+ *
+ * @param <S>
+ *            type of sequence the comparator supports.
+ */
+public abstract class SequenceComparator<S extends Sequence> {
+	/**
+	 * Compare two items to determine if they are equivalent.
+	 *
+	 * It is permissible to compare sequence {@code a} with itself (by passing
+	 * {@code a} again in position {@code b}).
+	 *
+	 * @param a
+	 *            the first sequence.
+	 * @param ai
+	 *            item of {@code ai} to compare.
+	 * @param b
+	 *            the second sequence.
+	 * @param bi
+	 *            item of {@code bi} to compare.
+	 * @return true if the two items are identical according to this function's
+	 *         equivalence rule.
+	 */
+	public abstract boolean equals(S a, int ai, S b, int bi);
+
+	/**
+	 * Get a hash value for an item in a sequence.
+	 *
+	 * If two items are equal according to this comparator's
+	 * {@link #equals(Sequence, int, Sequence, int)} method, then this hash
+	 * method must produce the same integer result for both items.
+	 *
+	 * It is not required for two items to have different hash values if they
+	 * are unequal according to the {@code equals()} method.
+	 *
+	 * @param seq
+	 *            the sequence.
+	 * @param ptr
+	 *            the item to obtain the hash for.
+	 * @return hash the hash value.
+	 */
+	public abstract int hash(S seq, int ptr);
+
+	/**
+	 * Modify the edit to remove common leading and trailing items.
+	 *
+	 * The supplied edit {@code e} is reduced in size by moving the beginning A
+	 * and B points so the edit does not cover any items that are in common
+	 * between the two sequences. The ending A and B points are also shifted to
+	 * remove common items from the end of the region.
+	 *
+	 * @param a
+	 *            the first sequence.
+	 * @param b
+	 *            the second sequence.
+	 * @param e
+	 *            the edit to start with and update.
+	 * @return {@code e} if it was updated in-place, otherwise a new edit
+	 *         containing the reduced region.
+	 */
+	public Edit reduceCommonStartEnd(S a, S b, Edit e) {
+		// Skip over items that are common at the start.
+		//
+		while (e.beginA < e.endA && e.beginB < e.endB
+				&& equals(a, e.beginA, b, e.beginB)) {
+			e.beginA++;
+			e.beginB++;
+		}
+
+		// Skip over items that are common at the end.
+		//
+		while (e.beginA < e.endA && e.beginB < e.endB
+				&& equals(a, e.endA - 1, b, e.endB - 1)) {
+			e.endA--;
+			e.endB--;
+		}
+
+		return e;
+	}
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/Subsequence.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/Subsequence.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Wraps a {@link org.eclipse.jgit.diff.Sequence} to have a narrower range of
+ * elements.
+ * <p>
+ * This sequence acts as a proxy for the real sequence, translating element
+ * indexes on the fly by adding {@code begin} to them. Sequences of this type
+ * must be used with a {@link org.eclipse.jgit.diff.SubsequenceComparator}.
+ *
+ * @param <S>
+ *            the base sequence type.
+ */
+public final class Subsequence<S extends Sequence> extends Sequence {
+	/**
+	 * Construct a subsequence around the A region/base sequence.
+	 *
+	 * @param a
+	 *            the A sequence.
+	 * @param region
+	 *            the region of {@code a} to create a subsequence around.
+	 * @return subsequence of {@code base} as described by A in {@code region}.
+	 */
+	public static <S extends Sequence> Subsequence<S> a(S a, Edit region) {
+		return new Subsequence<>(a, region.beginA, region.endA);
+	}
+
+	/**
+	 * Construct a subsequence around the B region/base sequence.
+	 *
+	 * @param b
+	 *            the B sequence.
+	 * @param region
+	 *            the region of {@code b} to create a subsequence around.
+	 * @return subsequence of {@code base} as described by B in {@code region}.
+	 */
+	public static <S extends Sequence> Subsequence<S> b(S b, Edit region) {
+		return new Subsequence<>(b, region.beginB, region.endB);
+	}
+
+	/**
+	 * Adjust the Edit to reflect positions in the base sequence.
+	 *
+	 * @param e
+	 *            edit to adjust in-place. Prior to invocation the indexes are
+	 *            in terms of the two subsequences; after invocation the indexes
+	 *            are in terms of the base sequences.
+	 * @param a
+	 *            the A sequence.
+	 * @param b
+	 *            the B sequence.
+	 */
+	public static <S extends Sequence> void toBase(Edit e, Subsequence<S> a,
+			Subsequence<S> b) {
+		e.beginA += a.begin;
+		e.endA += a.begin;
+
+		e.beginB += b.begin;
+		e.endB += b.begin;
+	}
+
+	/**
+	 * Adjust the Edits to reflect positions in the base sequence.
+	 *
+	 * @param edits
+	 *            edits to adjust in-place. Prior to invocation the indexes are
+	 *            in terms of the two subsequences; after invocation the indexes
+	 *            are in terms of the base sequences.
+	 * @param a
+	 *            the A sequence.
+	 * @param b
+	 *            the B sequence.
+	 * @return always {@code edits} (as the list was updated in-place).
+	 */
+	public static <S extends Sequence> EditList toBase(EditList edits,
+			Subsequence<S> a, Subsequence<S> b) {
+		for (Edit e : edits)
+			toBase(e, a, b);
+		return edits;
+	}
+
+	final S base;
+
+	final int begin;
+
+	private final int size;
+
+	/**
+	 * Construct a subset of another sequence.
+	 *
+	 * The size of the subsequence will be {@code end - begin}.
+	 *
+	 * @param base
+	 *            the real sequence.
+	 * @param begin
+	 *            First element index of {@code base} that will be part of this
+	 *            new subsequence. The element at {@code begin} will be this
+	 *            sequence's element 0.
+	 * @param end
+	 *            One past the last element index of {@code base} that will be
+	 *            part of this new subsequence.
+	 */
+	public Subsequence(S base, int begin, int end) {
+		this.base = base;
+		this.begin = begin;
+		this.size = end - begin;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public int size() {
+		return size;
+	}
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/SubsequenceComparator.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/SubsequenceComparator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2010, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spoofax.jsglr2.incremental.diff.jgit;
+
+/**
+ * Wrap another comparator for use with
+ * {@link org.eclipse.jgit.diff.Subsequence}.
+ * <p>
+ * This comparator acts as a proxy for the real comparator, translating element
+ * indexes on the fly by adding the subsequence's begin offset to them.
+ * Comparators of this type must be used with a
+ * {@link org.eclipse.jgit.diff.Subsequence}.
+ *
+ * @param <S>
+ *            the base sequence type.
+ */
+public final class SubsequenceComparator<S extends Sequence> extends
+		SequenceComparator<Subsequence<S>> {
+	private final SequenceComparator<? super S> cmp;
+
+	/**
+	 * Construct a comparator wrapping another comparator.
+	 *
+	 * @param cmp
+	 *            the real comparator.
+	 */
+	public SubsequenceComparator(SequenceComparator<? super S> cmp) {
+		this.cmp = cmp;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public boolean equals(Subsequence<S> a, int ai, Subsequence<S> b, int bi) {
+		return cmp.equals(a.base, ai + a.begin, b.base, bi + b.begin);
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public int hash(Subsequence<S> seq, int ptr) {
+		return cmp.hash(seq.base, ptr + seq.begin);
+	}
+}

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiffTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiffTest.java
@@ -14,6 +14,9 @@ public class JGitHistogramDiffTest {
         assertEquals(asList(new EditorUpdate(2, 4, "fghij")), diff.diff("abcde", "abfghije"));
         assertEquals(asList(), diff.diff("abcde", "abcde"));
         assertEquals(asList(new EditorUpdate(0, 5, "fghij")), diff.diff("abcde", "fghij"));
+        assertEquals(asList(new EditorUpdate(0, 0, "xyz")), diff.diff("abcde", "xyzabcde"));
+        assertEquals(asList(new EditorUpdate(5, 5, "xyz")), diff.diff("abcde", "abcdexyz"));
+        assertEquals(asList(new EditorUpdate(3, 4, "*")), diff.diff("x+x+x", "x+x*x"));
         assertEquals(asList(new EditorUpdate(1, 3, "uvw"), new EditorUpdate(12, 12, "xyz")),
             diff.diff("abcde\nfghij\nklmno", "auvwde\nfghij\nxyzklmno"));
     }

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiffTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiffTest.java
@@ -1,0 +1,21 @@
+package org.spoofax.jsglr2.incremental.diff;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.spoofax.jsglr2.incremental.EditorUpdate;
+
+public class JGitHistogramDiffTest {
+
+    private final JGitHistogramDiff diff = new JGitHistogramDiff();
+
+    @Test public void testDiff() {
+        assertEquals(asList(new EditorUpdate(2, 4, "fghij")), diff.diff("abcde", "abfghije"));
+        assertEquals(asList(), diff.diff("abcde", "abcde"));
+        assertEquals(asList(new EditorUpdate(0, 5, "fghij")), diff.diff("abcde", "fghij"));
+        assertEquals(asList(new EditorUpdate(1, 3, "uvw"), new EditorUpdate(12, 12, "xyz")),
+            diff.diff("abcde\nfghij\nklmno", "auvwde\nfghij\nxyzklmno"));
+    }
+
+}

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdatesTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdatesTest.java
@@ -1,0 +1,143 @@
+package org.spoofax.jsglr2.incremental.diff;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.spoofax.jsglr2.incremental.EditorUpdate;
+import org.spoofax.jsglr2.incremental.IncrementalParse;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.parser.observing.ParserObserving;
+import org.spoofax.jsglr2.stack.collections.ActiveStacksFactory;
+import org.spoofax.jsglr2.stack.collections.ForActorStacksFactory;
+
+public class ProcessUpdatesTest {
+
+    private final ProcessUpdates<?> processUpdates = new ProcessUpdates<>(new IncrementalParse<>("", "",
+        new ActiveStacksFactory(), new ForActorStacksFactory(), new ParserObserving<>()));
+
+    @Test public void testDeleteSubtree() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3), node(4, 5));
+
+        IncrementalParseNode expected = node(node(0, 1), node(4, 5));
+
+        testUpdate(previous, expected, new EditorUpdate(2, 4, ""));
+    }
+
+    @Test public void testPrepend() {
+        IncrementalParseNode previous = node(node(0), node(1, 2));
+
+        IncrementalParseNode expected = node(node(node(4, 5), node(0)), node(1, 2));
+
+        testUpdate(previous, expected, new EditorUpdate(0, 0, "\4\5"));
+    }
+
+    @Test public void testPrependBeforeEmpty() {
+        IncrementalParseNode previous = node(node(), node(0), node(1, 2));
+
+        IncrementalParseNode expected = node(node(node(4, 5), node(0)), node(1, 2));
+
+        testUpdate(previous, expected, new EditorUpdate(0, 0, "\4\5"));
+    }
+
+    @Test public void testAppend() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3));
+
+        IncrementalParseNode expected = node(node(0, 1), node(node(2), node(node(3), node(4, 5))));
+
+        testUpdate(previous, expected, new EditorUpdate(4, 4, "\4\5"));
+    }
+
+    @Test public void testAppendBeforeEmpty() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3), node());
+
+        IncrementalParseNode expected = node(node(0, 1), node(node(2), node(node(3), node(4, 5))), node());
+
+        testUpdate(previous, expected, new EditorUpdate(4, 4, "\4\5"));
+    }
+
+    @Test public void testInsert() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3));
+
+        IncrementalParseNode expected = node(node(node(0), node(node(1), node(4, 5))), node(2, 3));
+
+        testUpdate(previous, expected, new EditorUpdate(2, 2, "\4\5"));
+    }
+
+    @Test public void testReplace() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3));
+
+        IncrementalParseNode expected = node(node(node(0), node(4, 5)), node(2, 3));
+
+        testUpdate(previous, expected, new EditorUpdate(1, 2, "\4\5"));
+    }
+
+    @Test public void testReplaceFirst() {
+        IncrementalParseNode previous = node(node(0, 1), node(2, 3));
+
+        IncrementalParseNode expected = node(node(node(4, 5, 6), node(1)), node(2, 3));
+
+        testUpdate(previous, expected, new EditorUpdate(0, 1, "\4\5\6"));
+    }
+
+    @Test public void testReplaceFirstAfterEmpty() {
+        IncrementalParseNode previous = node(node(), node(0, 1), node(2, 3));
+
+        IncrementalParseNode expected = node(node(node(4, 5, 6), node(1)), node(2, 3));
+
+        testUpdate(previous, expected, new EditorUpdate(0, 1, "\4\5\6"));
+    }
+
+    @Test public void testReplaceEnd() {
+        IncrementalParseNode previous = node(node(node(0, 1), node(2)), node(3));
+
+        IncrementalParseNode expected = node(node(node(0, 1), node(4, 5, 6)));
+
+        testUpdate(previous, expected, new EditorUpdate(2, 4, "\4\5\6"));
+    }
+
+    @Test public void testReplaceMultipleWithGap() {
+        IncrementalParseNode previous = node(node(node(0, 1), node(2)), node(3));
+
+        IncrementalParseNode expected =
+            node(node(node(node(0), node(4, 5)), node(2)), node(6, 7));
+
+        testUpdate(previous, expected, new EditorUpdate(1, 2, "\4\5"), new EditorUpdate(3, 4, "\6\7"));
+    }
+
+    @Test public void testReplaceMultipleWithoutGap() {
+        IncrementalParseNode previous = node(node(node(0, 1), node(2)), node(3));
+
+        IncrementalParseNode expected =
+                node(node(node(node(0), node(4, 5)), node(6, 7)), node(3));
+
+        testUpdate(previous, expected, new EditorUpdate(1, 2, "\4\5"), new EditorUpdate(2, 3, "\6\7"));
+    }
+
+
+    private void testUpdate(IncrementalParseNode previous, IncrementalParseNode expected, EditorUpdate... updates) {
+        assertEquals(expected.toString(), processUpdates.processUpdates(previous, updates).toString());
+    }
+
+    private static IncrementalCharacterNode node(int i) {
+        return new IncrementalCharacterNode(i);
+    }
+
+    private static IncrementalParseNode node(int... characters) {
+        IncrementalParseForest[] children = new IncrementalParseForest[characters.length];
+        for(int i = 0; i < characters.length; i++) {
+            children[i] = node(characters[i]);
+        }
+        return new IncrementalParseNode(children);
+    }
+
+    private static IncrementalParseNode node(IncrementalParseForest... children) {
+        return new IncrementalParseNode(children);
+    }
+
+    private static IncrementalParseNode node() {
+        return new IncrementalParseNode();
+    }
+
+}

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/SingleDiffTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/SingleDiffTest.java
@@ -13,7 +13,10 @@ public class SingleDiffTest {
         assertEquals(new EditorUpdate(2, 4, "fghij"), diff.diff("abcde", "abfghije").get(0));
         assertEquals(new EditorUpdate(5, 5, ""), diff.diff("abcde", "abcde").get(0));
         assertEquals(new EditorUpdate(0, 5, "fghij"), diff.diff("abcde", "fghij").get(0));
-        assertEquals(new EditorUpdate(1, 12, "uvw\nfghij\nxyz"),
+        assertEquals(new EditorUpdate(0, 0, "xyz"), diff.diff("abcde", "xyzabcde").get(0));
+        assertEquals(new EditorUpdate(5, 5, "xyz"), diff.diff("abcde", "abcdexyz").get(0));
+        assertEquals(new EditorUpdate(3, 4, "*"), diff.diff("x+x+x", "x+x*x").get(0));
+        assertEquals(new EditorUpdate(1, 12, "uvwde\nfghij\nxyz"),
             diff.diff("abcde\nfghij\nklmno", "auvwde\nfghij\nxyzklmno").get(0));
     }
 

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/SingleDiffTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/SingleDiffTest.java
@@ -7,9 +7,14 @@ import org.spoofax.jsglr2.incremental.EditorUpdate;
 
 public class SingleDiffTest {
 
+    private final SingleDiff diff = new SingleDiff();
+
     @Test public void testDiff() {
-        assertEquals(new EditorUpdate(2, 4, "fghij"), new SingleDiff().diff("abcde", "abfghije").get(0));
-        assertEquals(new EditorUpdate(5, 5, ""), new SingleDiff().diff("abcde", "abcde").get(0));
-        assertEquals(new EditorUpdate(0, 5, "fghij"), new SingleDiff().diff("abcde", "fghij").get(0));
+        assertEquals(new EditorUpdate(2, 4, "fghij"), diff.diff("abcde", "abfghije").get(0));
+        assertEquals(new EditorUpdate(5, 5, ""), diff.diff("abcde", "abcde").get(0));
+        assertEquals(new EditorUpdate(0, 5, "fghij"), diff.diff("abcde", "fghij").get(0));
+        assertEquals(new EditorUpdate(1, 12, "uvw\nfghij\nxyz"),
+            diff.diff("abcde\nfghij\nklmno", "auvwde\nfghij\nxyzklmno").get(0));
     }
+
 }


### PR DESCRIPTION
(I couldn't re-open #42 because I have rebased this branch.)

This PR improves the calculating of the text diff and applying that to the parse forest in several ways.

- Processing `EditorUpdate`s has been moved from several methods in `IncrementalParse` to its own class called `ProcessUpdates`.
- A new diffing algorithm has been added, taken from [JGit](http://download.eclipse.org/jgit/site/5.3.0.201903130848-r/org.eclipse.jgit/apidocs/index.html?org/eclipse/jgit/diff/HistogramDiff.html).
  - This diffing algorithm allows multiple changes in one file to be identified.
  - A small adapter has been written around this algorithm to make it return a list of `EditorUpdate`s.
  - **New compared to #42:** the code of JGit has been copied into a sub-package of this repository to avoid having an extra dependency. It is still possible to reduce the amount of code there which will also remove the need of having an adapter, but that's not my priority right now (I did add a `TODO` comment though).
- `ProcessUpdates` will now correctly apply a list of `EditorUpdate`s to the old parse forest, instead of looking only at the first update.
- Some tests have been added to verify that it all works correctly.	