### PR TITLE
Consistent tokens

### DIFF
--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -238,7 +238,7 @@ public abstract class BaseTest implements WithParseTable {
                 actualTokens.add(TokenDescriptor.from(inputString, token));
             }
 
-            TokenDescriptor expectedStartToken = new TokenDescriptor("", IToken.TK_RESERVED, 0, 1, 1);
+            TokenDescriptor expectedStartToken = new TokenDescriptor("", IToken.TK_RESERVED, 0, 1, 1, null, null);
             TokenDescriptor actualStartToken = actualTokens.get(0);
 
             assertEquals(variantPrefix + "\nStart token incorrect:", expectedStartToken, actualStartToken);
@@ -249,7 +249,7 @@ public abstract class BaseTest implements WithParseTable {
             int endColumn = endPosition.column;
 
             TokenDescriptor expectedEndToken =
-                new TokenDescriptor("", IToken.TK_EOF, inputString.length(), endLine, endColumn - 1);
+                new TokenDescriptor("", IToken.TK_EOF, inputString.length(), endLine, endColumn - 1, null, null);
             TokenDescriptor actualEndToken = actualTokens.get(actualTokens.size() - 1);
 
             List<TokenDescriptor> actualTokensWithoutStartAndEnd = actualTokens.subList(1, actualTokens.size() - 1);

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -227,7 +227,8 @@ public abstract class BaseTest implements WithParseTable {
         for(TestVariant variant : getTestVariants()) {
             JSGLR2Result<?> jsglr2Result = variant.jsglr2().parseResult(inputString, "", null);
 
-            assertTrue("Variant '" + variant.name() + "' failed", jsglr2Result.isSuccess());
+            String variantPrefix = "Variant '" + variant.name() + "' failed";
+            assertTrue(variantPrefix, jsglr2Result.isSuccess());
 
             JSGLR2Success<?> jsglr2Success = (JSGLR2Success<?>) jsglr2Result;
 
@@ -240,7 +241,7 @@ public abstract class BaseTest implements WithParseTable {
             TokenDescriptor expectedStartToken = new TokenDescriptor("", IToken.TK_RESERVED, 0, 1, 1);
             TokenDescriptor actualStartToken = actualTokens.get(0);
 
-            assertEquals("Start token incorrect:", expectedStartToken, actualStartToken);
+            assertEquals(variantPrefix + "\nStart token incorrect:", expectedStartToken, actualStartToken);
 
             Position endPosition = Position.atEnd(inputString);
 
@@ -253,9 +254,10 @@ public abstract class BaseTest implements WithParseTable {
 
             List<TokenDescriptor> actualTokensWithoutStartAndEnd = actualTokens.subList(1, actualTokens.size() - 1);
 
-            assertThat(actualTokensWithoutStartAndEnd, is(expectedTokens));
+            assertThat(variantPrefix + "\nToken lists don't match:", actualTokensWithoutStartAndEnd,
+                is(expectedTokens));
 
-            assertEquals("End token incorrect:", expectedEndToken, actualEndToken);
+            assertEquals(variantPrefix + "\nEnd token incorrect:", expectedEndToken, actualEndToken);
         }
     }
 

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/TokenDescriptor.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/TokenDescriptor.java
@@ -1,19 +1,30 @@
 package org.spoofax.jsglr2.integrationtest;
 
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.imploder.IToken;
+import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 
 public final class TokenDescriptor {
 
     public final String token;
     public final int kind;
     public final int offset, line, column;
+    @Nullable public String sort, cons;
 
-    public TokenDescriptor(String token, int kind, int offset, int line, int column) {
+    public TokenDescriptor(String token, int kind, int offset, int line, int column, @Nullable String sort,
+        @Nullable String cons) {
         this.token = token;
         this.kind = kind;
         this.offset = offset;
         this.line = line;
         this.column = column;
+        this.sort = sort;
+        this.cons = cons;
     }
 
     public static TokenDescriptor from(String inputString, IToken token) {
@@ -24,8 +35,12 @@ public final class TokenDescriptor {
         else
             inputPart = "";
 
+        IStrategoTerm astNode = (IStrategoTerm) token.getAstNode();
+        String sort = astNode == null ? null : ImploderAttachment.get(astNode).getSort();
+        String cons = astNode == null ? null
+            : astNode.getTermType() == IStrategoTerm.APPL ? ((IStrategoAppl) astNode).getConstructor().getName() : null;
         return new TokenDescriptor(inputPart, token.getKind(), token.getStartOffset(), token.getLine(),
-            token.getColumn());
+            token.getColumn(), sort, cons);
     }
 
     @Override public boolean equals(Object obj) {
@@ -35,11 +50,12 @@ public final class TokenDescriptor {
         TokenDescriptor other = (TokenDescriptor) obj;
 
         return token.equals(other.token) && kind == other.kind && offset == other.offset && line == other.line
-            && column == other.column;
+            && column == other.column && Objects.equals(sort, other.sort) && Objects.equals(cons, other.cons);
     }
 
     @Override public String toString() {
-        return "<'" + token.replace("\n", "\\n") + "';" + kind + ";" + offset + ";" + line + "," + column + ">";
+        return "<'" + token.replace("\n", "\\n") + "';" + kind + ";" + offset + ";" + line + "," + column + ";" + sort
+            + "." + cons + ">";
     }
 
 }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/grammars/TokenizationTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/grammars/TokenizationTest.java
@@ -17,7 +17,7 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     @Test public void number() throws ParseError {
         testTokens("1", Arrays.asList(
         //@formatter:off
-            new TokenDescriptor("1", IToken.TK_NUMBER, 0, 1, 1)
+            new TokenDescriptor("1", IToken.TK_NUMBER, 0, 1, 1, "NUMBER", null)
         //@formatter:on
         ));
     }
@@ -25,7 +25,7 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     @Test public void identifier() throws ParseError {
         testTokens("x", Arrays.asList(
         //@formatter:off
-            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 0, 1, 1)
+            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 0, 1, 1, "ID", null)
         //@formatter:on
         ));
     }
@@ -33,9 +33,9 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     @Test public void operator() throws ParseError {
         testTokens("x+x", Arrays.asList(
         //@formatter:off
-            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 0, 1, 1),
-            new TokenDescriptor("+", IToken.TK_OPERATOR,   1, 1, 2),
-            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 2, 1, 3)
+            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 0, 1, 1, "ID", null),
+            new TokenDescriptor("+", IToken.TK_OPERATOR,   1, 1, 2, "Exp", "AddOperator"),
+            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 2, 1, 3, "ID", null)
         //@formatter:on
         ));
     }
