### PR TITLE
Rename IIncrementalParseState.isMultipleStates to newParseNodesAreReusable

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IIncrementalParseState.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IIncrementalParseState.java
@@ -9,7 +9,7 @@ public interface IIncrementalParseState {
 
     ILookaheadStack lookahead();
 
-    boolean isMultipleStates();
+    boolean newParseNodesAreReusable();
 
     void setMultipleStates(boolean multipleStates);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParseState.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParseState.java
@@ -1,10 +1,5 @@
 package org.spoofax.jsglr2.incremental;
 
-import org.metaborg.parsetable.actions.IGoto;
-import org.metaborg.parsetable.query.ActionsForCharacterSeparated;
-import org.metaborg.parsetable.query.ActionsPerCharacterClass;
-import org.metaborg.parsetable.query.ProductionToGotoForLoop;
-import org.metaborg.parsetable.states.State;
 import org.spoofax.jsglr2.incremental.lookaheadstack.EagerLookaheadStack;
 import org.spoofax.jsglr2.incremental.lookaheadstack.ILookaheadStack;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalDerivation;
@@ -24,9 +19,6 @@ public class IncrementalParseState<StackNode extends IStackNode> extends Abstrac
 
     private boolean multipleStates = false;
     ILookaheadStack lookahead;
-
-    public static final State NO_STATE = new State(-1,
-        new ActionsForCharacterSeparated(new ActionsPerCharacterClass[0]), new ProductionToGotoForLoop(new IGoto[0]));
 
     public IncrementalParseState(String inputString, String filename, IActiveStacks<StackNode> activeStacks,
         IForActorStacks<StackNode> forActorStacks) {
@@ -73,8 +65,8 @@ public class IncrementalParseState<StackNode extends IStackNode> extends Abstrac
         return lookahead;
     }
 
-    @Override public boolean isMultipleStates() {
-        return multipleStates;
+    @Override public boolean newParseNodesAreReusable() {
+        return !multipleStates;
     }
 
     @Override public void setMultipleStates(boolean multipleStates) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalCharacterNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalCharacterNode.java
@@ -3,6 +3,7 @@ package org.spoofax.jsglr2.incremental.parseforest;
 import static org.metaborg.parsetable.characterclasses.CharacterClassFactory.EOF_INT;
 
 import org.metaborg.parsetable.characterclasses.CharacterClassFactory;
+import org.metaborg.parsetable.states.IState;
 import org.spoofax.jsglr2.parseforest.ICharacterNode;
 import org.spoofax.jsglr2.util.TreePrettyPrinter;
 
@@ -15,6 +16,14 @@ public class IncrementalCharacterNode extends IncrementalParseForest implements 
     public IncrementalCharacterNode(int character) {
         super(1);
         this.character = character;
+    }
+
+    @Override public boolean isReusable() {
+        return true;
+    }
+
+    @Override public boolean isReusable(IState stackState) {
+        return true;
     }
 
     @Override public boolean isTerminal() {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalDerivation.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalDerivation.java
@@ -2,7 +2,6 @@ package org.spoofax.jsglr2.incremental.parseforest;
 
 import org.metaborg.parsetable.productions.IProduction;
 import org.metaborg.parsetable.productions.ProductionType;
-import org.metaborg.parsetable.states.IState;
 import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.util.TreePrettyPrinter;
 
@@ -11,15 +10,13 @@ public class IncrementalDerivation implements IDerivation<IncrementalParseForest
     private final IProduction production;
     private final ProductionType productionType;
     public final IncrementalParseForest[] parseForests;
-    public final IState state;
 
     public IncrementalDerivation(IProduction production, ProductionType productionType,
-        IncrementalParseForest[] parseForests, IState state) {
+        IncrementalParseForest[] parseForests) {
 
         this.production = production;
         this.productionType = productionType;
         this.parseForests = parseForests;
-        this.state = state;
         int width = 0;
         for(IncrementalParseForest parseForest : parseForests) {
             if(parseForest == null)
@@ -49,7 +46,7 @@ public class IncrementalDerivation implements IDerivation<IncrementalParseForest
         if(production == null)
             printer.println("d null : {");
         else
-            printer.println("d" + production.id() + " : " + production.toString() + " { (s" + state.id() + ")");
+            printer.println("d" + production.id() + " : " + production.toString() + " {");
         printer.indent(2);
 
         for(IncrementalParseForest parseForest : parseForests) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseForest.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseForest.java
@@ -1,5 +1,6 @@
 package org.spoofax.jsglr2.incremental.parseforest;
 
+import org.metaborg.parsetable.states.IState;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.util.TreePrettyPrinter;
 
@@ -10,6 +11,12 @@ public abstract class IncrementalParseForest implements IParseForest {
         super();
         this.width = width;
     }
+
+    /** Returns whether this parse node is in theory reusable, not taking into account the stack it's shifted onto. */
+    public abstract boolean isReusable();
+
+    /** Returns whether this parse node is reusable, taking into account the state of the stack it's shifted onto. */
+    public abstract boolean isReusable(IState stackState);
 
     public abstract boolean isTerminal();
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseForestManager.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseForestManager.java
@@ -1,17 +1,18 @@
 package org.spoofax.jsglr2.incremental.parseforest;
 
+import static org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode.NO_STATE;
+
+import java.util.List;
+
 import org.metaborg.parsetable.productions.IProduction;
 import org.metaborg.parsetable.productions.ProductionType;
 import org.metaborg.parsetable.states.IState;
 import org.spoofax.jsglr2.incremental.IIncrementalParseState;
-import org.spoofax.jsglr2.incremental.IncrementalParseState;
 import org.spoofax.jsglr2.parseforest.ParseForestManager;
 import org.spoofax.jsglr2.parseforest.ParseForestManagerFactory;
 import org.spoofax.jsglr2.parser.AbstractParseState;
 import org.spoofax.jsglr2.parser.observing.ParserObserving;
 import org.spoofax.jsglr2.stack.IStackNode;
-
-import java.util.List;
 
 public class IncrementalParseForestManager
 //@formatter:off
@@ -39,7 +40,8 @@ public class IncrementalParseForestManager
     @Override public IncrementalParseNode createParseNode(ParseState parseState, IStackNode stack,
         IProduction production, IncrementalDerivation firstDerivation) {
 
-        IncrementalParseNode parseNode = new IncrementalParseNode(production, firstDerivation);
+        IState state = parseState.newParseNodesAreReusable() ? stack.state() : NO_STATE;
+        IncrementalParseNode parseNode = new IncrementalParseNode(production, firstDerivation, state);
 
         observing.notify(observer -> observer.createParseNode(parseNode, production));
         observing.notify(observer -> observer.addDerivation(parseNode, firstDerivation));
@@ -60,8 +62,7 @@ public class IncrementalParseForestManager
     @Override public IncrementalDerivation createDerivation(ParseState parseState, IStackNode stack,
         IProduction production, ProductionType productionType, IncrementalParseForest[] parseForests) {
 
-        IState state = parseState.isMultipleStates() ? IncrementalParseState.NO_STATE : stack.state();
-        IncrementalDerivation derivation = new IncrementalDerivation(production, productionType, parseForests, state);
+        IncrementalDerivation derivation = new IncrementalDerivation(production, productionType, parseForests);
 
         observing.notify(observer -> observer.createDerivation(derivation, production, derivation.parseForests));
 
@@ -94,7 +95,8 @@ public class IncrementalParseForestManager
 
     @Override protected IncrementalParseNode filteredTopParseNode(IncrementalParseNode parseNode,
         List<IncrementalDerivation> derivations) {
-        IncrementalParseNode topParseNode = new IncrementalParseNode(parseNode.production(), derivations.get(0));
+        IncrementalParseNode topParseNode =
+            new IncrementalParseNode(parseNode.production(), derivations.get(0), NO_STATE);
 
         for(int i = 1; i < derivations.size(); i++)
             topParseNode.addDerivation(derivations.get(i));

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseNode.java
@@ -1,12 +1,16 @@
 package org.spoofax.jsglr2.incremental.parseforest;
 
-import static org.spoofax.jsglr2.incremental.IncrementalParseState.NO_STATE;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.metaborg.parsetable.actions.IGoto;
 import org.metaborg.parsetable.productions.IProduction;
+import org.metaborg.parsetable.query.ActionsForCharacterSeparated;
+import org.metaborg.parsetable.query.ActionsPerCharacterClass;
+import org.metaborg.parsetable.query.ProductionToGotoForLoop;
+import org.metaborg.parsetable.states.IState;
+import org.metaborg.parsetable.states.State;
 import org.spoofax.jsglr2.parseforest.IParseNode;
 import org.spoofax.jsglr2.util.TreePrettyPrinter;
 import org.spoofax.jsglr2.util.iterators.SingleElementWithListIterable;
@@ -14,18 +18,32 @@ import org.spoofax.jsglr2.util.iterators.SingleElementWithListIterable;
 public class IncrementalParseNode extends IncrementalParseForest
     implements IParseNode<IncrementalParseForest, IncrementalDerivation> {
 
+    public static final State NO_STATE = new State(-1,
+        new ActionsForCharacterSeparated(new ActionsPerCharacterClass[0]), new ProductionToGotoForLoop(new IGoto[0]));
+
     private final IProduction production;
     private final IncrementalDerivation firstDerivation;
     private List<IncrementalDerivation> otherDerivations;
+    private IState state;
 
-    public IncrementalParseNode(IProduction production, IncrementalDerivation firstDerivation) {
+    public IncrementalParseNode(IProduction production, IncrementalDerivation firstDerivation, IState state) {
         super(firstDerivation.width());
         this.production = production;
         this.firstDerivation = firstDerivation;
+        this.state = state;
     }
 
     public IncrementalParseNode(IncrementalParseForest... parseForests) {
-        this(null, new IncrementalDerivation(null, null, parseForests, NO_STATE));
+        this(null, new IncrementalDerivation(null, null, parseForests), NO_STATE);
+    }
+
+    @Override public boolean isReusable() {
+        return state != NO_STATE;
+    }
+
+    @Override public boolean isReusable(IState stackState) {
+        // If state == NO_STATE, its ID is -1, and can in that case never equal the ID of stackState
+        return stackState.id() == state.id();
     }
 
     @Override public boolean isTerminal() {
@@ -45,6 +63,8 @@ public class IncrementalParseNode extends IncrementalParseForest
             otherDerivations = new ArrayList<>();
 
         otherDerivations.add(derivation);
+
+        state = NO_STATE; // Parse nodes with multiple derivations are by definition not reusable
     }
 
     @Override public Iterable<IncrementalDerivation> getDerivations() {
@@ -67,7 +87,7 @@ public class IncrementalParseNode extends IncrementalParseForest
         if(production == null)
             printer.println("p null {");
         else
-            printer.println("p" + production.id() + " : " + production.sort() + "{");
+            printer.println("p" + production.id() + " : " + production.sort() + "{ (s" + state.id() + ")");
         if(isAmbiguous()) {
             printer.indent(1);
             printer.println("amb[");

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/recoveryincremental/RecoveryIncrementalParseState.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/recoveryincremental/RecoveryIncrementalParseState.java
@@ -77,9 +77,8 @@ public class RecoveryIncrementalParseState<StackNode extends IStackNode>
         return lookahead;
     }
 
-    @Override public boolean isMultipleStates() {
-        // TODO: since isRecovering is also here, is isMultipleStates still the correct name?
-        return multipleStates || isRecovering();
+    @Override public boolean newParseNodesAreReusable() {
+        return !multipleStates && !isRecovering();
     }
 
     @Override public void setMultipleStates(boolean multipleStates) {


### PR DESCRIPTION
This should make the meaning of the method more clear.
In addition to this, the `state` field has been moved from `IncrementalDerivation` to `IncrementalParseNode`, which removes a layer of indirection in most cases.
The `state` field is set to `NO_STATE` when a new derivation is added, following Wagner's algorithm more closely.
To make the algorithm even more understandable, `IncrementalParseNode`s now have a method named `isReusable` and no longer expose the `state` field directly.