### PR TITLE
Fix messages generated by IterativeTreeTokenizer

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
@@ -106,7 +106,7 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<ImplodeResult<Tr
                 }
             }
 
-            if(tree.production.isRecovery()) {
+            if(tree.production != null && tree.production.isRecovery()) {
                 if(messages == null)
                     messages = new ArrayList<>();
 


### PR DESCRIPTION
@jasperdenkers to fix your WIP commit 09c474c91486f4ddbffbb7cbb2be26881f7c3ccd :slightly_smiling_face: 

The problem was that you needed the `startPosition` to create the message, as you did in [line 113 of `TreeTokenizer`](https://github.com/metaborg/jsglr/pull/65/files#diff-77ccac298ad768082f12c80edc422128R113), but the `currentPos` variable in the iterative tokenizer corresponded to the `pivotPosition` instead of the `startPosition`. I fixed this by also saving the `startPosition`s on a stack.