@@ -43,11 +43,11 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     @Test public void operatorWithLayout() throws ParseError {
         testTokens("x + x", Arrays.asList(
         //@formatter:off
-            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 0, 1, 1),
-            new TokenDescriptor(" ", IToken.TK_LAYOUT,     1, 1, 2),
-            new TokenDescriptor("+", IToken.TK_OPERATOR,   2, 1, 3),
-            new TokenDescriptor(" ", IToken.TK_LAYOUT,     3, 1, 4),
-            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 4, 1, 5)
+            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 0, 1, 1, "ID", null),
+            new TokenDescriptor(" ", IToken.TK_LAYOUT,     1, 1, 2, "Exp", "AddOperator"),
+            new TokenDescriptor("+", IToken.TK_OPERATOR,   2, 1, 3, "Exp", "AddOperator"),
+            new TokenDescriptor(" ", IToken.TK_LAYOUT,     3, 1, 4, "Exp", "AddOperator"),
+            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 4, 1, 5, "ID", null)
         //@formatter:on
         ));
     }
@@ -55,13 +55,13 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     @Test public void operatorWithLayout2() throws ParseError {
         testTokens(" x + x ", Arrays.asList(
         //@formatter:off
-            new TokenDescriptor(" ", IToken.TK_LAYOUT,     0, 1, 1),
-            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 1, 1, 2),
-            new TokenDescriptor(" ", IToken.TK_LAYOUT,     2, 1, 3),
-            new TokenDescriptor("+", IToken.TK_OPERATOR,   3, 1, 4),
-            new TokenDescriptor(" ", IToken.TK_LAYOUT,     4, 1, 5),
-            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 5, 1, 6),
-            new TokenDescriptor(" ", IToken.TK_LAYOUT,     6, 1, 7)
+            new TokenDescriptor(" ", IToken.TK_LAYOUT,     0, 1, 1, null, null),
+            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 1, 1, 2, "ID", null),
+            new TokenDescriptor(" ", IToken.TK_LAYOUT,     2, 1, 3, "Exp", "AddOperator"),
+            new TokenDescriptor("+", IToken.TK_OPERATOR,   3, 1, 4, "Exp", "AddOperator"),
+            new TokenDescriptor(" ", IToken.TK_LAYOUT,     4, 1, 5, "Exp", "AddOperator"),
+            new TokenDescriptor("x", IToken.TK_IDENTIFIER, 5, 1, 6, "ID", null),
+            new TokenDescriptor(" ", IToken.TK_LAYOUT,     6, 1, 7, null, null)
         //@formatter:on
         ));
     }
