### PR TITLE
Make sure parse tables are only created once in integration test

### DIFF
--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/ParseTableVariant.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/ParseTableVariant.java
@@ -1,5 +1,7 @@
 package org.spoofax.jsglr2.integration;
 
+import java.util.Objects;
+
 import org.metaborg.sdf2table.parsetable.query.ActionsForCharacterRepresentation;
 import org.metaborg.sdf2table.parsetable.query.ProductionToGotoRepresentation;
 
@@ -17,6 +19,10 @@ public class ParseTableVariant {
     public String name() {
         return "ActionsForCharacterRepresentation:" + actionsForCharacterRepresentation
             + "/ProductionToGotoRepresentation:" + productionToGotoRepresentation;
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(actionsForCharacterRepresentation, productionToGotoRepresentation);
     }
 
     @Override public boolean equals(Object o) {

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTestWithSdf3ParseTables.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTestWithSdf3ParseTables.java
@@ -6,9 +6,13 @@ import org.metaborg.parsetable.IParseTable;
 import org.spoofax.jsglr2.integration.ParseTableVariant;
 import org.spoofax.jsglr2.integration.Sdf3ToParseTable;
 
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+
 public abstract class BaseTestWithSdf3ParseTables extends BaseTest {
 
     private String sdf3Resource;
+    private static Table<String, ParseTableVariant, IParseTable> parseTableTable = HashBasedTable.create();
 
     protected BaseTestWithSdf3ParseTables(String sdf3Resource) {
         this.sdf3Resource = sdf3Resource;
@@ -22,7 +26,10 @@ public abstract class BaseTestWithSdf3ParseTables extends BaseTest {
     }
 
     public IParseTable getParseTable(ParseTableVariant variant) throws Exception {
-        return sdf3ToParseTable.getParseTable(variant, sdf3Resource);
+        if(!parseTableTable.contains(sdf3Resource, variant)) {
+            parseTableTable.put(sdf3Resource, variant, sdf3ToParseTable.getParseTable(variant, sdf3Resource));
+        }
+        return parseTableTable.get(sdf3Resource, variant);
     }
 
 }


### PR DESCRIPTION
In the integration tests, quite some time was lost by generating parse tables that had already been generated before. Therefore, I have added a parse table table (pun intended) that stores for every `(sdf3Resource, parseTableVariant)` pair the parse table that has been generated.

On my machine, this improves the run time of the integration tests from 38 seconds to 23 seconds. :smile::rocket: 

Before:
![image](https://user-images.githubusercontent.com/9739541/60442294-06942b80-9c19-11e9-970b-a686dfe7cde4.png)

After:
![image](https://user-images.githubusercontent.com/9739541/60442125-ac936600-9c18-11e9-86af-e3f71aa9202d.png)

Note: the parse table variant is currently not yet used in parse table generation. Because this may be the case later, I've still added it as key to the table.
