### PR TITLE
Reduce duplicate code in incremental imploder

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeStrategoTermImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeStrategoTermImploder.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.imploder;
 
 import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.jsglr2.imploder.input.ImplodeInput;
 import org.spoofax.jsglr2.imploder.treefactory.StrategoTermTreeFactory;
 import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
@@ -12,10 +13,10 @@ public class IterativeStrategoTermImploder
     ParseNode   extends IParseNode<ParseForest, Derivation>,
     Derivation  extends IDerivation<ParseForest>>
 //@formatter:on
-    extends IterativeTreeImploder<ParseForest, ParseNode, Derivation, IStrategoTerm> {
+    extends IterativeTreeImploder<ParseForest, ParseNode, Derivation, IStrategoTerm, ImplodeInput> {
 
     public IterativeStrategoTermImploder() {
-        super(new StrategoTermTreeFactory());
+        super(ImplodeInput::new, new StrategoTermTreeFactory());
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeImploder.java
@@ -10,6 +10,8 @@ import java.util.stream.Collectors;
 
 import org.metaborg.parsetable.IProduction;
 import org.metaborg.util.iterators.Iterables2;
+import org.spoofax.jsglr2.imploder.input.IImplodeInputFactory;
+import org.spoofax.jsglr2.imploder.input.ImplodeInput;
 import org.spoofax.jsglr2.imploder.treefactory.ITreeFactory;
 import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
@@ -22,12 +24,13 @@ public class IterativeTreeImploder
    <ParseForest extends IParseForest,
     ParseNode   extends IParseNode<ParseForest, Derivation>,
     Derivation  extends IDerivation<ParseForest>,
-    Tree>
+    Tree,
+    Input       extends ImplodeInput>
 //@formatter:on
-    extends TreeImploder<ParseForest, ParseNode, Derivation, Tree> {
+    extends TreeImploder<ParseForest, ParseNode, Derivation, Tree, Input> {
 
-    public IterativeTreeImploder(ITreeFactory<Tree> treeFactory) {
-        super(treeFactory);
+    public IterativeTreeImploder(IImplodeInputFactory<Input> inputFactory, ITreeFactory<Tree> treeFactory) {
+        super(inputFactory, treeFactory);
     }
 
     private class PseudoNode {
@@ -44,7 +47,7 @@ public class IterativeTreeImploder
         }
     }
 
-    @Override protected SubTree<Tree> implodeParseNode(String inputString, ParseNode rootNode, int startOffset) {
+    @Override protected SubTree<Tree> implodeParseNode(Input input, ParseNode rootNode, int startOffset) {
         // This stack contains the parse nodes that we still need to process
         Stack<PseudoNode> parseNodeStack = new Stack<>();
         // These stack elements contain: one list for each derivation, and per derivation: one list for all subtrees.
@@ -86,7 +89,7 @@ public class IterativeTreeImploder
                 IProduction production = parseNode.production();
                 if(!production.isContextFree()) { // If the current parse node is a lexical node
                     SubTree<Tree> lexicalSubTree =
-                        createLexicalSubTree(inputString, parseNode, pseudoNode.pivotOffset, production);
+                        createLexicalSubTree(input.inputString, parseNode, pseudoNode.pivotOffset, production);
                     currentOut.getLast().add(lexicalSubTree); // Add a new SubTree to the output
                     pseudoNode.pivotOffset += lexicalSubTree.width;
                 } else { // If the current parse node is a context-free node

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/StrategoTermImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/StrategoTermImploder.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.imploder;
 
 import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.jsglr2.imploder.input.ImplodeInput;
 import org.spoofax.jsglr2.imploder.treefactory.StrategoTermTreeFactory;
 import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
@@ -12,10 +13,10 @@ public class StrategoTermImploder
     ParseNode   extends IParseNode<ParseForest, Derivation>,
     Derivation  extends IDerivation<ParseForest>>
 //@formatter:on
-    extends TreeImploder<ParseForest, ParseNode, Derivation, IStrategoTerm> {
+    extends TreeImploder<ParseForest, ParseNode, Derivation, IStrategoTerm, ImplodeInput> {
 
     public StrategoTermImploder() {
-        super(new StrategoTermTreeFactory());
+        super(ImplodeInput::new, new StrategoTermTreeFactory());
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IIncrementalImplodeInputFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IIncrementalImplodeInputFactory.java
@@ -1,0 +1,12 @@
+package org.spoofax.jsglr2.imploder.incremental;
+
+import java.util.WeakHashMap;
+
+import org.spoofax.jsglr2.imploder.TreeImploder;
+import org.spoofax.jsglr2.parseforest.IParseNode;
+
+public interface IIncrementalImplodeInputFactory<ParseNode extends IParseNode, Tree, Input extends IncrementalImplodeInput<ParseNode, Tree>> {
+
+    Input get(String inputString, WeakHashMap<ParseNode, TreeImploder.SubTree<Tree>> cache);
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalImplodeInput.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalImplodeInput.java
@@ -1,0 +1,18 @@
+package org.spoofax.jsglr2.imploder.incremental;
+
+import java.util.WeakHashMap;
+
+import org.spoofax.jsglr2.imploder.TreeImploder;
+import org.spoofax.jsglr2.imploder.input.ImplodeInput;
+import org.spoofax.jsglr2.parseforest.IParseNode;
+
+class IncrementalImplodeInput<ParseNode extends IParseNode, Tree> extends ImplodeInput {
+
+    final WeakHashMap<ParseNode, TreeImploder.SubTree<Tree>> resultCache;
+
+    IncrementalImplodeInput(String inputString, WeakHashMap<ParseNode, TreeImploder.SubTree<Tree>> resultCache) {
+        super(inputString);
+        this.resultCache = resultCache;
+    }
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalStrategoTermImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalStrategoTermImploder.java
@@ -12,10 +12,12 @@ public class IncrementalStrategoTermImploder
     ParseNode   extends IParseNode<ParseForest, Derivation>,
     Derivation  extends IDerivation<ParseForest>>
 //@formatter:on
-    extends IncrementalTreeImploder<ParseForest, ParseNode, Derivation, IStrategoTerm> {
+    extends
+    IncrementalTreeImploder<ParseForest, ParseNode, Derivation, IStrategoTerm, IncrementalImplodeInput<ParseNode, IStrategoTerm>> {
 
     public IncrementalStrategoTermImploder() {
-        super(new StrategoTermTreeFactory());
+        super(inputString -> new IncrementalImplodeInput<>(inputString, null), IncrementalImplodeInput::new,
+            new StrategoTermTreeFactory());
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalTreeImploder.java
@@ -1,9 +1,11 @@
 package org.spoofax.jsglr2.imploder.incremental;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.WeakHashMap;
 
-import org.metaborg.parsetable.IProduction;
 import org.spoofax.jsglr2.imploder.TreeImploder;
+import org.spoofax.jsglr2.imploder.input.IImplodeInputFactory;
 import org.spoofax.jsglr2.imploder.treefactory.ITreeFactory;
 import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
@@ -12,92 +14,46 @@ import org.spoofax.jsglr2.parseforest.IParseNode;
 public abstract class IncrementalTreeImploder
 //@formatter:off
    <ParseForest extends IParseForest,
-    ParseNode extends IParseNode<ParseForest, Derivation>,
-    Derivation extends IDerivation<ParseForest>,
-    Tree>
+    ParseNode   extends IParseNode<ParseForest, Derivation>,
+    Derivation  extends IDerivation<ParseForest>,
+    Tree,
+    Input       extends IncrementalImplodeInput<ParseNode, Tree>>
 //@formatter:on
-    extends TreeImploder<ParseForest, ParseNode, Derivation, Tree> {
+    extends TreeImploder<ParseForest, ParseNode, Derivation, Tree, Input> {
 
-    private Map<String, WeakHashMap<ParseNode, SubTree<Tree>>> cache = new HashMap<>();
+    private final IIncrementalImplodeInputFactory<ParseNode, Tree, Input> incrementalInputFactory;
+    private final TreeImploder<ParseForest, ParseNode, Derivation, Tree, Input> regularImplode;
+    private final Map<String, WeakHashMap<ParseNode, SubTree<Tree>>> cache = new HashMap<>();
 
-    public IncrementalTreeImploder(ITreeFactory<Tree> treeFactory) {
-        super(treeFactory);
+    public IncrementalTreeImploder(IImplodeInputFactory<Input> inputFactory,
+        IIncrementalImplodeInputFactory<ParseNode, Tree, Input> incrementalInputFactory,
+        ITreeFactory<Tree> treeFactory) {
+        super(inputFactory, treeFactory);
+        this.regularImplode = new TreeImploder<>(inputFactory, treeFactory);
+        this.incrementalInputFactory = incrementalInputFactory;
     }
 
     @Override public SubTree<Tree> implode(String inputString, String filename, ParseForest parseForest) {
-        @SuppressWarnings("unchecked") ParseNode topParseNode = (ParseNode) parseForest;
-
         if(filename.equals("")) {
-            return implodeParseNode(inputString, topParseNode, 0);
+            return regularImplode.implode(inputString, filename, parseForest);
         }
+
+        @SuppressWarnings("unchecked") ParseNode topParseNode = (ParseNode) parseForest;
 
         if(!cache.containsKey(filename)) {
             cache.put(filename, new WeakHashMap<>());
         }
 
-        return implodeParseNode(inputString, topParseNode, 0, cache.get(filename));
+        return implodeParseNode(incrementalInputFactory.get(inputString, cache.get(filename)), topParseNode, 0);
     }
 
-    // Implementation note: the code in implodeParseNode and implodeDerivation is exactly equal to the superclass,
-    // except for the usage of the cache. Since it's an extra parameter that needs to be passed and the changes are
-    // nested deeply, it's not easy to reuse code, unfortunately...
-    private SubTree<Tree> implodeParseNode(String inputString, ParseNode parseNode, int startOffset,
-        WeakHashMap<ParseNode, SubTree<Tree>> oldResult) {
-        if(oldResult.containsKey(parseNode))
-            return oldResult.get(parseNode);
+    @Override protected SubTree<Tree> implodeParseNode(Input input, ParseNode parseNode, int startOffset) {
+        if(input.resultCache.containsKey(parseNode))
+            return input.resultCache.get(parseNode);
 
-        IProduction production = parseNode.production();
-
-        if(production.isContextFree()) {
-            List<Derivation> filteredDerivations = applyDisambiguationFilters(parseNode);
-
-            if(filteredDerivations.size() > 1) {
-                List<Tree> trees = new ArrayList<>(filteredDerivations.size());
-                List<SubTree<Tree>> subTrees = new ArrayList<>(filteredDerivations.size());
-
-                for(Derivation derivation : filteredDerivations) {
-                    SubTree<Tree> result = implodeDerivation(inputString, derivation, startOffset, oldResult);
-                    trees.add(result.tree);
-                    subTrees.add(result);
-                }
-
-                return new SubTree<>(treeFactory.createAmb(production.sort(), trees), subTrees, null, null,
-                    subTrees.get(0).width);
-            } else
-                return implodeDerivation(inputString, filteredDerivations.get(0), startOffset, oldResult);
-        } else {
-            String substring = inputString.substring(startOffset, startOffset + parseNode.width());
-
-            return new SubTree<>(createLexicalTerm(production, substring), production, substring);
-        }
-    }
-
-    private SubTree<Tree> implodeDerivation(String inputString, Derivation derivation, int startOffset,
-        WeakHashMap<ParseNode, SubTree<Tree>> oldResult) {
-        IProduction production = derivation.production();
-
-        if(!production.isContextFree())
-            throw new RuntimeException("non context free imploding not supported");
-
-        List<Tree> childASTs = new ArrayList<>();
-        List<SubTree<Tree>> subTrees = new ArrayList<>();
-
-        for(ParseForest childParseForest : getChildParseForests(derivation)) {
-            if(childParseForest != null) { // Can be null in the case of a layout subtree parse node that is not created
-                @SuppressWarnings("unchecked") ParseNode childParseNode = (ParseNode) childParseForest;
-
-                SubTree<Tree> subTree = implodeParseNode(inputString, childParseNode, startOffset, oldResult);
-                oldResult.put(childParseNode, subTree);
-
-                if(subTree.tree != null) {
-                    childASTs.add(subTree.tree);
-                }
-                subTrees.add(subTree);
-                startOffset += subTree.width;
-            }
-        }
-
-        return new SubTree<>(createContextFreeTerm(production, childASTs), subTrees, derivation.production());
+        SubTree<Tree> result = super.implodeParseNode(input, parseNode, startOffset);
+        input.resultCache.put(parseNode, result);
+        return result;
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/input/IImplodeInputFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/input/IImplodeInputFactory.java
@@ -1,0 +1,7 @@
+package org.spoofax.jsglr2.imploder.input;
+
+public interface IImplodeInputFactory<Input extends ImplodeInput> {
+
+    Input get(String inputString);
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/input/ImplodeInput.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/input/ImplodeInput.java
@@ -1,0 +1,11 @@
+package org.spoofax.jsglr2.imploder.input;
+
+public class ImplodeInput {
+
+    public final String inputString;
+
+    public ImplodeInput(String inputString) {
+        this.inputString = inputString;
+    }
+
+}


### PR DESCRIPTION
Instead of adding an extra parameter to `implodeParseNode` and `implodeDerivation`, the first input parameter is now a generic object that can contain whichever input needs to be passed to these methods.

For the regular imploder, this object (of class `ImplodeInput`) will only contain the input string. For the incremental imploder, this object (of class `IncrementalImplodeInput`) will also contain the `WeakHashMap` that is used as cache.

To properly override `implodeParseNode` in `IncrementalTreeImploder`, the type of the input object needs to be a type parameter of the class. Because of this, there needs to be a factory that creates the input object.