@@ -69,11 +69,11 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     @Test public void keywordWithLayout() throws ParseError {
         testTokens("x add x", Arrays.asList(
         //@formatter:off
-            new TokenDescriptor("x",   IToken.TK_IDENTIFIER, 0, 1, 1),
-            new TokenDescriptor(" ",   IToken.TK_LAYOUT,     1, 1, 2),
-            new TokenDescriptor("add", IToken.TK_KEYWORD,    2, 1, 3),
-            new TokenDescriptor(" ",   IToken.TK_LAYOUT,     5, 1, 6),
-            new TokenDescriptor("x",   IToken.TK_IDENTIFIER, 6, 1, 7)
+            new TokenDescriptor("x",   IToken.TK_IDENTIFIER, 0, 1, 1, "ID", null),
+            new TokenDescriptor(" ",   IToken.TK_LAYOUT,     1, 1, 2, "Exp", "AddKeyword"),
+            new TokenDescriptor("add", IToken.TK_KEYWORD,    2, 1, 3, "Exp", "AddKeyword"),
+            new TokenDescriptor(" ",   IToken.TK_LAYOUT,     5, 1, 6, "Exp", "AddKeyword"),
+            new TokenDescriptor("x",   IToken.TK_IDENTIFIER, 6, 1, 7, "ID", null)
         //@formatter:on
         ));
     }
@@ -81,11 +81,11 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     @Test public void keywordWithNumber() throws ParseError {
         testTokens("x add2 x", Arrays.asList(
         //@formatter:off
-            new TokenDescriptor("x",    IToken.TK_IDENTIFIER, 0, 1, 1),
-            new TokenDescriptor(" ",    IToken.TK_LAYOUT,     1, 1, 2),
-            new TokenDescriptor("add2", IToken.TK_KEYWORD,    2, 1, 3),
-            new TokenDescriptor(" ",    IToken.TK_LAYOUT,     6, 1, 7),
-            new TokenDescriptor("x",    IToken.TK_IDENTIFIER, 7, 1, 8)
+            new TokenDescriptor("x",    IToken.TK_IDENTIFIER, 0, 1, 1, "ID", null),
+            new TokenDescriptor(" ",    IToken.TK_LAYOUT,     1, 1, 2, "Exp", "Add2Keyword"),
+            new TokenDescriptor("add2", IToken.TK_KEYWORD,    2, 1, 3, "Exp", "Add2Keyword"),
+            new TokenDescriptor(" ",    IToken.TK_LAYOUT,     6, 1, 7, "Exp", "Add2Keyword"),
+            new TokenDescriptor("x",    IToken.TK_IDENTIFIER, 7, 1, 8, "ID", null)
         //@formatter:on
         ));
     }
@@ -93,10 +93,10 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     @Test public void multipleLines() throws ParseError {
         testTokens("x;\nx", Arrays.asList(
         //@formatter:off
-            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 0, 1, 1),
-            new TokenDescriptor(";",  IToken.TK_OPERATOR,   1, 1, 2),
-            new TokenDescriptor("\n", IToken.TK_LAYOUT,     2, 1, 3),
-            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 3, 2, 1)
+            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 0, 1, 1, "ID", null),
+            new TokenDescriptor(";",  IToken.TK_OPERATOR,   1, 1, 2, null, null),
+            new TokenDescriptor("\n", IToken.TK_LAYOUT,     2, 1, 3, null, null),
+            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 3, 2, 1, "ID", null)
         //@formatter:on
         ));
     }
