### PR TITLE
Make the parser variants descriptions shorter

### DIFF
--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/IntegrationVariant.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/IntegrationVariant.java
@@ -41,7 +41,7 @@ public class IntegrationVariant {
     }
 
     public String name() {
-        return parseTable.name() + "//" + jsglr2.name();
+        return (parseTable.equals(ParseTableVariant.standard()) ? "_" : parseTable.name()) + "//" + jsglr2.name();
     }
 
     @Override public boolean equals(Object o) {

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/ParseTableVariant.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/integration/ParseTableVariant.java
@@ -24,9 +24,15 @@ public class ParseTableVariant {
         this(ActionsForCharacterRepresentation.standard(), ProductionToGotoRepresentation.standard());
     }
 
+    public static ParseTableVariant standard() {
+        return new ParseTableVariant();
+    }
+
     public String name() {
-        return "ActionsForCharacterRepresentation:" + actionsForCharacterRepresentation
-            + "/ProductionToGotoRepresentation:" + productionToGotoRepresentation;
+        return (actionsForCharacterRepresentation == ActionsForCharacterRepresentation.standard() ? "_"
+            : "ActionsForCharacterRepresentation:" + actionsForCharacterRepresentation) + "/"
+            + (productionToGotoRepresentation == ProductionToGotoRepresentation.standard() ? "_"
+                : "ProductionToGotoRepresentation:" + productionToGotoRepresentation);
     }
 
     public ParseTableReader parseTableReader() {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variant.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variant.java
@@ -76,7 +76,8 @@ public class JSGLR2Variant {
     }
 
     public String name() {
-        return parser.name() + "//Imploder:" + imploder.name() + "//Tokenizer:" + tokenizer.name();
+        return parser.name() + "//" + (imploder == ImploderVariant.standard() ? "_" : "Imploder:" + imploder.name())
+            + "//" + (tokenizer == TokenizerVariant.standard() ? "_" : "Tokenizer:" + tokenizer.name());
     }
 
     @Override public boolean equals(Object o) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/ParserVariant.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/ParserVariant.java
@@ -108,10 +108,15 @@ public class ParserVariant {
     }
 
     public String name() {
-        return "ActiveStacksRepresentation:" + activeStacksRepresentation + "/ForActorStacksRepresentation:"
-            + forActorStacksRepresentation + "/ParseForestRepresentation:" + parseForestRepresentation
-            + "/ParseForestConstruction:" + parseForestConstruction + "/StackRepresentation:" + stackRepresentation
-            + "/Reducing:" + reducing + "/Recovery:" + recovery;
+        //@formatter:off
+        return  (activeStacksRepresentation == ActiveStacksRepresentation.standard() ? "_" : "ActiveStacksRepresentation:" + activeStacksRepresentation)
+        + "/" + (forActorStacksRepresentation == ForActorStacksRepresentation.standard() ? "_" : "ForActorStacksRepresentation:" + forActorStacksRepresentation)
+        + "/" + (parseForestRepresentation == ParseForestRepresentation.standard() ? "_" : "ParseForestRepresentation:" + parseForestRepresentation)
+        + "/" + (parseForestConstruction == ParseForestConstruction.standard() ? "_" : "ParseForestConstruction:" + parseForestConstruction)
+        + "/" + (stackRepresentation == StackRepresentation.standard() ? "_" : "StackRepresentation:" + stackRepresentation)
+        + "/" + (reducing == Reducing.standard() ? "_" : "Reducing:" + reducing)
+        + "/Recovery:" + recovery;
+        //@formatter:on
     }
 
     @Override public boolean equals(Object o) {


### PR DESCRIPTION
Replacing "standard" variants with `_`. Now I can actually see which variants are failing, because the full name never fits on my screen :joy: 