### PR TITLE
Refactor layout-sensitive parsing implementation and tests

### DIFF
--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTestWithLayoutSensitiveSdf3ParseTables.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTestWithLayoutSensitiveSdf3ParseTables.java
@@ -24,11 +24,21 @@ public abstract class BaseTestWithLayoutSensitiveSdf3ParseTables extends BaseTes
         testVariant -> testVariant.variant.parser.parseForestRepresentation
             .equals(ParseForestRepresentation.LayoutSensitive);
 
-    protected void testLayoutSensitiveParseFailure(String inputString) {
+    private Predicate<TestVariant> isNotLayoutSensitiveVariant =
+        testVariant -> !testVariant.variant.parser.parseForestRepresentation
+            .equals(ParseForestRepresentation.LayoutSensitive);
+
+    protected void testLayoutSensitiveParseFiltered(String inputString) {
+        for(TestVariant variant : getTestVariants(isNotLayoutSensitiveVariant)) {
+            ParseResult<?> parseResult = variant.parser().parse(inputString);
+
+            assertEquals("Variant '" + variant.name() + "' should succeed for non-layout-sensitive parsing: ", true, parseResult.isSuccess());
+        }
+
         for(TestVariant variant : getTestVariants(isLayoutSensitiveVariant)) {
             ParseResult<?> parseResult = variant.parser().parse(inputString);
 
-            assertEquals("Variant '" + variant.name() + "' should fail: ", false, parseResult.isSuccess());
+            assertEquals("Variant '" + variant.name() + "' should fail for layout-sensitive parsing: ", false, parseResult.isSuccess());
         }
     }
 

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/grammars/LayoutSensitiveDisambiguationTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/grammars/LayoutSensitiveDisambiguationTest.java
@@ -11,11 +11,11 @@ public class LayoutSensitiveDisambiguationTest extends BaseTestWithLayoutSensiti
     }
 
     @Test public void alignmentMisaligned1() throws ParseError {
-        testLayoutSensitiveParseFailure("doAlignList s1 \n" + "       s2");
+        testLayoutSensitiveParseFiltered("doAlignList s1 \n" + "       s2");
     }
 
     @Test public void alignmentMisaligned2() throws ParseError {
-        testLayoutSensitiveParseFailure("doAlignList s1 \n" + "             s2");
+        testLayoutSensitiveParseFiltered("doAlignList s1 \n" + "             s2");
     }
 
     @Test public void alignmentAligned() throws ParseError {
@@ -23,11 +23,11 @@ public class LayoutSensitiveDisambiguationTest extends BaseTestWithLayoutSensiti
     }
 
     @Test public void explicitAlignmentMisaligned1() throws ParseError {
-        testLayoutSensitiveParseFailure("doAlign s1 \n" + "       s2");
+        testLayoutSensitiveParseFiltered("doAlign s1 \n" + "       s2");
     }
 
     @Test public void explicitAlignmentMisaligned2() throws ParseError {
-        testLayoutSensitiveParseFailure("doAlign s1 \n" + "         s2");
+        testLayoutSensitiveParseFiltered("doAlign s1 \n" + "         s2");
     }
 
     @Test public void explicitAlignmentAligned() throws ParseError {
@@ -64,15 +64,15 @@ public class LayoutSensitiveDisambiguationTest extends BaseTestWithLayoutSensiti
     }
 
     @Test public void indentExpressionFailed() throws ParseError {
-        testLayoutSensitiveParseFailure("doIndent \n" + "s1");
+        testLayoutSensitiveParseFiltered("doIndent \n" + "s1");
     }
 
     @Test public void newlineIndentExpressionFailed1() throws ParseError {
-        testLayoutSensitiveParseFailure("doNLIndent s1");
+        testLayoutSensitiveParseFiltered("doNLIndent s1");
     }
 
     @Test public void newlineIndentExpressionFailed2() throws ParseError {
-        testLayoutSensitiveParseFailure("doNLIndent \n" + "s1");
+        testLayoutSensitiveParseFiltered("doNLIndent \n" + "s1");
     }
 
     @Test public void newlineIndentExpression() throws ParseError {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutConstraintEvaluator.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutConstraintEvaluator.java
@@ -4,9 +4,10 @@ import java.util.Optional;
 
 import org.metaborg.sdf2table.grammar.layoutconstraints.*;
 
-public class LayoutConstraintEvaluator<ParseForest extends LayoutSensitiveParseForest> {
+class LayoutConstraintEvaluator {
 
-    public Optional<Boolean> evaluate(ILayoutConstraint layoutConstraint, ParseForest[] parseNodes) {
+    static <ParseForest extends LayoutSensitiveParseForest> Optional<Boolean>
+        evaluate(ILayoutConstraint layoutConstraint, ParseForest[] parseNodes) {
         if(layoutConstraint instanceof BooleanLayoutConstraint) {
             BooleanLayoutConstraint booleanLayoutConstraint = (BooleanLayoutConstraint) layoutConstraint;
 
@@ -70,7 +71,8 @@ public class LayoutConstraintEvaluator<ParseForest extends LayoutSensitiveParseF
         throw new IllegalStateException("Could not evaluate constraint: " + layoutConstraint);
     }
 
-    private Optional<Integer> evaluateNumeric(ILayoutConstraint layoutConstraint, ParseForest[] parseNodes) {
+    private static <ParseForest extends LayoutSensitiveParseForest> Optional<Integer>
+        evaluateNumeric(ILayoutConstraint layoutConstraint, ParseForest[] parseNodes) {
         if(layoutConstraint instanceof NumericLayoutConstraint) {
             NumericLayoutConstraint numericLayoutConstraint = (NumericLayoutConstraint) layoutConstraint;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutConstraintEvaluator.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutConstraintEvaluator.java
@@ -60,9 +60,7 @@ public class LayoutConstraintEvaluator<ParseForest extends LayoutSensitiveParseF
     private int evaluateNumeric(ILayoutConstraint layoutConstraint, ParseForest[] parseNodes) throws Exception {
 
         if(layoutConstraint instanceof NumericLayoutConstraint) {
-            ParseForest tree = parseNodes[((NumericLayoutConstraint) layoutConstraint).getTree()]; // selectCorrectTree(((NumericLayoutConstraint)
-                                                                                                   // layoutConstraint).getTree(),
-                                                                                                   // parseNodes);
+            ParseForest tree = parseNodes[((NumericLayoutConstraint) layoutConstraint).getTree()];
 
             if(tree instanceof LayoutSensitiveParseNode
                 && ((LayoutSensitiveParseNode) tree).production().isIgnoreLayoutConstraint()) {
@@ -117,30 +115,6 @@ public class LayoutConstraintEvaluator<ParseForest extends LayoutSensitiveParseF
         }
 
         throw new Exception("Could not evaluate constraint: " + layoutConstraint);
-    }
-
-    // skip LAYOUT?-CF nodes
-    private ParseForest selectCorrectTree(int tree, ParseForest[] parseNodes) throws Exception {
-
-        int treeCount = tree;
-
-        for(int i = 0; i < parseNodes.length; i++) {
-            ParseForest current = parseNodes[i];
-            if(current == null || current instanceof LayoutSensitiveParseNode) {
-                if(current == null || ((LayoutSensitiveParseNode) current).production().isLayout()) {
-                    continue;
-                } else {
-                    treeCount--;
-                }
-            } else {
-                throw new Exception("Could not select correct tree at index " + tree);
-            }
-            if(treeCount == 0) {
-                return current;
-            }
-        }
-
-        throw new Exception("Could not select correct tree at index " + tree);
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveDerivation.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveDerivation.java
@@ -20,9 +20,6 @@ public class LayoutSensitiveDerivation extends LayoutSensitiveParseForest
 
     public Position leftPosition, rightPosition;
 
-    // longest-match positions
-    // public Set<PositionInterval> longestMatchPos = Sets.newLinkedHashSet();
-
     public LayoutSensitiveDerivation(AbstractParse<?, ?, ?> parse, Position startPosition, Position leftPosition,
         Position rightPosition, Position endPosition, IProduction production, ProductionType productionType,
         LayoutSensitiveParseForest[] parseForests) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveDerivation.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveDerivation.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.metaborg.parsetable.productions.IProduction;
 import org.metaborg.parsetable.productions.ProductionType;
 import org.spoofax.jsglr2.parseforest.IDerivation;
-import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.Position;
 import org.spoofax.jsglr2.parser.PositionInterval;
 
@@ -20,8 +19,8 @@ public class LayoutSensitiveDerivation extends LayoutSensitiveParseForest
 
     public Position leftPosition, rightPosition;
 
-    public LayoutSensitiveDerivation(AbstractParse<?, ?, ?> parse, Position startPosition, Position leftPosition,
-        Position rightPosition, Position endPosition, IProduction production, ProductionType productionType,
+    public LayoutSensitiveDerivation(Position startPosition, Position leftPosition, Position rightPosition,
+        Position endPosition, IProduction production, ProductionType productionType,
         LayoutSensitiveParseForest[] parseForests) {
         super(startPosition, endPosition);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
@@ -59,31 +59,35 @@ public class LayoutSensitiveParseForestManager<Parse extends AbstractParse<Layou
         Position rightPosition = null;
 
         for(LayoutSensitiveParseForest pf : parseForests) {
-            if(pf instanceof LayoutSensitiveParseNode && (((LayoutSensitiveParseNode) pf).production().isLayout()
-                || ((LayoutSensitiveParseNode) pf).production().isIgnoreLayoutConstraint())) {
-                continue;
-            }
             if(pf instanceof LayoutSensitiveParseNode) {
-                Position currentStartPosition = ((LayoutSensitiveParseNode) pf).getFirstDerivation().getStartPosition();
-                Position currentLeftPosition = ((LayoutSensitiveParseNode) pf).getFirstDerivation().leftPosition;
-                Position currentRightPosition = ((LayoutSensitiveParseNode) pf).getFirstDerivation().rightPosition;
-                Position currentEndPosition = ((LayoutSensitiveParseNode) pf).getFirstDerivation().getEndPosition();
+                LayoutSensitiveParseNode layoutSensitiveParseNode = (LayoutSensitiveParseNode) pf;
 
-                if(currentLeftPosition != null) {
-                    leftPosition = leftMost(leftPosition, currentLeftPosition);
-                }
+                if(!layoutSensitiveParseNode.production().isLayout()
+                    && !layoutSensitiveParseNode.production().isIgnoreLayoutConstraint()) {
+                    LayoutSensitiveDerivation firstDerivation = layoutSensitiveParseNode.getFirstDerivation();
 
-                if(currentStartPosition.line > beginPosition.line && !currentStartPosition.equals(currentEndPosition)) {
-                    leftPosition = leftMost(leftPosition, currentStartPosition);
-                }
+                    Position currentStartPosition = firstDerivation.getStartPosition();
+                    Position currentLeftPosition = firstDerivation.leftPosition;
+                    Position currentRightPosition = firstDerivation.rightPosition;
+                    Position currentEndPosition = firstDerivation.getEndPosition();
 
-                if(currentRightPosition != null) {
-                    rightPosition = rightMost(rightPosition, currentRightPosition);
-                }
+                    if(currentLeftPosition != null) {
+                        leftPosition = leftMost(leftPosition, currentLeftPosition);
+                    }
 
-                if(currentEndPosition.line < parse.currentPosition().line
-                    && !currentStartPosition.equals(currentEndPosition)) {
-                    rightPosition = rightMost(rightPosition, currentEndPosition);
+                    if(currentStartPosition.line > beginPosition.line
+                        && !currentStartPosition.equals(currentEndPosition)) {
+                        leftPosition = leftMost(leftPosition, currentStartPosition);
+                    }
+
+                    if(currentRightPosition != null) {
+                        rightPosition = rightMost(rightPosition, currentRightPosition);
+                    }
+
+                    if(currentEndPosition.line < parse.currentPosition().line
+                        && !currentStartPosition.equals(currentEndPosition)) {
+                        rightPosition = rightMost(rightPosition, currentEndPosition);
+                    }
                 }
             } else if(pf instanceof LayoutSensitiveCharacterNode) {
                 if(pf.getStartPosition().line > beginPosition.line
@@ -97,7 +101,7 @@ public class LayoutSensitiveParseForestManager<Parse extends AbstractParse<Layou
                         new Position(pf.getEndPosition().offset, pf.getEndPosition().line, pf.getEndPosition().column);
                 }
             } else if(pf != null) {
-                System.err.println("Not a valid tree node.");
+                throw new IllegalStateException("Invalid layout sensitive node");
             }
         }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
@@ -101,8 +101,8 @@ public class LayoutSensitiveParseForestManager<Parse extends AbstractParse<Layou
             }
         }
 
-        LayoutSensitiveDerivation derivation = new LayoutSensitiveDerivation(parse, beginPosition, leftPosition,
-            rightPosition, parse.currentPosition(), production, productionType, parseForests);
+        LayoutSensitiveDerivation derivation = new LayoutSensitiveDerivation(beginPosition, leftPosition, rightPosition,
+            parse.currentPosition(), production, productionType, parseForests);
 
         parse.observing.notify(observer -> observer.createDerivation(derivation, production, parseForests));
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseForestManager.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.metaborg.parsetable.productions.IProduction;
 import org.metaborg.parsetable.productions.ProductionType;
-import org.metaborg.sdf2table.grammar.layoutconstraints.ConstraintSelector;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parser.AbstractParse;
 import org.spoofax.jsglr2.parser.Position;
@@ -86,41 +85,6 @@ public class LayoutSensitiveParseForestManager<Parse extends AbstractParse<Layou
                     && !currentStartPosition.equals(currentEndPosition)) {
                     rightPosition = rightMost(rightPosition, currentEndPosition);
                 }
-
-
-                // if(currentLeftPosition != null) {
-                // if(leftPosition == null) {
-                // leftPosition = currentLeftPosition;
-                // } else if(leftPosition.column > currentLeftPosition.column
-                // && beginPosition.line < currentLeftPosition.line) {
-                // leftPosition = currentLeftPosition;
-                // }
-                // }
-                //
-                // if(currentStartPosition != null) {
-                // if(leftPosition == null && currentStartPosition.line > beginPosition.line
-                // ) {
-                // leftPosition = currentStartPosition;
-                // } else if(leftPosition != null && currentStartPosition.line > beginPosition.line
-                // && currentStartPosition.column < leftPosition.column
-                // && !currentStartPosition.equals(currentEndPosition)) {
-                // leftPosition = currentStartPosition;
-                // }
-                // }
-                //
-                // if(rightPosition == null && currentRightPosition != null) {
-                // rightPosition = currentRightPosition;
-                // }
-                // if(currentRightPosition != null && (rightPosition.column < currentRightPosition.column
-                // && parse.currentPosition().line > currentRightPosition.line)) {
-                // rightPosition = currentRightPosition;
-                // }
-                // if(currentEndPosition != null && (currentEndPosition.line < parse.currentPosition().line
-                // && currentEndPosition.column > parse.currentPosition().column)) {
-                // rightPosition = currentEndPosition;
-                // }
-
-
             } else if(pf instanceof LayoutSensitiveCharacterNode) {
                 if(pf.getStartPosition().line > beginPosition.line
                     && pf.getStartPosition().column < beginPosition.column) {
@@ -187,57 +151,6 @@ public class LayoutSensitiveParseForestManager<Parse extends AbstractParse<Layou
 
     @Override public LayoutSensitiveParseForest[] parseForestsArray(int length) {
         return new LayoutSensitiveParseForest[length];
-    }
-
-    private Position verifyPositionAmbiguities(ConstraintSelector selector, LayoutSensitiveParseForest pf) {
-        // For trees in an ambiguity such that left and right are different, take the one with smallest and largest
-        // column, respectively
-        Position currentPosition = null;
-        for(LayoutSensitiveDerivation rn : ((LayoutSensitiveParseNode) pf).getDerivations()) {
-            switch(selector) {
-                case FIRST:
-                    // if(currentPosition != null && !rn.startPosition.equals(currentPosition)) {
-                    // System.err.println("StartPosition is different for trees that are part of an ambiguity.");
-                    // }
-                    if(rn.getStartPosition() != null) {
-                        currentPosition = new Position(rn.getStartPosition());
-                    }
-                    break;
-                case LAST:
-                    // if(currentPosition != null && !rn.endPosition.equals(currentPosition)) {
-                    // System.err.println("EndPosition is different for trees that are part of an ambiguity.");
-                    // }
-                    if(rn.getEndPosition() != null) {
-                        currentPosition = new Position(rn.getEndPosition());
-                    }
-                    break;
-                case RIGHT:
-                    if(rn.rightPosition != null) {
-                        if(currentPosition != null && !rn.rightPosition.equals(currentPosition)) {
-                            if(rn.rightPosition.column > currentPosition.column) {
-                                currentPosition = new Position(rn.rightPosition);
-                            }
-                        } else {
-                            currentPosition = new Position(rn.rightPosition);
-                        }
-                    }
-                    break;
-                case LEFT:
-                    if(rn.leftPosition != null) {
-                        if(currentPosition != null && !rn.leftPosition.equals(currentPosition)) {
-                            if(rn.leftPosition.column < currentPosition.column) {
-                                currentPosition = new Position(rn.leftPosition);
-                            }
-                        } else {
-                            currentPosition = new Position(rn.leftPosition);
-                        }
-
-                    }
-                    break;
-            }
-        }
-
-        return currentPosition;
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveParseNode.java
@@ -79,7 +79,7 @@ public class LayoutSensitiveParseNode extends LayoutSensitiveParseForest
                 }
             }
         }
-        //
+
         if(disambiguatedLongestMatch) {
             LayoutSensitiveDerivation longestDerivation = derivations.get(currentLongestDerivation);
             derivations.clear();
@@ -104,33 +104,13 @@ public class LayoutSensitiveParseNode extends LayoutSensitiveParseForest
     }
 
     public List<PositionInterval> getLongestMatchPositions() {
-        // System.out.println("getting positions for " + this);
         if(longestMatchPos == null && !filteredLongestMatch) {
             filterLongestMatchDerivations();
+
             return longestMatchPos;
         } else {
             return longestMatchPos;
         }
-
     }
-
-    // @Override public String toString() {
-    // if(derivations.size() == 1) {
-    // return derivations.get(0).toString();
-    // }
-    // String buf = "amb(";
-    // int i = 0;
-    // for(LayoutSensitiveDerivation der : derivations) {
-    // if(der == null)
-    // continue;
-    // if(i != 0)
-    // buf += ", ";
-    // buf += der.toString();
-    // i++;
-    // }
-    // buf += ")";
-    //
-    // return buf;
-    // }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
@@ -26,8 +26,6 @@ public class LayoutSensitiveReduceManager
 //@formatter:on
     extends ReduceManager<ParseForest, ParseNode, Derivation, StackNode, ParseState, Parse> {
 
-    private LayoutConstraintEvaluator<ParseForest> lce = new LayoutConstraintEvaluator<>();
-
     public LayoutSensitiveReduceManager(IParseTable parseTable,
         AbstractStackManager<ParseForest, StackNode, ParseState, Parse> stackManager,
         ParseForestManager<ParseForest, ParseNode, Derivation, Parse> parseForestManager,
@@ -49,7 +47,7 @@ public class LayoutSensitiveReduceManager
 
                     for(LayoutConstraintAttribute lca : sdf2tableProduction.getLayoutConstraints()) {
                         // Skip the reduction if the constraint evaluates to false or if it is not present
-                        if(!lce.evaluate(lca.getLayoutConstraint(), parseNodes).orElse(false)) {
+                        if(!LayoutConstraintEvaluator.evaluate(lca.getLayoutConstraint(), parseNodes).orElse(false)) {
                             skipReduce = true;
                             break;
                         }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
@@ -2,7 +2,6 @@ package org.spoofax.jsglr2.layoutsensitive;
 
 import org.metaborg.parsetable.IParseTable;
 import org.metaborg.parsetable.actions.IReduce;
-import org.metaborg.parsetable.productions.IProduction;
 import org.metaborg.sdf2table.grammar.LayoutConstraintAttribute;
 import org.metaborg.sdf2table.parsetable.ParseTableProduction;
 import org.spoofax.jsglr2.parseforest.IDerivation;
@@ -45,17 +44,13 @@ public class LayoutSensitiveReduceManager
 
                 boolean skipReduce = false;
 
-                IProduction prod = reduce.production();
-                if(prod instanceof ParseTableProduction) {
-                    if(!((ParseTableProduction) prod).getLayoutConstraints().isEmpty()) {
-                        for(LayoutConstraintAttribute lca : ((ParseTableProduction) prod).getLayoutConstraints()) {
-                            try {
-                                if(!lce.evaluate(lca.getLayoutConstraint(), parseNodes)) {
-                                    skipReduce = true;
-                                    break;
-                                }
-                            } catch(Exception e) {
-                                System.err.println(e.getMessage());
+                if(reduce.production() instanceof ParseTableProduction) {
+                    ParseTableProduction sdf2tableProduction = (ParseTableProduction) reduce.production();
+
+                    if(!sdf2tableProduction.getLayoutConstraints().isEmpty()) {
+                        for(LayoutConstraintAttribute lca : sdf2tableProduction.getLayoutConstraints()) {
+                            // Skip the reduction if the constraint evaluates to false or if it is not present
+                            if(!lce.evaluate(lca.getLayoutConstraint(), parseNodes).orElse(false)) {
                                 skipReduce = true;
                                 break;
                             }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
@@ -45,8 +45,8 @@ public class LayoutSensitiveReduceManager
                     ParseTableProduction sdf2tableProduction = (ParseTableProduction) reduce.production();
 
                     for(LayoutConstraintAttribute lca : sdf2tableProduction.getLayoutConstraints()) {
-                        // Skip the reduction if the constraint evaluates to false or if it is not present
-                        if(!LayoutConstraintEvaluator.evaluate(lca.getLayoutConstraint(), parseNodes).orElse(false))
+                        // Skip the reduction if the constraint evaluates to false
+                        if(!LayoutConstraintEvaluator.evaluate(lca.getLayoutConstraint(), parseNodes).orElse(true))
                             continue pathsLoop;
                     }
                 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
@@ -35,27 +35,20 @@ public class LayoutSensitiveReduceManager
 
     @Override protected void doReductionsHelper(Parse parse, StackNode stack, IReduce reduce,
         StackLink<ParseForest, StackNode> throughLink) {
-        for(StackPath<ParseForest, StackNode> path : stackManager.findAllPathsOfLength(stack, reduce.arity())) {
+        pathsLoop: for(StackPath<ParseForest, StackNode> path : stackManager.findAllPathsOfLength(stack,
+            reduce.arity())) {
             if(throughLink == null || path.contains(throughLink)) {
                 StackNode pathBegin = path.head();
                 ParseForest[] parseNodes = stackManager.getParseForests(parseForestManager, path);
-
-                boolean skipReduce = false;
 
                 if(reduce.production() instanceof ParseTableProduction) {
                     ParseTableProduction sdf2tableProduction = (ParseTableProduction) reduce.production();
 
                     for(LayoutConstraintAttribute lca : sdf2tableProduction.getLayoutConstraints()) {
                         // Skip the reduction if the constraint evaluates to false or if it is not present
-                        if(!LayoutConstraintEvaluator.evaluate(lca.getLayoutConstraint(), parseNodes).orElse(false)) {
-                            skipReduce = true;
-                            break;
-                        }
+                        if(!LayoutConstraintEvaluator.evaluate(lca.getLayoutConstraint(), parseNodes).orElse(false))
+                            continue pathsLoop;
                     }
-                }
-
-                if(skipReduce) {
-                    continue;
                 }
 
                 reducer(parse, pathBegin, reduce, parseNodes);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/LayoutSensitiveReduceManager.java
@@ -47,13 +47,11 @@ public class LayoutSensitiveReduceManager
                 if(reduce.production() instanceof ParseTableProduction) {
                     ParseTableProduction sdf2tableProduction = (ParseTableProduction) reduce.production();
 
-                    if(!sdf2tableProduction.getLayoutConstraints().isEmpty()) {
-                        for(LayoutConstraintAttribute lca : sdf2tableProduction.getLayoutConstraints()) {
-                            // Skip the reduction if the constraint evaluates to false or if it is not present
-                            if(!lce.evaluate(lca.getLayoutConstraint(), parseNodes).orElse(false)) {
-                                skipReduce = true;
-                                break;
-                            }
+                    for(LayoutConstraintAttribute lca : sdf2tableProduction.getLayoutConstraints()) {
+                        // Skip the reduction if the constraint evaluates to false or if it is not present
+                        if(!lce.evaluate(lca.getLayoutConstraint(), parseNodes).orElse(false)) {
+                            skipReduce = true;
+                            break;
                         }
                     }
                 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/NoValueLayoutException.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/layoutsensitive/NoValueLayoutException.java
@@ -1,7 +1,0 @@
-package org.spoofax.jsglr2.layoutsensitive;
-
-public class NoValueLayoutException extends Exception {
-
-    private static final long serialVersionUID = -1438365001287025365L;
-
-}


### PR DESCRIPTION
Removing obsolete code and refactoring in the layout-sensitive parsing implementation and tests. For testing, I added that tests check that inputs that are discarded due to layout-constraints are valid when parsed without layout-sensitivity enabled.