### PR TITLE
Extract duplicate code to AbstractLookaheadStack

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/AbstractLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/AbstractLookaheadStack.java
@@ -1,0 +1,28 @@
+package org.spoofax.jsglr2.incremental.lookaheadstack;
+
+import static org.metaborg.characterclasses.CharacterClassFactory.EOF_INT;
+
+public abstract class AbstractLookaheadStack implements ILookaheadStack {
+    protected final String inputString;
+    protected final int inputLength;
+    protected int position = 0;
+
+    public AbstractLookaheadStack(String inputString) {
+        this.inputString = inputString;
+        this.inputLength = inputString.length();
+    }
+
+    @Override public int actionQueryCharacter() {
+        if(position < inputLength)
+            return inputString.charAt(position);
+        if(position == inputLength)
+            return EOF_INT;
+        else
+            return -1;
+    }
+
+    @Override public String actionQueryLookahead(int length) {
+        return inputString.substring(position + 1, Math.min(position + 1 + length, inputLength))
+            + (position + 1 + length > inputLength ? (char) EOF_INT : "");
+    }
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/EagerLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/EagerLookaheadStack.java
@@ -1,33 +1,26 @@
 package org.spoofax.jsglr2.incremental.lookaheadstack;
 
-import static org.metaborg.characterclasses.CharacterClassFactory.EOF_INT;
-
 import java.util.Stack;
 
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 
-public class EagerLookaheadStack implements ILookaheadStack {
+public class EagerLookaheadStack extends AbstractLookaheadStack {
     /**
      * The stack contains all subtrees that are yet to be popped. The top of the stack also contains the subtree that
      * has been returned last time. The stack initially only contains EOF and the root.
      */
-    private final Stack<IncrementalParseForest> stack = new Stack<>();
-    private final String inputString;
-    private final int inputLength;
-    private int position = 0;
+    protected final Stack<IncrementalParseForest> stack = new Stack<>();
 
     /**
      * @param inputString
      *            should be equal to the yield of the root.
      */
     public EagerLookaheadStack(IncrementalParseForest root, String inputString) {
+        super(inputString);
         stack.push(IncrementalCharacterNode.EOF_NODE);
         stack.push(root);
-
-        this.inputString = inputString;
-        this.inputLength = inputString.length();
     }
 
     public EagerLookaheadStack(IncrementalParseForest root) {
@@ -51,20 +44,6 @@ public class EagerLookaheadStack implements ILookaheadStack {
 
     @Override public void popLookahead() {
         position += stack.pop().width();
-    }
-
-    @Override public int actionQueryCharacter() {
-        if(position < inputLength)
-            return inputString.charAt(position);
-        if(position == inputLength)
-            return EOF_INT;
-        else
-            return -1;
-    }
-
-    @Override public String actionQueryLookahead(int length) {
-        return inputString.substring(position + 1, Math.min(position + 1 + length, inputLength))
-            + (position + 1 + length > inputLength ? (char) EOF_INT : "");
     }
 
     @Override public IncrementalParseForest get() {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/LazyLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/LazyLookaheadStack.java
@@ -1,7 +1,5 @@
 package org.spoofax.jsglr2.incremental.lookaheadstack;
 
-import static org.metaborg.characterclasses.CharacterClassFactory.EOF_INT;
-
 import java.util.Stack;
 
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
@@ -9,15 +7,12 @@ import org.spoofax.jsglr2.incremental.parseforest.IncrementalDerivation;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 
-public class LazyLookaheadStack implements ILookaheadStack {
+public class LazyLookaheadStack extends AbstractLookaheadStack {
     /**
      * The stack contains the parent and child index of the node that has been returned last time. When the stack is
      * initialized, a mock root is created and pushed to the stack.
      */
     private final Stack<StackTuple> stack = new Stack<>();
-    private final String inputString;
-    private final int inputLength;
-    private int position = 0;
     private IncrementalParseForest last;
 
     /**
@@ -25,12 +20,11 @@ public class LazyLookaheadStack implements ILookaheadStack {
      *            should be equal to the yield of the root.
      */
     public LazyLookaheadStack(IncrementalParseForest root, String inputString) {
+        super(inputString);
         IncrementalParseNode ultraRoot = new IncrementalParseNode(root, IncrementalCharacterNode.EOF_NODE);
         stack.push(new StackTuple(ultraRoot, 0));
 
         this.last = root;
-        this.inputString = inputString;
-        this.inputLength = inputString.length();
     }
 
     public LazyLookaheadStack(IncrementalParseForest root) {
@@ -79,20 +73,6 @@ public class LazyLookaheadStack implements ILookaheadStack {
             else
                 return parent.parseForests()[res.childIndex + 1];
         }
-    }
-
-    @Override public int actionQueryCharacter() {
-        if(position < inputLength)
-            return inputString.charAt(position);
-        if(position == inputLength)
-            return EOF_INT;
-        else
-            return -1;
-    }
-
-    @Override public String actionQueryLookahead(int length) {
-        return inputString.substring(position + 1, Math.min(position + 1 + length, inputLength))
-            + (position + 1 + length > inputLength ? (char) EOF_INT : "");
     }
 
     private final class StackTuple {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserLogObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/ParserLogObserver.java
@@ -81,13 +81,13 @@ public class ParserLogObserver
 
     @Override public void reducer(StackNode stack, IReduce reduce, ParseForest[] parseNodes,
         StackNode activeStackWithGotoState) {
-        log("Reduce by prodution " + reduce.production().id() + " (" + reduce.productionType().toString()
+        log("Reduce by production " + reduce.production().id() + " (" + reduce.productionType().toString()
             + ") with parse nodes " + parseForestListToString(parseNodes) + ", using existing stack: "
             + (activeStackWithGotoState != null ? id(activeStackWithGotoState) : "no"));
     }
 
     @Override public void reducerElkhound(StackNode stack, IReduce reduce, ParseForest[] parseNodes) {
-        log("Reduce (Elkhound) by prodution " + reduce.production().id() + " (" + reduce.productionType().toString()
+        log("Reduce (Elkhound) by production " + reduce.production().id() + " (" + reduce.productionType().toString()
             + ") with parse nodes " + parseForestListToString(parseNodes));
     }
 


### PR DESCRIPTION
There was some duplicate code in the different types of `LookaheadStack`. I've created a common abstract super-class to pull the duplicate code to.

As an added bonus, I've fixed a small typo.