### PR TITLE
Remove redundant access modifiers in interfaces

### DIFF
--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/IKeywordRecognizer.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/IKeywordRecognizer.java
@@ -4,6 +4,6 @@ import java.io.Serializable;
 
 public interface IKeywordRecognizer extends Serializable {
 
-    public boolean isKeyword(String literal);
+    boolean isKeyword(String literal);
     
 }

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/IRecoveryResult.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/IRecoveryResult.java
@@ -3,6 +3,6 @@ package org.spoofax.jsglr.client;
 import java.util.Map;
 
 public interface IRecoveryResult {
-    public String getResult();
-    public Map<Integer, char[]> getSuggestions();
+    String getResult();
+    Map<Integer, char[]> getSuggestions();
 }

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/editregion/detection/LCSCommand.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/editregion/detection/LCSCommand.java
@@ -14,6 +14,6 @@ public interface LCSCommand<T> {
 	 * @param t2 element in input list 2
 	 * @return True in case t1 and t2 can be matched
 	 */
-	abstract boolean isMatch(T t1, T t2);
+	boolean isMatch(T t1, T t2);
 
 }

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/IToken.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/IToken.java
@@ -8,88 +8,88 @@ import org.spoofax.interpreter.terms.ISimpleTerm;
  * @author Lennart Kats <lennart add lclnet.nl>
  */
 public interface IToken extends Comparable<IToken>, Serializable {
-	/** Unknown token kind. */
-	public static final int TK_UNKNOWN = 0;
-	
-	/** Token kind for a generic identifier. */
-	public static final int TK_IDENTIFIER = 1;
-	
-	/** Token kind for a generic numeric value. */
-	public static final int TK_NUMBER = 2;
-	
-	/** Token kind for a generic string literal. */
-	public static final int TK_STRING = 3;
-	
-	/** Token kind for a generic keyword token. */
-	public static final int TK_KEYWORD = 4;
-	
-	/** Token kind for a generic operator token. */
-	public static final int TK_OPERATOR = 5;
-	
-	/** Token kind for a meta-variable. */
-	public static final int TK_VAR = 6;
-	
-	/** Token kind for a layout (or comment) token. */
-	public static final int TK_LAYOUT = 7;
-	
-	/** Token kind for an EOF token. */
-	public static final int TK_EOF = 8;
-	
-	/** Token kind for an erroneous non-keyword token. */
-	public static final int TK_ERROR = 9;
-	
-	/** Token kind for an erroneous keyword token. */
-	public static final int TK_ERROR_KEYWORD = 10;
-	
-	/** Token kind for an whitespace near an erroneous token. */
-	public static final int TK_ERROR_LAYOUT = 11;
-	
-	/** Token kind for an erroneous token. */
-	public static final int TK_ERROR_EOF_UNEXPECTED = 12;
-	
-	/** Token kind for a meta-escape operator. */
-	public static final int TK_ESCAPE_OPERATOR = 13;
-	
-	/** A reserved token kind for internal use only. */
-	public static final int TK_RESERVED = 63;
-	
-	/** A special value indicating no token kind is specified or desired. */
-	public static final int TK_NO_TOKEN_KIND = 64;
-	
-	int getKind();
-	
-	void setKind(int kind);
-	
-	int getIndex();
+    /** Unknown token kind. */
+    int TK_UNKNOWN = 0;
 
-	int getStartOffset();
+    /** Token kind for a generic identifier. */
+    int TK_IDENTIFIER = 1;
 
-	/**
-	 * Gets the end offset (inclusive).
-	 */
-	int getEndOffset();
+    /** Token kind for a generic numeric value. */
+    int TK_NUMBER = 2;
 
-	int getLine();
-	
-	int getEndLine();
-	
-	int getColumn();
+    /** Token kind for a generic string literal. */
+    int TK_STRING = 3;
 
-	int getEndColumn();
-	
-	int getLength();
-	
-	char charAt(int index);
-	
-	String getError();
+    /** Token kind for a generic keyword token. */
+    int TK_KEYWORD = 4;
+
+    /** Token kind for a generic operator token. */
+    int TK_OPERATOR = 5;
+
+    /** Token kind for a meta-variable. */
+    int TK_VAR = 6;
+
+    /** Token kind for a layout (or comment) token. */
+    int TK_LAYOUT = 7;
+
+    /** Token kind for an EOF token. */
+    int TK_EOF = 8;
+
+    /** Token kind for an erroneous non-keyword token. */
+    int TK_ERROR = 9;
+
+    /** Token kind for an erroneous keyword token. */
+    int TK_ERROR_KEYWORD = 10;
+
+    /** Token kind for an whitespace near an erroneous token. */
+    int TK_ERROR_LAYOUT = 11;
+
+    /** Token kind for an erroneous token. */
+    int TK_ERROR_EOF_UNEXPECTED = 12;
+
+    /** Token kind for a meta-escape operator. */
+    int TK_ESCAPE_OPERATOR = 13;
+
+    /** A reserved token kind for internal use only. */
+    int TK_RESERVED = 63;
+
+    /** A special value indicating no token kind is specified or desired. */
+    int TK_NO_TOKEN_KIND = 64;
+
+    int getKind();
+
+    void setKind(int kind);
+
+    int getIndex();
+
+    int getStartOffset();
+
+    /**
+     * Gets the end offset (inclusive).
+     */
+    int getEndOffset();
+
+    int getLine();
+
+    int getEndLine();
+
+    int getColumn();
+
+    int getEndColumn();
+
+    int getLength();
+
+    char charAt(int index);
+
+    String getError();
 
     void setAstNode(ISimpleTerm astNode);
-	
-	ISimpleTerm getAstNode();
-	
-	String getFilename();
-	
-	ITokens getTokenizer();
-	
-	IToken clone();
+
+    ISimpleTerm getAstNode();
+
+    String getFilename();
+
+    ITokens getTokenizer();
+
+    IToken clone();
 }

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/ITokens.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/ITokens.java
@@ -3,22 +3,22 @@ package org.spoofax.jsglr.client.imploder;
 import java.io.Serializable;
 
 public interface ITokens extends Iterable<IToken>, Serializable {
-    
-    public static final String ERROR_SKIPPED_REGION = "Syntax error, unexpected construct(s)";
-    
-    public static final String ERROR_UNEXPECTED_EOF = "Syntax error, unexpected end of input";
-    
-    public static final String ERROR_WATER_PREFIX = "Syntax error, not expected here";
-    
-    public static final String ERROR_INSERT_PREFIX = "Syntax error, expected";
-    
-    public static final String ERROR_INSERT_END_PREFIX = "Syntax error, unterminated construct";
 
-    public static final String ERROR_INCOMPLETE_PREFIX = "Syntax error, incomplete construct";
+    String ERROR_SKIPPED_REGION = "Syntax error, unexpected construct(s)";
 
-    public static final String ERROR_GENERIC_PREFIX = "Syntax error";
+    String ERROR_UNEXPECTED_EOF = "Syntax error, unexpected end of input";
 
-    public static final String ERROR_WARNING_PREFIX = "Warning";
+    String ERROR_WATER_PREFIX = "Syntax error, not expected here";
+
+    String ERROR_INSERT_PREFIX = "Syntax error, expected";
+
+    String ERROR_INSERT_END_PREFIX = "Syntax error, unterminated construct";
+
+    String ERROR_INCOMPLETE_PREFIX = "Syntax error, incomplete construct";
+
+    String ERROR_GENERIC_PREFIX = "Syntax error";
+
+    String ERROR_WARNING_PREFIX = "Warning";
 
     String getInput();
 
@@ -33,14 +33,13 @@ public interface ITokens extends Iterable<IToken>, Serializable {
     String toString(IToken left, IToken right);
 
     String toString(int startOffset, int endOffset);
-    
+
     /**
-     * Determines if the tokenizer is ambiguous.
-     * If it is, tokens with subsequent indices may not
-     * always have matching start/end offsets.
+     * Determines if the tokenizer is ambiguous. If it is, tokens with subsequent indices may not always have matching
+     * start/end offsets.
      * 
-     * @see Tokenizer#getTokenAfter(IToken)   Gets the next token with a matching offset.
-     * @see Tokenizer#getTokenBefore(IToken)  Gets the previous token with a matching offset.
+     * @see Tokenizer#getTokenAfter(IToken) Gets the next token with a matching offset.
+     * @see Tokenizer#getTokenBefore(IToken) Gets the previous token with a matching offset.
      */
     boolean isAmbiguous();
 


### PR DESCRIPTION
Just a fix for an IntelliJ code inspection.
Immediately ran the auto-formatter for `IToken` and `ITokens`, while I was there anyway.