### PR TITLE
Add LinkedLookaheadStack and make ILookaheadStack clonable

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/AbstractLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/AbstractLookaheadStack.java
@@ -25,4 +25,6 @@ public abstract class AbstractLookaheadStack implements ILookaheadStack {
         return inputString.substring(position + 1, Math.min(position + 1 + length, inputLength))
             + (position + 1 + length > inputLength ? (char) EOF_INT : "");
     }
+
+    public abstract ILookaheadStack clone();
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/EagerLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/EagerLookaheadStack.java
@@ -27,6 +27,16 @@ public class EagerLookaheadStack extends AbstractLookaheadStack {
         this(root, root.getYield());
     }
 
+    @Override public EagerLookaheadStack clone() {
+        EagerLookaheadStack clone = new EagerLookaheadStack(IncrementalCharacterNode.EOF_NODE, inputString);
+        clone.stack.clear();
+        for (IncrementalParseForest node : stack) {
+            clone.stack.push(node);
+        }
+        clone.position = position;
+        return clone;
+    }
+
     @Override public void leftBreakdown() {
         if(stack.isEmpty())
             return;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/ILookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/ILookaheadStack.java
@@ -4,7 +4,7 @@ import org.metaborg.parsetable.query.IActionQuery;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
 
 // TODO the name LookaheadStack is a bit misleading. Rename to something like MixedInputStream?
-public interface ILookaheadStack extends IActionQuery {
+public interface ILookaheadStack extends IActionQuery, Cloneable {
     void leftBreakdown();
 
     void popLookahead();

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/ILookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/ILookaheadStack.java
@@ -10,4 +10,9 @@ public interface ILookaheadStack extends IActionQuery, Cloneable {
     void popLookahead();
 
     IncrementalParseForest get();
+
+    // TODO add support for recovery. Resetting should push the characters between new and old position on the stack.
+    // This is an optimization because the parse nodes in the the part of the input being recovered need to be broken
+    // down anyway.
+    // void resetPosition(int position);
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/LazyLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/LazyLookaheadStack.java
@@ -31,6 +31,17 @@ public class LazyLookaheadStack extends AbstractLookaheadStack {
         this(root, root.getYield());
     }
 
+    @Override public LazyLookaheadStack clone() {
+        LazyLookaheadStack clone = new LazyLookaheadStack(IncrementalCharacterNode.EOF_NODE, inputString);
+        clone.stack.clear();
+        for (StackTuple stackTuple : stack) {
+            clone.stack.push(stackTuple);
+        }
+        clone.last = last;
+        clone.position = position;
+        return clone;
+    }
+
     @Override public IncrementalParseForest get() {
         return last;
     }
@@ -75,11 +86,11 @@ public class LazyLookaheadStack extends AbstractLookaheadStack {
         }
     }
 
-    private final class StackTuple {
+    private static final class StackTuple {
         private final IncrementalParseNode parseForest;
         private final int childIndex;
 
-        public StackTuple(IncrementalParseNode parseForest, int childIndex) {
+        StackTuple(IncrementalParseNode parseForest, int childIndex) {
             this.parseForest = parseForest;
             this.childIndex = childIndex;
         }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/LinkedLookaheadStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/lookaheadstack/LinkedLookaheadStack.java
@@ -1,0 +1,67 @@
+package org.spoofax.jsglr2.incremental.lookaheadstack;
+
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+
+public class LinkedLookaheadStack extends AbstractLookaheadStack {
+    private StackTuple head;
+
+    /**
+     * @param inputString
+     *            should be equal to the yield of the root.
+     */
+    public LinkedLookaheadStack(IncrementalParseForest root, String inputString) {
+        super(inputString);
+        this.head = new StackTuple(root, new StackTuple(IncrementalCharacterNode.EOF_NODE));
+    }
+
+    public LinkedLookaheadStack(IncrementalParseForest root) {
+        this(root, root.getYield());
+    }
+
+    @Override public IncrementalParseForest get() {
+        return head == null ? null : head.node;
+    }
+
+    @Override public LinkedLookaheadStack clone() {
+        LinkedLookaheadStack clone = new LinkedLookaheadStack(IncrementalCharacterNode.EOF_NODE, inputString);
+        clone.head = head;
+        clone.position = position;
+        return clone;
+    }
+
+    @Override public void leftBreakdown() {
+        if(head == null)
+            return;
+        IncrementalParseForest current = head.node;
+        if(current.isTerminal()) {
+            return;
+        }
+        head = head.next; // always pop last lookahead, whether it has children or not
+        IncrementalParseForest[] children = ((IncrementalParseNode) current).getFirstDerivation().parseForests();
+        // Push all children to stack in reverse order
+        for(int i = children.length - 1; i >= 0; i--) {
+            head = new StackTuple(children[i], head);
+        }
+    }
+
+    @Override public void popLookahead() {
+        position += head.node.width();
+        head = head.next;
+    }
+
+    private static class StackTuple {
+        final IncrementalParseForest node;
+        final StackTuple next;
+
+        StackTuple(IncrementalParseForest node, StackTuple next) {
+            this.node = node;
+            this.next = next;
+        }
+
+        StackTuple(IncrementalParseForest node) {
+            this(node, null);
+        }
+    }
+}

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/lookaheadstack/AbstractLookaheadStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/lookaheadstack/AbstractLookaheadStackTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertSame;
 import static org.metaborg.parsetable.characterclasses.CharacterClassFactory.EOF_INT;
 import static org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode.EOF_NODE;
 
+import java.util.function.BiConsumer;
+
 import org.junit.Test;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
@@ -99,6 +101,57 @@ public abstract class AbstractLookaheadStackTest {
         assertPoppingRoot(root);
     }
 
+    private static class TestTuple {
+        final BiConsumer<IncrementalParseForest, ILookaheadStack> action;
+        final IncrementalParseForest expected;
+
+        TestTuple(BiConsumer<IncrementalParseForest, ILookaheadStack> action, IncrementalParseForest expected) {
+            this.action = action;
+            this.expected = expected;
+        }
+    }
+
+    @Test public void testClone() {
+        IncrementalCharacterNode node1 = new IncrementalCharacterNode(97);
+        IncrementalCharacterNode node2 = new IncrementalCharacterNode(98);
+        IncrementalCharacterNode node3 = new IncrementalCharacterNode(99);
+        IncrementalCharacterNode node4 = new IncrementalCharacterNode(100);
+        IncrementalParseNode parseNode1 = new IncrementalParseNode(node1, node2);
+        IncrementalParseNode parseNode2 = new IncrementalParseNode(node3, node4);
+        IncrementalParseNode root = new IncrementalParseNode(parseNode1, parseNode2);
+
+        TestTuple[] actions =
+            new TestTuple[] { new TestTuple(AbstractLookaheadStackTest::assertLeftBreakdown, parseNode1),
+                new TestTuple(AbstractLookaheadStackTest::assertLeftBreakdown, node1),
+                new TestTuple(AbstractLookaheadStackTest::assertLeftBreakdown, node1),
+                new TestTuple(AbstractLookaheadStackTest::assertPopLookahead, node2),
+                new TestTuple(AbstractLookaheadStackTest::assertLeftBreakdown, node2),
+                new TestTuple(AbstractLookaheadStackTest::assertPopLookahead, parseNode2),
+                new TestTuple(AbstractLookaheadStackTest::assertLeftBreakdown, node3),
+                new TestTuple(AbstractLookaheadStackTest::assertLeftBreakdown, node3),
+                new TestTuple(AbstractLookaheadStackTest::assertPopLookahead, node4),
+                new TestTuple(AbstractLookaheadStackTest::assertLeftBreakdown, node4) };
+
+        ILookaheadStack original = getStack(root);
+        ILookaheadStack[] clones = new ILookaheadStack[actions.length];
+        for(int i = 0; i < actions.length; i++) {
+            // Before each action, create a clone
+            clones[i] = ((AbstractLookaheadStack) original).clone();
+            // Check whether the action works correctly for both the original and all clones created so far
+            actions[i].action.accept(actions[i].expected, original);
+            for(int j = 0; j <= i; j++) {
+                actions[i].action.accept(actions[i].expected, clones[j]);
+                // Also check that the position of the clone matches that of the original, after the action
+                assertEquals(((AbstractLookaheadStack) original).position,
+                    ((AbstractLookaheadStack) clones[j]).position);
+            }
+        }
+        assertPoppingEOF(original);
+        for(ILookaheadStack clone : clones) {
+            assertPoppingEOF(clone);
+        }
+    }
+
     @Test public void testLookaheadQuery() {
         IncrementalCharacterNode node1 = new IncrementalCharacterNode(97);
         IncrementalCharacterNode node2 = new IncrementalCharacterNode(98);
@@ -108,13 +161,16 @@ public abstract class AbstractLookaheadStackTest {
         IncrementalParseNode parseNode2 = new IncrementalParseNode(node3, node4);
         IncrementalParseNode root = new IncrementalParseNode(parseNode1, parseNode2);
 
-        ILookaheadStack stack = getStack(root);
-        assertEquals('a', stack.actionQueryCharacter());
-        assertEquals("b", stack.actionQueryLookahead(1));
-        assertEquals("bc", stack.actionQueryLookahead(2));
-        assertEquals("bcd", stack.actionQueryLookahead(3));
-        assertEquals("bcd" + (char) EOF_INT, stack.actionQueryLookahead(4));
-        assertEquals("bcd" + (char) EOF_INT, stack.actionQueryLookahead(5));
+        ILookaheadStack original = getStack(root);
+        ILookaheadStack clone = ((AbstractLookaheadStack) original).clone();
+        for(ILookaheadStack stack : new ILookaheadStack[] { original, clone }) {
+            assertEquals('a', stack.actionQueryCharacter());
+            assertEquals("b", stack.actionQueryLookahead(1));
+            assertEquals("bc", stack.actionQueryLookahead(2));
+            assertEquals("bcd", stack.actionQueryLookahead(3));
+            assertEquals("bcd" + (char) EOF_INT, stack.actionQueryLookahead(4));
+            assertEquals("bcd" + (char) EOF_INT, stack.actionQueryLookahead(5));
+        }
     }
 
     private void assertPoppingRoot(IncrementalParseNode root) {

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/lookaheadstack/LinkedLookaheadStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/lookaheadstack/LinkedLookaheadStackTest.java
@@ -1,0 +1,11 @@
+package org.spoofax.jsglr2.incremental.lookaheadstack;
+
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+
+public class LinkedLookaheadStackTest extends AbstractLookaheadStackTest {
+
+    @Override protected ILookaheadStack getStack(IncrementalParseNode root) {
+        return new LinkedLookaheadStack(root);
+    }
+
+}


### PR DESCRIPTION
This PR adds support for cloning a lookahead stack, so that it can be stored in a choice point and used when jumping back to this point. If the implementation of parsing with recovery somehow requires that choice points can be jumped back to multiple times, then the lookahead stack should also be cloned when restoring it from a choice point, in order to not change the stored lookahead stack.

The `LinkedLookaheadStack` acts like the `EagerLookaheadStack` (in that it explicitly pushes all children of a broken-down node to the stack), but the difference is that the stack is now implemented using immutable linked-together nodes. This means that cloning the lookahead stack to store it in a choice point becomes much less expensive.

Note that this implementation can later be replaced with something smart that just pushes character nodes to the input stack when jumping back (added a `TODO`). But this is PR is enough for the "let's first make it work" implementation :slightly_smiling_face: 