### PR TITLE
Extensible CLI

### DIFF
--- a/org.spoofax.jsglr2.cli/pom.xml
+++ b/org.spoofax.jsglr2.cli/pom.xml
@@ -34,6 +34,12 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <!-- Suppressing SLF4J warnings -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.28</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/org.spoofax.jsglr2.cli/pom.xml
+++ b/org.spoofax.jsglr2.cli/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>4.0.0-beta-2</version>
+            <version>4.0.4</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/JSGLR2CLI.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/JSGLR2CLI.java
@@ -28,7 +28,7 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command(name = "JSGLR2 CLI", sortOptions = false, mixinStandardHelpOptions = true)
+@Command(name = "JSGLR2 CLI", sortOptions = false, mixinStandardHelpOptions = true, abbreviateSynopsis = true)
 public class JSGLR2CLI implements Runnable {
 
     @Parameters(arity = "1..*", description = "The input file(s)/string(s) to be parsed") public String[] input;
@@ -42,6 +42,9 @@ public class JSGLR2CLI implements Runnable {
 
     @Option(names = { "-v", "--verbose" }, negatable = true,
         description = "Print stack traces") public boolean verbose = false;
+
+    @Option(names = { "-l", "--language" },
+        description = "The identifier of a Spoofax language in the local Maven repository, in the format '[groupId]/[artifactId]/[version]', where the groupId is slash-separated, the artifactId is period-separated, and the version is optional. Examples: 'org/metaborg/lang.java', 'org/metaborg/lang.java/1.1.0-SNAPSHOT'") public static String language;
 
     // TODO As alternative to the parser builder, we could also load a Spoofax language and use its parsing services.
     // However, that cannot easily be combined with the custom output options, because 1) not all languages use JSGLR2
@@ -67,6 +70,12 @@ public class JSGLR2CLI implements Runnable {
 
     public void run() {
         try {
+            if(language == null && parserBuilder.parseTableOptions.parseTableFile == null) {
+                System.err.println("Either option --parseTable or --language should be provided");
+                new CommandLine(new JSGLR2CLI()).execute("-h");
+                System.exit(2);
+            }
+
             outputProcessor.checkAllowed(this);
 
             JSGLR2Implementation<?, ?, IStrategoTerm> jsglr2 =

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/JSGLR2CLI.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/JSGLR2CLI.java
@@ -1,151 +1,61 @@
 package org.spoofax.jsglr2.cli;
 
-import org.apache.commons.io.IOUtils;
-import org.metaborg.parsetable.IParseTable;
-import org.metaborg.parsetable.ParseTableReadException;
-import org.metaborg.parsetable.ParseTableReader;
-import org.metaborg.parsetable.query.ActionsForCharacterRepresentation;
-import org.metaborg.parsetable.query.ProductionToGotoRepresentation;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+import java.util.Scanner;
+
 import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.jsglr2.*;
-import org.spoofax.jsglr2.imploder.ImploderVariant;
-import org.spoofax.jsglr2.integration.ParseTableVariant;
-import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
-import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
+import org.spoofax.jsglr2.JSGLR2Failure;
+import org.spoofax.jsglr2.JSGLR2Implementation;
+import org.spoofax.jsglr2.JSGLR2Result;
+import org.spoofax.jsglr2.JSGLR2Success;
+import org.spoofax.jsglr2.cli.output.DefaultOutputProcessor;
+import org.spoofax.jsglr2.cli.output.IOutputProcessor;
+import org.spoofax.jsglr2.cli.output.dot.DotOutputProcessor;
+import org.spoofax.jsglr2.cli.parserbuilder.ParserBuilder;
 import org.spoofax.jsglr2.parser.IObservableParser;
 import org.spoofax.jsglr2.parser.IParser;
-import org.spoofax.jsglr2.parser.ParserVariant;
+import org.spoofax.jsglr2.parser.observing.ParserObserver;
 import org.spoofax.jsglr2.parser.result.ParseFailure;
 import org.spoofax.jsglr2.parser.result.ParseResult;
 import org.spoofax.jsglr2.parser.result.ParseSuccess;
-import org.spoofax.jsglr2.reducing.Reducing;
-import org.spoofax.jsglr2.stack.StackRepresentation;
-import org.spoofax.jsglr2.stack.collections.ActiveStacksRepresentation;
-import org.spoofax.jsglr2.stack.collections.ForActorStacksRepresentation;
-import org.spoofax.jsglr2.tokens.TokenizerVariant;
+
 import picocli.CommandLine;
-import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.util.Scanner;
-import java.util.concurrent.TimeUnit;
-
-@CommandLine.Command(name = "JSGLR2 CLI", sortOptions = false)
+@Command(name = "JSGLR2 CLI", sortOptions = false, mixinStandardHelpOptions = true)
 public class JSGLR2CLI implements Runnable {
 
-    @Option(names = { "-pt", "--parseTable" }, required = true,
-        description = "Parse table file") private File parseTableFile;
+    @Parameters(arity = "1..*", description = "The input file(s)/string(s) to be parsed") public String[] input;
 
-    @Parameters(arity = "1..*", description = "The input file(s)/string(s) to be parsed") private String[] input;
+    @Option(names = { "-i", "--im", "--implode" }, negatable = true,
+        description = "Implode parse tree to AST") public boolean implode = true;
 
-    @Option(names = { "-im", "--implode" }, negatable = true,
-        description = "Implode parse tree to AST") private boolean implode = true;
+    @Option(names = { "--logging" }, description = "Log parser operations") public boolean logging = false;
 
-    @Option(names = { "-p", "--preset" },
-        description = "Parser variant preset: ${COMPLETION-CANDIDATES}") private JSGLR2Variant.Preset preset = null;
+    @Option(names = { "-o", "--output" }, description = "Output file") public File outputFile;
 
-    @ArgGroup(exclusive = false, validate = false, heading = "Parser variant%n") ParserVariantOptions parserVariant =
-        new ParserVariantOptions();
+    @Option(names = { "-v", "--verbose" }, negatable = true,
+        description = "Print stack traces") public boolean verbose = false;
 
-    static class ParserVariantOptions {
-        @Option(names = { "--activeStacks" },
-            description = "Active stacks implementation: ${COMPLETION-CANDIDATES}") private ActiveStacksRepresentation activeStacksRepresentation =
-                ActiveStacksRepresentation.standard();
+    // TODO As alternative to the parser builder, we could also load a Spoofax language and use its parsing services.
+    // However, that cannot easily be combined with the custom output options, because 1) not all languages use JSGLR2
+    // and 2) you can't seem to be able to get a JSGLR2 parser instance from a Spoofax service...
+    @Mixin public ParserBuilder parserBuilder = new ParserBuilder();
 
-        @Option(names = { "--forActorStacks" },
-            description = "For actor stacks implementation: ${COMPLETION-CANDIDATES}") private ForActorStacksRepresentation forActorStacksRepresentation =
-                ForActorStacksRepresentation.standard();
+    @Mixin public DotOutputProcessor dotOutputOptions = new DotOutputProcessor();
 
-        @Option(names = { "--parseForest" },
-            description = "Parse forest representation: ${COMPLETION-CANDIDATES}") private ParseForestRepresentation parseForestRepresentation =
-                ParseForestRepresentation.standard();
-
-        @Option(names = { "--parseForestConstruction" },
-            description = "Parse forest construction method: ${COMPLETION-CANDIDATES}") private ParseForestConstruction parseForestConstruction =
-                ParseForestConstruction.standard();
-
-        @Option(names = { "--stack" },
-            description = "Stack representation: ${COMPLETION-CANDIDATES}") private StackRepresentation stackRepresentation =
-                StackRepresentation.standard();
-
-        @Option(names = { "--reducing" },
-            description = "Reducing implementation: ${COMPLETION-CANDIDATES}") private Reducing reducing =
-                Reducing.standard();
-
-        @Option(names = { "--recovery" }, description = "Recovery: ${COMPLETION-CANDIDATES}") private boolean recovery =
-            false;
-
-        @Option(names = { "--imploder" },
-            description = "Imploder variant: ${COMPLETION-CANDIDATES}") private ImploderVariant imploderVariant =
-                ImploderVariant.standard();
-
-        @Option(names = { "--tokenizer" },
-            description = "Tokenizer variant: ${COMPLETION-CANDIDATES}") private TokenizerVariant tokenizerVariant =
-                TokenizerVariant.standard();
-
-        JSGLR2Variant getVariant() throws WrappedException {
-            ParserVariant parserVariant = new ParserVariant(activeStacksRepresentation, forActorStacksRepresentation,
-                parseForestRepresentation, parseForestConstruction, stackRepresentation, reducing, recovery);
-
-            JSGLR2Variant variant = new JSGLR2Variant(parserVariant, imploderVariant, tokenizerVariant);
-
-            if(variant.isValid())
-                return variant;
-            else
-                throw new WrappedException("Invalid parser variant");
-        }
-    }
-
-    @ArgGroup(exclusive = false, validate = false,
-        heading = "Parse table variant%n") ParseTableVariantOptions parseTableVariant = new ParseTableVariantOptions();
-
-    static class ParseTableVariantOptions {
-        @Option(names = { "--actionsForCharacters" },
-            description = "Actions for character representation: ${COMPLETION-CANDIDATES}") private ActionsForCharacterRepresentation actionsForCharacterRepresentation =
-                ActionsForCharacterRepresentation.standard();
-
-        @Option(names = { "--productionToGoto" },
-            description = "Production to goto representation: ${COMPLETION-CANDIDATES}") private ProductionToGotoRepresentation productionToGotoRepresentation =
-                ProductionToGotoRepresentation.standard();
-
-        ParseTableVariant getVariant() {
-            return new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation);
-        }
-    }
-
-    @Option(names = { "--logging" }, description = "Log parser operations") boolean logging = false;
-
-    @ArgGroup(exclusive = false, validate = false, heading = "Output%n") OutputOptions outputOptions =
-        new OutputOptions();
-
-    static class OutputOptions {
-        boolean isParseResult() {
-            return dot == null;
-        }
-
-        @Option(names = { "-o", "--output" }, required = false, description = "Output file") private File outputFile;
-
-        @Option(names = "--dot", required = true,
-            description = "Visualization in DOT: ${COMPLETION-CANDIDATES}") DotVisualization dot;
-
-        @Option(names = "--dot-format", required = false,
-            description = "DOT format: ${COMPLETION-CANDIDATES}") DotVisualizationFormat dotFormat =
-                DotVisualizationFormat.Text;
-    }
-
-    enum DotVisualization {
-        Stack, ParseForest
-    }
-
-    enum DotVisualizationFormat {
-        Text, PDF, PNG
-    }
-
-    @Option(names = { "-v", "--verbose" }, negatable = true, description = "Print stack traces") boolean verbose =
-        false;
+    /**
+     * To create a custom output processor, just set this static variable to something else. For an example:
+     * 
+     * @see DotOutputProcessor#setDotOutputOptions
+     */
+    public static IOutputProcessor outputProcessor = new DefaultOutputProcessor();
 
     public static void main(String[] args) {
         int exitCode = new CommandLine(new JSGLR2CLI()).execute(args);
@@ -153,26 +63,24 @@ public class JSGLR2CLI implements Runnable {
         System.exit(exitCode);
     }
 
-    private OutputStream outputStream;
+    private PrintStream outputStream;
 
     public void run() {
         try {
-            IParseTable parseTable = getParseTable();
+            outputProcessor.checkAllowed(this);
+
             JSGLR2Implementation<?, ?, IStrategoTerm> jsglr2 =
-                (JSGLR2Implementation<?, ?, IStrategoTerm>) getJSGLR2(parseTable);
+                (JSGLR2Implementation<?, ?, IStrategoTerm>) parserBuilder.getJSGLR2();
             IObservableParser<?, ?, ?, ?, ?> observableParser = (IObservableParser<?, ?, ?, ?, ?>) jsglr2.parser;
 
             outputStream = outputStream();
 
             if(logging)
-                observableParser.observing().attachObserver(new LogParserObserver<>(this::output));
+                observableParser.observing().attachObserver(new LogParserObserver<>(outputStream::println));
 
-            if(outputOptions.dot == DotVisualization.Stack)
-                observableParser.observing().attachObserver(new StackDotVisualisationParserObserver<>(this::outputDot));
-
-            if(outputOptions.dot == DotVisualization.ParseForest)
-                observableParser.observing()
-                    .attachObserver(new ParseForestDotVisualisationParserObserver<>(this::outputDot));
+            for(ParserObserver observer : outputProcessor.observers()) {
+                observableParser.observing().attachObserver(observer);
+            }
 
             // For each input, try to check if it is a file, and if so, read its contents
             for(int i = 0; i < input.length; i++) {
@@ -188,113 +96,43 @@ public class JSGLR2CLI implements Runnable {
             }
 
             if(implode)
-                parseAndImplode(jsglr2);
+                parseAndImplode(jsglr2, outputProcessor);
             else
-                parse(jsglr2.parser);
+                parse(jsglr2.parser, outputProcessor);
         } catch(WrappedException e) {
-            failOnWrappedException(e, verbose);
+            failOnWrappedException(e);
         }
     }
 
-    private JSGLR2<IStrategoTerm> getJSGLR2(IParseTable parseTable) throws WrappedException {
-        if(preset == null)
-            return parserVariant.getVariant().getJSGLR2(parseTable);
-        else
-            return preset.getJSGLR2(parseTable);
-    }
-
-    private void parse(IParser<?> parser) {
+    private void parse(IParser<?> parser, IOutputProcessor outputProcessor) throws WrappedException {
         for(String in : input) {
             // Explicit filename to enable caching in incremental parser
             ParseResult<?> result = parser.parse(in, "cli", null);
 
-            if(result.isSuccess()) {
-                ParseSuccess<?> success = (ParseSuccess<?>) result;
-
-                if(outputOptions.isParseResult())
-                    output(success.parseResult.toString());
-            } else {
-                ParseFailure<?> failure = (ParseFailure<?>) result;
-
-                if(outputOptions.isParseResult())
-                    output(failure.failureType.message);
-            }
+            if(result.isSuccess())
+                outputProcessor.outputParseResult((ParseSuccess<?>) result, outputStream);
+            else
+                outputProcessor.outputParseFailure((ParseFailure<?>) result, outputStream);
         }
     }
 
-    private void parseAndImplode(JSGLR2Implementation<?, ?, IStrategoTerm> jsglr2) {
+    private void parseAndImplode(JSGLR2Implementation<?, ?, IStrategoTerm> jsglr2, IOutputProcessor outputProcessor)
+        throws WrappedException {
         for(String in : input) {
             // Explicit filename to enable caching in incremental parser
             JSGLR2Result<IStrategoTerm> result = jsglr2.parseResult(in, "cli", null);
 
-            if(result.isSuccess()) {
-                JSGLR2Success<IStrategoTerm> success = (JSGLR2Success<IStrategoTerm>) result;
-
-                if(outputOptions.isParseResult())
-                    output(success.ast.toString());
-            } else {
-                JSGLR2Failure<IStrategoTerm> failure = (JSGLR2Failure<IStrategoTerm>) result;
-
-                if(outputOptions.isParseResult())
-                    output(failure.parseFailure.failureType.message);
-            }
+            if(result.isSuccess())
+                outputProcessor.outputResult((JSGLR2Success<IStrategoTerm>) result, outputStream);
+            else
+                outputProcessor.outputFailure((JSGLR2Failure<IStrategoTerm>) result, outputStream);
         }
     }
 
-    private void output(String output) {
+    private PrintStream outputStream() throws WrappedException {
         try {
-            outputStream.write((output + "\n").getBytes(StandardCharsets.UTF_8));
-        } catch(IOException e) {
-            failOnWrappedException(new WrappedException("Writing output failed", e), verbose);
-        }
-    }
-
-    private void outputDot(String dot) {
-        try {
-            switch(outputOptions.dotFormat) {
-                case Text:
-                    output(dot);
-                    break;
-                case PDF:
-                    outputDot(dot, "pdf");
-                    break;
-                case PNG:
-                    outputDot(dot, "png");
-                    break;
-            }
-        } catch(WrappedException e) {
-            failOnWrappedException(e, verbose);
-        }
-    }
-
-    private void outputDot(String dot, String format) throws WrappedException {
-        try {
-            Process pr = Runtime.getRuntime().exec("dot -T" + format);
-
-            try(InputStream dotOutputStream = pr.getInputStream(); OutputStream input = pr.getOutputStream()) {
-                input.write(dot.getBytes(StandardCharsets.UTF_8));
-                input.close();
-
-                IOUtils.copy(dotOutputStream, outputStream);
-
-                if(!pr.waitFor(5, TimeUnit.SECONDS)) {
-                    int exitCode = pr.exitValue();
-
-                    if(exitCode == 0)
-                        throw new WrappedException("DOT timed out");
-                    else
-                        throw new WrappedException("DOT exited with " + exitCode);
-                }
-            }
-        } catch(IOException | InterruptedException e) {
-            throw new WrappedException("Writing output failed", e);
-        }
-    }
-
-    private OutputStream outputStream() throws WrappedException {
-        try {
-            if(outputOptions.outputFile != null)
-                return new FileOutputStream(outputOptions.outputFile);
+            if(outputFile != null)
+                return new PrintStream(outputFile);
             else
                 return System.out;
         } catch(FileNotFoundException e) {
@@ -302,24 +140,11 @@ public class JSGLR2CLI implements Runnable {
         }
     }
 
-    private IParseTable getParseTable() throws WrappedException {
-        try {
-            InputStream parseTableInputStream = new FileInputStream(parseTableFile);
-            ParseTableReader parseTableReader = parseTableVariant.getVariant().parseTableReader();
+    private void failOnWrappedException(WrappedException e) {
+        System.err.println(e.getMessage());
 
-            return parseTableReader.read(parseTableInputStream);
-        } catch(IOException e) {
-            throw new WrappedException("Invalid parse table file", e);
-        } catch(ParseTableReadException e) {
-            throw new WrappedException("Invalid parse table", e);
-        }
-    }
-
-    private static void failOnWrappedException(WrappedException e, boolean verbose) {
-        System.out.println(e.message);
-
-        if(verbose && e.exception != null)
-            e.exception.printStackTrace();
+        if(verbose && e.getCause() != null)
+            e.getCause().printStackTrace();
     }
 
 }

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/WrappedException.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/WrappedException.java
@@ -1,18 +1,13 @@
 package org.spoofax.jsglr2.cli;
 
-final class WrappedException extends Exception {
+public final class WrappedException extends Exception {
 
-    final String message;
-    final Exception exception;
-
-    WrappedException(String message, Exception exception) {
-        this.message = message;
-        this.exception = exception;
+    public WrappedException(String message, Exception exception) {
+        super(message, exception);
     }
 
-    WrappedException(String message) {
-        this.message = message;
-        this.exception = null;
+    public WrappedException(String message) {
+        super(message);
     }
 
 }

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/DefaultOutputProcessor.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/DefaultOutputProcessor.java
@@ -1,0 +1,19 @@
+package org.spoofax.jsglr2.cli.output;
+
+import java.io.PrintStream;
+
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.jsglr2.JSGLR2Success;
+import org.spoofax.jsglr2.parser.result.ParseSuccess;
+
+public class DefaultOutputProcessor implements IOutputProcessor {
+
+    @Override public void outputParseResult(ParseSuccess<?> parseResult, PrintStream output) {
+        output.println(parseResult.parseResult);
+    }
+
+    @Override public void outputResult(JSGLR2Success<IStrategoTerm> result, PrintStream output) {
+        output.println(result.ast);
+    }
+
+}

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/IOutputProcessor.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/IOutputProcessor.java
@@ -1,0 +1,37 @@
+package org.spoofax.jsglr2.cli.output;
+
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
+
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.jsglr2.JSGLR2Failure;
+import org.spoofax.jsglr2.JSGLR2Success;
+import org.spoofax.jsglr2.cli.JSGLR2CLI;
+import org.spoofax.jsglr2.cli.WrappedException;
+import org.spoofax.jsglr2.parser.observing.ParserObserver;
+import org.spoofax.jsglr2.parser.result.ParseFailure;
+import org.spoofax.jsglr2.parser.result.ParseSuccess;
+
+public interface IOutputProcessor {
+
+    default void checkAllowed(JSGLR2CLI cli) throws WrappedException {
+    }
+
+    default List<ParserObserver<?, ?, ?, ?, ?>> observers() {
+        return Collections.emptyList();
+    }
+
+    void outputParseResult(ParseSuccess<?> parseResult, PrintStream output) throws WrappedException;
+
+    default void outputParseFailure(ParseFailure<?> parseResult, PrintStream output) throws WrappedException {
+        output.println(parseResult.failureType.message);
+    }
+
+    void outputResult(JSGLR2Success<IStrategoTerm> result, PrintStream output) throws WrappedException;
+
+    default void outputFailure(JSGLR2Failure<IStrategoTerm> result, PrintStream output) throws WrappedException {
+        output.println(result.parseFailure.failureType.message);
+    }
+
+}

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/dot/DotOutputProcessor.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/dot/DotOutputProcessor.java
@@ -1,0 +1,116 @@
+package org.spoofax.jsglr2.cli.output.dot;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.jsglr2.JSGLR2Success;
+import org.spoofax.jsglr2.cli.JSGLR2CLI;
+import org.spoofax.jsglr2.cli.WrappedException;
+import org.spoofax.jsglr2.cli.output.IOutputProcessor;
+import org.spoofax.jsglr2.parser.observing.ParserObserver;
+import org.spoofax.jsglr2.parser.result.ParseSuccess;
+
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Option;
+
+public class DotOutputProcessor implements IOutputProcessor {
+
+    private DotOutputOptions dotOutputOptions;
+
+    @ArgGroup(exclusive = false, heading = "Dot output options%n") public void
+        setDotOutputOptions(DotOutputOptions dotOutputOptions) {
+        this.dotOutputOptions = dotOutputOptions;
+        JSGLR2CLI.outputProcessor = this;
+    }
+
+    static class DotOutputOptions {
+
+        @Option(names = "--dot",
+            description = "Visualization in DOT: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})") DotVisualization dot =
+                DotVisualization.ParseForest;
+
+        @Option(names = "--dot-format",
+            description = "DOT format: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})") DotVisualizationFormat dotFormat =
+                DotVisualizationFormat.text;
+
+    }
+
+    protected enum DotVisualization {
+        Stack, ParseForest
+    }
+
+    protected enum DotVisualizationFormat {
+        text,
+        // Not used directly, but converted to string in outputParseResult
+        @SuppressWarnings("unused")
+        pdf,
+        // Not used directly, but converted to string in outputParseResult
+        @SuppressWarnings("unused")
+        png
+    }
+
+    private DotVisualisationParserObserver<?, ?, ?, ?, ?> observer;
+
+    @Override public void checkAllowed(JSGLR2CLI cli) throws WrappedException {
+        if(cli.input.length != 1)
+            throw new WrappedException("Dot visualisation is only supported for exactly one input.");
+    }
+
+    @Override public List<ParserObserver<?, ?, ?, ?, ?>> observers() {
+        switch(dotOutputOptions.dot) {
+            default:
+            case ParseForest:
+                observer = new ParseForestDotVisualisationParserObserver<>();
+                break;
+            case Stack:
+                observer = new StackDotVisualisationParserObserver<>();
+                break;
+        }
+        return Collections.singletonList(observer);
+    }
+
+    @Override public void outputParseResult(ParseSuccess<?> parseResult, PrintStream output) throws WrappedException {
+        if(dotOutputOptions.dotFormat == DotVisualizationFormat.text)
+            output.println(observer.output());
+        else
+            outputDot(output, dotOutputOptions.dotFormat.name());
+    }
+
+    @Override public void outputResult(JSGLR2Success<IStrategoTerm> result, PrintStream output)
+        throws WrappedException {
+        outputParseResult(null, output);
+    }
+
+    private void outputDot(PrintStream output, String format) throws WrappedException {
+        try {
+            Process pr = Runtime.getRuntime().exec("dot -T" + format);
+
+            try(InputStream dotOutputStream = pr.getInputStream(); OutputStream input = pr.getOutputStream()) {
+                input.write(observer.output().getBytes(StandardCharsets.UTF_8));
+                input.close();
+
+                IOUtils.copy(dotOutputStream, output);
+
+                if(!pr.waitFor(5, TimeUnit.SECONDS)) {
+                    int exitCode = pr.exitValue();
+
+                    if(exitCode == 0)
+                        throw new WrappedException("DOT timed out");
+                    else
+                        throw new WrappedException("DOT exited with " + exitCode);
+                }
+            }
+        } catch(IOException | InterruptedException e) {
+            throw new WrappedException("Writing output failed", e);
+        }
+    }
+
+}

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/dot/DotVisualisationParserObserver.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/dot/DotVisualisationParserObserver.java
@@ -1,4 +1,4 @@
-package org.spoofax.jsglr2.cli;
+package org.spoofax.jsglr2.cli.output.dot;
 
 import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
@@ -9,8 +9,6 @@ import org.spoofax.jsglr2.parser.result.ParseFailure;
 import org.spoofax.jsglr2.parser.result.ParseSuccess;
 import org.spoofax.jsglr2.stack.IStackNode;
 
-import java.util.function.Consumer;
-
 abstract class DotVisualisationParserObserver
 //@formatter:off
    <ParseForest extends IParseForest,
@@ -20,12 +18,6 @@ abstract class DotVisualisationParserObserver
     ParseState  extends AbstractParseState<ParseForest, StackNode>>
 //@formatter:on
     extends ParserObserver<ParseForest, Derivation, ParseNode, StackNode, ParseState> {
-
-    final Consumer<String> outputConsumer;
-
-    DotVisualisationParserObserver(Consumer<String> outputConsumer) {
-        this.outputConsumer = outputConsumer;
-    }
 
     StringBuilder dotStatements;
 
@@ -48,7 +40,7 @@ abstract class DotVisualisationParserObserver
     }
 
     void dotStatement(String string) {
-        dotStatements.append(string + "\n");
+        dotStatements.append(string).append('\n');
     }
 
     @Override public void success(ParseSuccess<ParseForest> success) {
@@ -59,13 +51,13 @@ abstract class DotVisualisationParserObserver
         output();
     }
 
-    abstract void output();
+    public abstract String output();
 
     String escape(String string) {
         return string.replace("[", "\\[").replace("]", "\\]").replace("\"", "\\\"");
     }
 
-    String escapeHtml(String string) {
+    private String escapeHtml(String string) {
         return string.replace("<", "&lt;").replace(">", "&gt;");
     }
 

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/dot/ParseForestDotVisualisationParserObserver.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/dot/ParseForestDotVisualisationParserObserver.java
@@ -1,4 +1,4 @@
-package org.spoofax.jsglr2.cli;
+package org.spoofax.jsglr2.cli.output.dot;
 
 import org.metaborg.parsetable.productions.IProduction;
 import org.spoofax.jsglr2.parseforest.IDerivation;
@@ -7,9 +7,7 @@ import org.spoofax.jsglr2.parseforest.IParseNode;
 import org.spoofax.jsglr2.parser.AbstractParseState;
 import org.spoofax.jsglr2.stack.IStackNode;
 
-import java.util.function.Consumer;
-
-class ParseForestDotVisualisationParserObserver
+public class ParseForestDotVisualisationParserObserver
 //@formatter:off
    <ParseForest extends IParseForest,
     Derivation  extends IDerivation<ParseForest>,
@@ -18,10 +16,6 @@ class ParseForestDotVisualisationParserObserver
     ParseState  extends AbstractParseState<ParseForest, StackNode>>
 //@formatter:on
     extends DotVisualisationParserObserver<ParseForest, Derivation, ParseNode, StackNode, ParseState> {
-
-    public ParseForestDotVisualisationParserObserver(Consumer<String> outputConsumer) {
-        super(outputConsumer);
-    }
 
     @Override public void parseStart(ParseState parseState) {
         super.parseStart(parseState);
@@ -53,26 +47,24 @@ class ParseForestDotVisualisationParserObserver
             dotStatement(parseNodeId(parseForest) + ":p:n -> " + derivationId(derivation) + ":p:s;");
     }
 
-    String parseNodeId(ParseForest parseNode) {
+    private String parseNodeId(ParseForest parseNode) {
         return parseNodeId(id(parseNode));
     }
 
-    String parseNodeId(int id) {
+    private String parseNodeId(int id) {
         return "parseNode_" + id;
     }
 
-    String derivationId(IDerivation<ParseForest> derivation) {
+    private String derivationId(IDerivation<ParseForest> derivation) {
         return derivationId(id(derivation));
     }
 
-    String derivationId(int id) {
+    private String derivationId(int id) {
         return "derivation_" + id;
     }
 
-    void output() {
-        String prefix = "digraph {\nrankdir = BT;\n";
-
-        outputConsumer.accept(prefix + dotStatements + "}");
+    public String output() {
+        return "digraph {\nrankdir = BT;\n" + dotStatements + "}";
     }
 
 }

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/dot/StackDotVisualisationParserObserver.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/output/dot/StackDotVisualisationParserObserver.java
@@ -1,4 +1,10 @@
-package org.spoofax.jsglr2.cli;
+package org.spoofax.jsglr2.cli.output.dot;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
@@ -6,13 +12,6 @@ import org.spoofax.jsglr2.parseforest.IParseNode;
 import org.spoofax.jsglr2.parser.AbstractParseState;
 import org.spoofax.jsglr2.stack.IStackNode;
 import org.spoofax.jsglr2.stack.StackLink;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 class StackDotVisualisationParserObserver
 //@formatter:off
@@ -30,16 +29,13 @@ class StackDotVisualisationParserObserver
     private int[] offsetMaxStackNodeRank;
     private Map<StackNode, Integer> stackNodeOffset;
 
-    public StackDotVisualisationParserObserver(Consumer<String> outputConsumer) {
-        super(outputConsumer);
-    }
-
     @Override public void parseStart(ParseState parseState) {
         super.parseStart(parseState);
         stackNodeRank = new HashMap<>();
         currentOffset = 0;
         maxStackNodeRank = 0;
         offsetMaxStackNodeRank = new int[parseState.inputLength + 1];
+        stackNodeOffset = new HashMap<>();
     }
 
     @Override public void parseRound(ParseState parseState, Iterable<StackNode> activeStacks) {
@@ -80,15 +76,15 @@ class StackDotVisualisationParserObserver
             + id(link.parseForest) + ": " + escape(link.parseForest.descriptor()) + "\"];");
     }
 
-    String stackNodeId(StackNode stack) {
+    private String stackNodeId(StackNode stack) {
         return stackNodeId(id(stack));
     }
 
-    String stackNodeId(int id) {
+    private String stackNodeId(int id) {
         return "stack_" + id;
     }
 
-    void output() {
+    public String output() {
         String prefix = "digraph {\nrankdir = LR;\nedge [dir=\"back\"];\n";
 
         for(int rank = 0; rank <= maxStackNodeRank; rank++) {
@@ -103,7 +99,7 @@ class StackDotVisualisationParserObserver
                 + stackNodesForRank.stream().map(id -> stackNodeId(id) + ";").collect(Collectors.joining()) + "}");
         }
 
-        outputConsumer.accept(prefix + dotStatements + "}");
+        return prefix + dotStatements + "}";
     }
 
 }

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/ParseTableOptions.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/ParseTableOptions.java
@@ -1,6 +1,5 @@
 package org.spoofax.jsglr2.cli.parserbuilder;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -8,6 +7,7 @@ import java.util.zip.ZipFile;
 
 import org.metaborg.parsetable.IParseTable;
 import org.metaborg.parsetable.ParseTableReadException;
+import org.spoofax.jsglr2.cli.JSGLR2CLI;
 import org.spoofax.jsglr2.cli.WrappedException;
 
 import picocli.CommandLine.ArgGroup;
@@ -15,23 +15,20 @@ import picocli.CommandLine.Option;
 
 @SuppressWarnings("WeakerAccess")
 public class ParseTableOptions {
-    @Option(names = { "-t", "--pt", "--parseTable" }, required = true,
-        description = "Parse table file") private String parseTableFile;
+    @Option(names = { "-t", "--pt", "--parseTable" }, description = "Parse table file") public String parseTableFile;
 
     @ArgGroup(exclusive = false,
-        heading = "Parse table variant%n") private ParserBuilder.ParseTableVariantOptions parseTableVariant =
+        heading = "Parse table variant%n") public ParserBuilder.ParseTableVariantOptions parseTableVariant =
             new ParserBuilder.ParseTableVariantOptions();
 
     IParseTable getParseTable() throws WrappedException {
         try {
-            File file = new File(parseTableFile);
             final InputStream parseTableInputStream;
-            if(file.isFile()) {
-                parseTableInputStream = new FileInputStream(parseTableFile);
-            } else {
-                // If the parse table file cannot directly be found, try to dig into the local maven repository
-                ZipFile languageZip = new ZipFile(SpoofaxLanguageFinder.getSpoofaxLanguage(this.parseTableFile));
+            if(JSGLR2CLI.language != null) {
+                ZipFile languageZip = new ZipFile(SpoofaxLanguageFinder.getSpoofaxLanguage(JSGLR2CLI.language));
                 parseTableInputStream = languageZip.getInputStream(languageZip.getEntry("target/metaborg/sdf.tbl"));
+            } else {
+                parseTableInputStream = new FileInputStream(parseTableFile);
             }
 
             return parseTableVariant.getVariant().parseTableReader().read(parseTableInputStream);

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/ParseTableOptions.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/ParseTableOptions.java
@@ -1,0 +1,45 @@
+package org.spoofax.jsglr2.cli.parserbuilder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipFile;
+
+import org.metaborg.parsetable.IParseTable;
+import org.metaborg.parsetable.ParseTableReadException;
+import org.spoofax.jsglr2.cli.WrappedException;
+
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Option;
+
+@SuppressWarnings("WeakerAccess")
+public class ParseTableOptions {
+    @Option(names = { "-t", "--pt", "--parseTable" }, required = true,
+        description = "Parse table file") private String parseTableFile;
+
+    @ArgGroup(exclusive = false,
+        heading = "Parse table variant%n") private ParserBuilder.ParseTableVariantOptions parseTableVariant =
+            new ParserBuilder.ParseTableVariantOptions();
+
+    IParseTable getParseTable() throws WrappedException {
+        try {
+            File file = new File(parseTableFile);
+            final InputStream parseTableInputStream;
+            if(file.isFile()) {
+                parseTableInputStream = new FileInputStream(parseTableFile);
+            } else {
+                // If the parse table file cannot directly be found, try to dig into the local maven repository
+                ZipFile languageZip = new ZipFile(SpoofaxLanguageFinder.getSpoofaxLanguage(this.parseTableFile));
+                parseTableInputStream = languageZip.getInputStream(languageZip.getEntry("target/metaborg/sdf.tbl"));
+            }
+
+            return parseTableVariant.getVariant().parseTableReader().read(parseTableInputStream);
+        } catch(IOException e) {
+            throw new WrappedException("Invalid parse table file", e);
+        } catch(ParseTableReadException e) {
+            throw new WrappedException("Invalid parse table", e);
+        }
+    }
+
+}

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/ParserBuilder.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/ParserBuilder.java
@@ -22,7 +22,7 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
 public class ParserBuilder {
-    @Mixin private ParseTableOptions parseTableOptions = new ParseTableOptions();
+    @Mixin public ParseTableOptions parseTableOptions = new ParseTableOptions();
 
     @SuppressWarnings("DefaultAnnotationParam") @ArgGroup(exclusive = true,
         heading = "Parser preset%n") private PresetOrVariantOptions presetOrVariantOptions =

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/ParserBuilder.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/ParserBuilder.java
@@ -1,0 +1,110 @@
+package org.spoofax.jsglr2.cli.parserbuilder;
+
+import org.metaborg.parsetable.query.ActionsForCharacterRepresentation;
+import org.metaborg.parsetable.query.ProductionToGotoRepresentation;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.jsglr2.JSGLR2;
+import org.spoofax.jsglr2.JSGLR2Variant;
+import org.spoofax.jsglr2.cli.WrappedException;
+import org.spoofax.jsglr2.imploder.ImploderVariant;
+import org.spoofax.jsglr2.integration.ParseTableVariant;
+import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
+import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
+import org.spoofax.jsglr2.parser.ParserVariant;
+import org.spoofax.jsglr2.reducing.Reducing;
+import org.spoofax.jsglr2.stack.StackRepresentation;
+import org.spoofax.jsglr2.stack.collections.ActiveStacksRepresentation;
+import org.spoofax.jsglr2.stack.collections.ForActorStacksRepresentation;
+import org.spoofax.jsglr2.tokens.TokenizerVariant;
+
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+public class ParserBuilder {
+    @Mixin private ParseTableOptions parseTableOptions = new ParseTableOptions();
+
+    @SuppressWarnings("DefaultAnnotationParam") @ArgGroup(exclusive = true,
+        heading = "Parser preset%n") private PresetOrVariantOptions presetOrVariantOptions =
+            new PresetOrVariantOptions();
+
+    public static class PresetOrVariantOptions {
+        @Option(names = { "-p", "--preset" },
+            description = "Parser variant preset: ${COMPLETION-CANDIDATES}") JSGLR2Variant.Preset preset = null;
+
+        @ArgGroup(exclusive = false, heading = "Parser variant%n") ParserVariantOptions parserVariant =
+            new ParserVariantOptions();
+
+        JSGLR2Variant getVariant() throws WrappedException {
+            return preset != null ? preset.variant : parserVariant.getVariant();
+        }
+    }
+
+    public static class ParserVariantOptions {
+        @Option(names = { "--activeStacks" },
+            description = "Active stacks implementation: ${COMPLETION-CANDIDATES}") private ActiveStacksRepresentation activeStacksRepresentation =
+                ActiveStacksRepresentation.standard();
+
+        @Option(names = { "--forActorStacks" },
+            description = "For actor stacks implementation: ${COMPLETION-CANDIDATES}") private ForActorStacksRepresentation forActorStacksRepresentation =
+                ForActorStacksRepresentation.standard();
+
+        @Option(names = { "--parseForest" },
+            description = "Parse forest representation: ${COMPLETION-CANDIDATES}") private ParseForestRepresentation parseForestRepresentation =
+                ParseForestRepresentation.standard();
+
+        @Option(names = { "--parseForestConstruction" },
+            description = "Parse forest construction method: ${COMPLETION-CANDIDATES}") private ParseForestConstruction parseForestConstruction =
+                ParseForestConstruction.standard();
+
+        @Option(names = { "--stack" },
+            description = "Stack representation: ${COMPLETION-CANDIDATES}") private StackRepresentation stackRepresentation =
+                StackRepresentation.standard();
+
+        @Option(names = { "--reducing" },
+            description = "Reducing implementation: ${COMPLETION-CANDIDATES}") private Reducing reducing =
+                Reducing.standard();
+
+        @Option(names = { "--recovery" }, description = "Recovery: ${COMPLETION-CANDIDATES}") private boolean recovery =
+            false;
+
+        @Option(names = { "--imploder" },
+            description = "Imploder variant: ${COMPLETION-CANDIDATES}") private ImploderVariant imploderVariant =
+                ImploderVariant.standard();
+
+        @Option(names = { "--tokenizer" },
+            description = "Tokenizer variant: ${COMPLETION-CANDIDATES}") private TokenizerVariant tokenizerVariant =
+                TokenizerVariant.standard();
+
+        JSGLR2Variant getVariant() throws WrappedException {
+            ParserVariant parserVariant = new ParserVariant(activeStacksRepresentation, forActorStacksRepresentation,
+                parseForestRepresentation, parseForestConstruction, stackRepresentation, reducing, recovery);
+
+            JSGLR2Variant variant = new JSGLR2Variant(parserVariant, imploderVariant, tokenizerVariant);
+
+            if(variant.isValid())
+                return variant;
+            else
+                throw new WrappedException("Invalid parser variant");
+        }
+    }
+
+    static class ParseTableVariantOptions {
+        @Option(names = { "--actionsForCharacters" },
+            description = "Actions for character representation: ${COMPLETION-CANDIDATES}") private ActionsForCharacterRepresentation actionsForCharacterRepresentation =
+                ActionsForCharacterRepresentation.standard();
+
+        @Option(names = { "--productionToGoto" },
+            description = "Production to goto representation: ${COMPLETION-CANDIDATES}") private ProductionToGotoRepresentation productionToGotoRepresentation =
+                ProductionToGotoRepresentation.standard();
+
+        ParseTableVariant getVariant() {
+            return new ParseTableVariant(actionsForCharacterRepresentation, productionToGotoRepresentation);
+        }
+    }
+
+    public JSGLR2<IStrategoTerm> getJSGLR2() throws WrappedException {
+        return presetOrVariantOptions.getVariant().getJSGLR2(parseTableOptions.getParseTable());
+    }
+
+}

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/SpoofaxLanguageFinder.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/SpoofaxLanguageFinder.java
@@ -3,7 +3,11 @@ package org.spoofax.jsglr2.cli.parserbuilder;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.apache.commons.io.comparator.NameFileComparator;
 import org.spoofax.jsglr2.cli.WrappedException;
@@ -46,9 +50,18 @@ public final class SpoofaxLanguageFinder {
 
     private static String getLocalRepository() throws WrappedException {
         try {
-            return new BufferedReader(new InputStreamReader(Runtime.getRuntime()
-                .exec("mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout").getInputStream()))
-                    .readLine();
+            // Caching the repo location somewhere in the tmpdir so that we don't need to get it every time again
+            Path tmpFile = Paths.get(System.getProperty("java.io.tmpdir"), "SpoofaxLanguageFinder_maven_repo.txt");
+            if(tmpFile.toFile().exists()) {
+                return Files.readAllLines(tmpFile).get(0);
+            } else {
+                // This command takes like two seconds to run...
+                final String repoLocation = new BufferedReader(new InputStreamReader(Runtime.getRuntime()
+                    .exec("mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout").getInputStream()))
+                        .readLine();
+                Files.write(tmpFile, Collections.singletonList(repoLocation));
+                return repoLocation;
+            }
         } catch(Exception e) {
             throw new WrappedException("Could not locate local Maven repository", e);
         }

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/SpoofaxLanguageFinder.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/SpoofaxLanguageFinder.java
@@ -17,9 +17,10 @@ public final class SpoofaxLanguageFinder {
      * "org/metaborg/lang.java".
      *
      * @param repoName
-     *            The identifier of the language in the repository, in the format "[groupId]/[artifactId]/[version]",
-     *            where the groupId is slash-separated, the artifactId is period-separated, and the version is optional.
-     *            Example: "org/metaborg/lang.java/1.1.0-SNAPSHOT"
+     *            The identifier of a Spoofax language in the local Maven repository, in the format
+     *            "[groupId]/[artifactId]/[version]", where the groupId is slash-separated, the artifactId is
+     *            period-separated, and the version is optional. Examples: "org/metaborg/lang.java",
+     *            "org/metaborg/lang.java/1.1.0-SNAPSHOT"
      * @return A *.spoofax-language file.
      */
     public static File getSpoofaxLanguage(String repoName) throws WrappedException {

--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/SpoofaxLanguageFinder.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/parserbuilder/SpoofaxLanguageFinder.java
@@ -1,0 +1,55 @@
+package org.spoofax.jsglr2.cli.parserbuilder;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+import org.apache.commons.io.comparator.NameFileComparator;
+import org.spoofax.jsglr2.cli.WrappedException;
+
+@SuppressWarnings("WeakerAccess")
+public final class SpoofaxLanguageFinder {
+    /**
+     * This only works when the repoName is formatted like "path/to/group/id/artifactId[/version]". Providing a version
+     * is optional; note however that the version you provide must already be installed. Example: for the groupId
+     * "org.metaborg" and the artifactId "lang.java", you would be able to find this language using
+     * "org/metaborg/lang.java".
+     *
+     * @param repoName
+     *            The identifier of the language in the repository, in the format "[groupId]/[artifactId]/[version]",
+     *            where the groupId is slash-separated, the artifactId is period-separated, and the version is optional.
+     *            Example: "org/metaborg/lang.java/1.1.0-SNAPSHOT"
+     * @return A *.spoofax-language file.
+     */
+    public static File getSpoofaxLanguage(String repoName) throws WrappedException {
+        File repoFolder = new File(getLocalRepository()).toPath().resolve(repoName).toFile();
+        File[] versionDirs = repoFolder.listFiles(File::isDirectory);
+
+        // If we find version directories, the version is not provided. We choose the latest version.
+        if(versionDirs != null && versionDirs.length > 0) {
+            Arrays.sort(versionDirs, NameFileComparator.NAME_REVERSE);
+            repoFolder = versionDirs[0];
+        }
+
+        // If no version directories are found, either the version is already provided or there's nothing
+        File[] languageFiles = repoFolder.listFiles((f, n) -> n.endsWith(".spoofax-language"));
+        if(languageFiles == null || languageFiles.length == 0)
+            // In this case, there's nothing :(
+            throw new WrappedException("Language not found in local Maven repository: " + repoName);
+
+        // There can be multiple *.spoofax-language files; take the one with the latest version name
+        Arrays.sort(languageFiles, NameFileComparator.NAME_REVERSE);
+        return languageFiles[0];
+    }
+
+    private static String getLocalRepository() throws WrappedException {
+        try {
+            return new BufferedReader(new InputStreamReader(Runtime.getRuntime()
+                .exec("mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout").getInputStream()))
+                    .readLine();
+        } catch(Exception e) {
+            throw new WrappedException("Could not locate local Maven repository", e);
+        }
+    }
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variant.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variant.java
@@ -185,7 +185,7 @@ public class JSGLR2Variant {
                 TokenizerVariant.Recursive));
         // @formatter:on
 
-        public JSGLR2Variant variant;
+        public final JSGLR2Variant variant;
 
         Preset(JSGLR2Variant variant) {
             this.variant = variant;


### PR DESCRIPTION
I've done a major refactoring to the way that the CLI works. Most notable changes:

- The output options are no longer hardcoded in the CLI class, but are moved to a separate class and can be swapped in or out by setting `JSGLR2CLI.outputProcessor`. The output processor has to implement a couple of methods that check whether the config is correct (`checkAllowed`), whether the parser should receive observers (`observers`), and four methods for processing the parse/implode result/failure.
- The CLI can now load an SDF file by peeking in the `*.spoofax-language` file for the language identifier given as `--language` option.
	- This used to be a hidden feature in `--parseTable`, but for extensibility it's better to separate these options.
	- The location of the local Maven repository is get via a Maven command and is cached in `/tmp` because this command takes a couple of seconds to run.

Has been extended in ChielBruin/spoofax-latex-tools#3. 