@@ -104,11 +104,11 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     @Test public void multipleLinesNewlineEnd() throws ParseError {
         testTokens("x;\nx\n", Arrays.asList(
         //@formatter:off
-            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 0, 1, 1),
-            new TokenDescriptor(";",  IToken.TK_OPERATOR,   1, 1, 2),
-            new TokenDescriptor("\n", IToken.TK_LAYOUT,     2, 1, 3),
-            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 3, 2, 1),
-            new TokenDescriptor("\n", IToken.TK_LAYOUT,     4, 2, 2)
+            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 0, 1, 1, "ID", null),
+            new TokenDescriptor(";",  IToken.TK_OPERATOR,   1, 1, 2, null, null),
+            new TokenDescriptor("\n", IToken.TK_LAYOUT,     2, 1, 3, null, null),
+            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 3, 2, 1, "ID", null),
+            new TokenDescriptor("\n", IToken.TK_LAYOUT,     4, 2, 2, null, null)
         //@formatter:on
         ));
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeImploder.java
@@ -179,14 +179,15 @@ public class IterativeTreeImploder
 
     private SubTree<Tree> createAmbiguousSubTree(ParseNode parseNode, List<SubTree<Tree>> subTrees) {
         return new SubTree<>(treeFactory.createAmb(subTrees.stream().map(t -> t.tree)::iterator), subTrees, null, null,
-            subTrees.get(0).width);
+            subTrees.get(0).width, false);
     }
 
     private SubTree<Tree> createNonTerminalSubTree(IProduction production, List<SubTree<Tree>> subTrees) {
-        return new SubTree<>(
-            createContextFreeTerm(production,
-                subTrees.stream().filter(t -> t.tree != null).map(t -> t.tree).collect(Collectors.toList())),
-            subTrees, production);
+        List<Tree> childASTs =
+            subTrees.stream().filter(t -> t.tree != null).map(t -> t.tree).collect(Collectors.toList());
+        Tree contextFreeTerm = createContextFreeTerm(production, childASTs);
+        return new SubTree<>(contextFreeTerm, subTrees, production,
+            childASTs.size() > 0 && contextFreeTerm == childASTs.get(0));
     }
 
     private SubTree<Tree> createLexicalSubTree(String inputString, ParseNode parseNode, int startOffset,

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
@@ -41,7 +41,7 @@ public abstract class IterativeTreeTokenizer<Tree> extends TreeTokenizer<Tree> {
                 Position pivotPosition = currentPos;
                 for(SubTree subTree : currentOut) {
                     // If child tree had tokens that were not yet bound, bind them
-                    if(tree.tree == null) {
+                    if(subTree.tree == null) {
                         if(subTree.leftToken != null)
                             tokenTreeBinding(subTree.leftToken, tree.tree);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
@@ -58,7 +58,7 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
                 SubTree subTree = tokenizeInternal(tokens, child, pivotPosition);
 
                 // If child tree had tokens that were not yet bound, bind them
-                if(child.tree == null) {
+                if(subTree.tree == null) {
                     if(subTree.leftToken != null)
                         tokenTreeBinding(subTree.leftToken, tree.tree);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
@@ -16,7 +16,7 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
             this.leftToken = leftToken;
             this.rightToken = rightToken;
             this.endPosition = endPosition;
-            if(tree.tree != null && leftToken != null && rightToken != null) {
+            if(!tree.isInjection && tree.tree != null && leftToken != null && rightToken != null) {
                 String sort = tree.production == null ? null : tree.production.sort();
                 configure(tree.tree, sort, leftToken, rightToken);
             }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/TokenizedTermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/TokenizedTermTreeFactory.java
@@ -28,7 +28,7 @@ public class TokenizedTermTreeFactory implements ITokenizedTreeFactory<IStratego
     @Override public IStrategoTerm createStringTerminal(ISymbol symbol, String value, IToken token) {
         IStrategoTerm stringTerminalTerm = termFactory.makeString(value);
 
-        configure(stringTerminalTerm, null, token, token);
+        configure(stringTerminalTerm, ISymbol.getSort(symbol), token, token);
 
         return stringTerminalTerm;
     }
@@ -37,7 +37,7 @@ public class TokenizedTermTreeFactory implements ITokenizedTreeFactory<IStratego
         IStrategoTerm stringTerm = termFactory.makeString(value);
         IStrategoTerm metaVarTerm = termFactory.makeAppl(symbol.metaVarCardinality().constructor, stringTerm);
 
-        configure(stringTerm, null, token, token);
+        configure(stringTerm, ISymbol.getSort(symbol), token, token);
         configure(metaVarTerm, null, token, token);
 
         return metaVarTerm;


### PR DESCRIPTION
During the development of the [Spoofax Pygments Lexer](https://github.com/ChielBruin/spoofax-latex-tools), @ChielBruin and I discovered some inconsistencies in how `ImploderAttachment`s stored the sort of an AST node. A couple of examples:

- JSGLR1 used to store the sort of a lexical AST term, but JSGLR2 always stored `null` as sort in this case. This broke ESV coloring that depended on this lexical sort (see 085ea3b).
- Calling `getSort` on a list/optional/etc symbol from a parse table taken directly from SDF3 generation returned `null`, but calling `getSort` on the same sort of a serialized-and-deserialized parse table would return the base sort (see metaborg/sdf#32 for more details; also, the new integration tests rely on this PR).
- Other small inconsistencies between a couple of the imploder/tokenizer implementations (see c4ecd25 and c4ecd25).

I've added fields for the sort and constructor to the `TokenDescriptor` class for use in the tokenization test. I've used the following rules for determining which token should get which sort and constructor:

- The start and end token always have sort and constructor `null`.
- Layout/literal tokens before or after the program have sort and constructor `null`, just like the start and end tokens (see test `operatorWithLayout2`).
- Layout/literal tokens have the sort and constructor of their related AST node.
- Lexical tokens have their lexical sort and constructor `null`.