### PR TITLE
Incremental optimized parse forest fix

### DIFF
--- a/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/JSGLR2CLI.java
+++ b/org.spoofax.jsglr2.cli/src/main/java/org/spoofax/jsglr2/cli/JSGLR2CLI.java
@@ -118,7 +118,7 @@ public class JSGLR2CLI implements Runnable {
         String prevInput = null;
         IParseForest prevParseForest = null;
         for(String in : input) {
-            ParseResult<?> result = parser.parse(in, null, prevInput, prevParseForest);
+            ParseResult<?> result = parser.parse(in, prevInput, prevParseForest);
 
             if(result.isSuccess()) {
                 prevInput = in;

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -201,12 +201,13 @@ public abstract class BaseTest implements WithParseTable {
     private Stream<DynamicTest> testIncrementalSuccess(String[] inputStrings, String[] expectedOutputAstStrings,
         String startSymbol, boolean equalityByExpansions, Stream<TestVariant> variants) {
         return testPerVariant(variants, variant -> () -> {
+            JSGLR2<IStrategoTerm> jsglr2 = variant.jsglr2();
             IStrategoTerm actualOutputAst;
             String fileName = "" + System.nanoTime(); // To ensure the results will be cached
             for(int i = 0; i < expectedOutputAstStrings.length; i++) {
                 String inputString = inputStrings[i];
                 actualOutputAst = testSuccess("Parsing failed at update " + i + ": ",
-                    "Imploding failed at update " + i + ": ", variant.jsglr2(), fileName, startSymbol, inputString);
+                    "Imploding failed at update " + i + ": ", jsglr2, fileName, startSymbol, inputString);
                 assertEqualAST("Incorrect AST at update " + i + ": ", expectedOutputAstStrings[i], actualOutputAst,
                     equalityByExpansions);
             }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParsingMeasurements.java
@@ -91,7 +91,7 @@ public class ParsingMeasurements extends Measurements {
             parser.observing().attachObserver(measureObserver);
 
             for(StringInput input : inputBatch.inputs)
-                parser.parse(input.content, null);
+                parser.parse(input.content);
 
             return toOutput(name, inputBatch, measureActiveStacksFactory, measureForActorStacksFactory,
                 measureObserver);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParser.java
@@ -67,7 +67,7 @@ public class IncrementalParser
     @Override protected ParseState getParseState(String inputString, String previousInput,
         IncrementalParseForest previousResult) {
         IncrementalParseForest updatedTree = previousInput != null && previousResult != null
-            ? processUpdates.processUpdates(previousResult, diff.diff(previousInput, inputString))
+            ? processUpdates.processUpdates(previousInput, previousResult, diff.diff(previousInput, inputString))
             : processUpdates.getParseNodeFromString(inputString);
         return parseStateFactory.get(incrementalInputStackFactory.get(updatedTree, inputString), observing);
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdates.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdates.java
@@ -76,6 +76,7 @@ public class ProcessUpdates
         int currentOffset, LinkedList<EditorUpdate> updates) {
         if(currentForest.isTerminal()) {
             if(currentForest instanceof IncrementalSkippedNode) {
+                // First explicitly instantiate all skipped character nodes before applying updates
                 return processUpdates(previousInput,
                     getParseNodeFromString(
                         previousInput.substring(currentOffset, currentOffset + currentForest.width())),

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/EagerIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/EagerIncrementalInputStack.java
@@ -4,8 +4,10 @@ import static org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNod
 
 import java.util.Stack;
 
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalSkippedNode;
 
 public class EagerIncrementalInputStack extends AbstractInputStack implements IIncrementalInputStack {
     /**
@@ -43,6 +45,13 @@ public class EagerIncrementalInputStack extends AbstractInputStack implements II
             return;
         IncrementalParseForest current = stack.peek();
         if(current.isTerminal()) {
+            if(current instanceof IncrementalSkippedNode) {
+                // Break down a skipped node by explicitly instantiating character nodes for the skipped part
+                stack.pop();
+                for(int i = currentOffset + current.width() - 1; i >= currentOffset; i--) {
+                    stack.push(new IncrementalCharacterNode(inputString.charAt(i)));
+                }
+            }
             return;
         }
         stack.pop(); // always pop last lookahead, whether it has children or not

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LazyIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LazyIncrementalInputStack.java
@@ -51,6 +51,7 @@ public class LazyIncrementalInputStack extends AbstractInputStack implements IIn
     @Override public void breakDown() {
         if(stack.isEmpty())
             last = null;
+        // TODO implement skipped nodes
         if(last == null || last.isTerminal())
             return;
         IncrementalParseForest[] children = ((IncrementalParseNode) last).getFirstDerivation().parseForests();

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LazyIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LazyIncrementalInputStack.java
@@ -50,8 +50,9 @@ public class LazyIncrementalInputStack extends AbstractInputStack implements IIn
             last = null;
         if(last == null || last.isTerminal()) {
             if(last instanceof IncrementalSkippedNode) {
+                // Replace skipped node by one that has all skipped characters explicitly instantiated
                 last = new IncrementalParseNode(inputString.substring(currentOffset, currentOffset + last.width())
-                    .chars().mapToObj(IncrementalCharacterNode::new).toArray(IncrementalParseForest[]::new));
+                    .codePoints().mapToObj(IncrementalCharacterNode::new).toArray(IncrementalParseForest[]::new));
             } else
                 return;
         }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LazyIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LazyIncrementalInputStack.java
@@ -4,10 +4,7 @@ import static org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNod
 
 import java.util.Stack;
 
-import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
-import org.spoofax.jsglr2.incremental.parseforest.IncrementalDerivation;
-import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
-import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.incremental.parseforest.*;
 
 public class LazyIncrementalInputStack extends AbstractInputStack implements IIncrementalInputStack {
     /**
@@ -51,9 +48,13 @@ public class LazyIncrementalInputStack extends AbstractInputStack implements IIn
     @Override public void breakDown() {
         if(stack.isEmpty())
             last = null;
-        // TODO implement skipped nodes
-        if(last == null || last.isTerminal())
-            return;
+        if(last == null || last.isTerminal()) {
+            if(last instanceof IncrementalSkippedNode) {
+                last = new IncrementalParseNode(inputString.substring(currentOffset, currentOffset + last.width())
+                    .chars().mapToObj(IncrementalCharacterNode::new).toArray(IncrementalParseForest[]::new));
+            } else
+                return;
+        }
         IncrementalParseForest[] children = ((IncrementalParseNode) last).getFirstDerivation().parseForests();
         if(children.length > 0) {
             stack.push(new StackTuple(((IncrementalParseNode) last), 0));

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LinkedIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LinkedIncrementalInputStack.java
@@ -2,8 +2,10 @@ package org.spoofax.jsglr2.inputstack.incremental;
 
 import static org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode.EOF_NODE;
 
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalSkippedNode;
 
 public class LinkedIncrementalInputStack extends AbstractInputStack implements IIncrementalInputStack {
     private StackTuple head;
@@ -37,6 +39,13 @@ public class LinkedIncrementalInputStack extends AbstractInputStack implements I
             return;
         IncrementalParseForest current = head.node;
         if(current.isTerminal()) {
+            if(current instanceof IncrementalSkippedNode) {
+                // Break down a skipped node by explicitly instantiating character nodes for the skipped part
+                head = head.next;
+                for(int i = currentOffset + current.width() - 1; i >= currentOffset; i--) {
+                    head = new StackTuple(new IncrementalCharacterNode(inputString.charAt(i)), head);
+                }
+            }
             return;
         }
         head = head.next; // always pop last lookahead, whether it has children or not

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/IParser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/IParser.java
@@ -9,12 +9,16 @@ public interface IParser<ParseForest extends IParseForest> {
 
     ParseResult<ParseForest> parse(String input, String startSymbol, String previousInput, ParseForest previousResult);
 
+    default ParseResult<ParseForest> parse(String input, String previousInput, ParseForest previousResult) {
+        return parse(input, null, previousInput, previousResult);
+    }
+
     default ParseResult<ParseForest> parse(String input, String startSymbol) {
         return parse(input, startSymbol, null, null);
     }
 
     default ParseResult<ParseForest> parse(String input) {
-        return parse(input, null);
+        return parse(input, null, null, null);
     }
 
     /**

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdatesTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdatesTest.java
@@ -117,7 +117,8 @@ public class ProcessUpdatesTest {
 
 
     private void testUpdate(IncrementalParseNode previous, IncrementalParseNode expected, EditorUpdate... updates) {
-        assertEquals(expected.toString(), processUpdates.processUpdates(previous, updates).toString());
+        assertEquals(expected.toString(),
+            processUpdates.processUpdates(previous.getYield(), previous, updates).toString());
     }
 
     private static IncrementalCharacterNode node(int i) {

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/EagerIncrementalInputStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/EagerIncrementalInputStackTest.java
@@ -4,8 +4,8 @@ import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 
 public class EagerIncrementalInputStackTest extends AbstractIncrementalInputStackTest {
 
-    @Override protected IIncrementalInputStack getStack(IncrementalParseNode root) {
-        return new EagerIncrementalInputStack(root);
+    @Override protected IIncrementalInputStack getStack(IncrementalParseNode root, String inputString) {
+        return new EagerIncrementalInputStack(root, inputString);
     }
 
 }

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/LazyIncrementalInputStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/LazyIncrementalInputStackTest.java
@@ -4,8 +4,8 @@ import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 
 public class LazyIncrementalInputStackTest extends AbstractIncrementalInputStackTest {
 
-    @Override protected IIncrementalInputStack getStack(IncrementalParseNode root) {
-        return new LazyIncrementalInputStack(root);
+    @Override protected IIncrementalInputStack getStack(IncrementalParseNode root, String inputString) {
+        return new LazyIncrementalInputStack(root, inputString);
     }
 
 }

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/LinkedIncrementalInputStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/LinkedIncrementalInputStackTest.java
@@ -4,8 +4,8 @@ import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 
 public class LinkedIncrementalInputStackTest extends AbstractIncrementalInputStackTest {
 
-    @Override protected IIncrementalInputStack getStack(IncrementalParseNode root) {
-        return new LinkedIncrementalInputStack(root);
+    @Override protected IIncrementalInputStack getStack(IncrementalParseNode root, String inputString) {
+        return new LinkedIncrementalInputStack(root, inputString);
     }
 
 }


### PR DESCRIPTION
Fixing a woopsie :innocent: 

In the incremental tests, `variant.jsglr2()` was called for every input string. Calling this method builds a new `JGSLR2Implementation` object with new caches, i.e. the previous results were never reused. This is fixed in a46bebe by extracting a variable that holds the `JSGLR2` instance.

Other than that, the commits should speak for themselves :slightly_smiling_face: 