### PR TITLE
Consistent imploders

### DIFF
--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/AbstractTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/AbstractTreeImploder.java
@@ -16,7 +16,7 @@ public abstract class AbstractTreeImploder
    <ParseForest extends IParseForest,
     ParseNode   extends IParseNode<ParseForest, Derivation>,
     Derivation  extends IDerivation<ParseForest>,
-    IntermediateResult, 
+    IntermediateResult,
     Cache,
     AbstractSyntaxTree,
     Result      extends IImplodeResult<IntermediateResult, Cache, AbstractSyntaxTree>>

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeStrategoTermTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeStrategoTermTokenizer.java
@@ -1,5 +1,6 @@
 package org.spoofax.jsglr2.imploder;
 
+import org.metaborg.parsetable.symbols.ISymbol;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr2.imploder.treefactory.TokenizedTermTreeFactory;
@@ -7,6 +8,10 @@ import org.spoofax.jsglr2.imploder.treefactory.TokenizedTermTreeFactory;
 public class IterativeStrategoTermTokenizer extends IterativeTreeTokenizer<IStrategoTerm> {
     @Override protected void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
         TokenizedTermTreeFactory.configure(term, sort, leftToken, rightToken);
+    }
+
+    @Override protected void configureInjection(ISymbol lhs, IStrategoTerm term, boolean isBracket) {
+        TokenizedTermTreeFactory.configureInjection(lhs, term, isBracket);
     }
 
     @Override protected void tokenTreeBinding(IToken token, IStrategoTerm term) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeStrategoTermTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeStrategoTermTokenizer.java
@@ -1,15 +1,12 @@
 package org.spoofax.jsglr2.imploder;
 
-import static org.spoofax.jsglr.client.imploder.ImploderAttachment.putImploderAttachment;
-
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.imploder.IToken;
+import org.spoofax.jsglr2.imploder.treefactory.TokenizedTermTreeFactory;
 
 public class IterativeStrategoTermTokenizer extends IterativeTreeTokenizer<IStrategoTerm> {
     @Override protected void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
-        // rightToken can be null, e.g. for an empty string lexical
-        putImploderAttachment(term, false, sort, leftToken, rightToken != null ? rightToken : leftToken, false, false,
-            false, false);
+        TokenizedTermTreeFactory.configure(term, sort, leftToken, rightToken);
     }
 
     @Override protected void tokenTreeBinding(IToken token, IStrategoTerm term) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeImploder.java
@@ -182,7 +182,7 @@ public class IterativeTreeImploder
             subTrees.stream().filter(t -> t.tree != null).map(t -> t.tree).collect(Collectors.toList());
         Tree contextFreeTerm = createContextFreeTerm(production, childASTs);
         return new SubTree<>(contextFreeTerm, subTrees, production,
-            childASTs.size() > 0 && contextFreeTerm == childASTs.get(0));
+            childASTs.size() == 1 && contextFreeTerm == childASTs.get(0));
     }
 
     private SubTree<Tree> createLexicalSubTree(String inputString, ParseNode parseNode, int startOffset,

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
@@ -13,15 +13,14 @@ public abstract class IterativeTreeTokenizer<Tree> extends TreeTokenizer<Tree> {
         tokens.makeStartToken();
         tokenTreeBinding(tokens.startToken(), rootTree.tree);
 
-        // SubTree res = tokenizeInternal(tokens, tree, new Position(0, 1, 1));
         Stack<LinkedList<TreeImploder.SubTree<Tree>>> inputStack = new Stack<>();
         Stack<Position> pivotPositionStack = new Stack<>();
         Stack<Position> startPositionStack = new Stack<>();
         Stack<LinkedList<SubTree>> outputStack = new Stack<>();
 
         inputStack.add(new LinkedList<>(Collections.singletonList(rootTree)));
-        pivotPositionStack.add(new Position(0, 1, 1));
-        startPositionStack.add(new Position(0, 1, 1));
+        pivotPositionStack.add(Position.START_POSITION);
+        startPositionStack.add(Position.START_POSITION);
         outputStack.add(new LinkedList<>());
 
         while(true) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
@@ -110,7 +110,7 @@ public abstract class IterativeTreeTokenizer<Tree> extends TreeTokenizer<Tree> {
 
         SubTree res = outputStack.pop().getFirst();
 
-        tokens.makeEndToken(new Position(res.endPosition.offset, res.endPosition.line, res.endPosition.column));
+        tokens.makeEndToken(res.endPosition);
         tokenTreeBinding(tokens.endToken(), res.tree);
 
         return res;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/StrategoTermTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/StrategoTermTokenizer.java
@@ -1,5 +1,6 @@
 package org.spoofax.jsglr2.imploder;
 
+import org.metaborg.parsetable.symbols.ISymbol;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr2.imploder.treefactory.TokenizedTermTreeFactory;
@@ -7,6 +8,10 @@ import org.spoofax.jsglr2.imploder.treefactory.TokenizedTermTreeFactory;
 public class StrategoTermTokenizer extends TreeTokenizer<IStrategoTerm> {
     @Override protected void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
         TokenizedTermTreeFactory.configure(term, sort, leftToken, rightToken);
+    }
+
+    @Override protected void configureInjection(ISymbol lhs, IStrategoTerm term, boolean isBracket) {
+        TokenizedTermTreeFactory.configureInjection(lhs, term, isBracket);
     }
 
     @Override protected void tokenTreeBinding(IToken token, IStrategoTerm term) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/StrategoTermTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/StrategoTermTokenizer.java
@@ -1,15 +1,12 @@
 package org.spoofax.jsglr2.imploder;
 
-import static org.spoofax.jsglr.client.imploder.ImploderAttachment.putImploderAttachment;
-
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.imploder.IToken;
+import org.spoofax.jsglr2.imploder.treefactory.TokenizedTermTreeFactory;
 
 public class StrategoTermTokenizer extends TreeTokenizer<IStrategoTerm> {
     @Override protected void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
-        // rightToken can be null, e.g. for an empty string lexical
-        putImploderAttachment(term, false, sort, leftToken, rightToken != null ? rightToken : leftToken, false, false,
-            false, false);
+        TokenizedTermTreeFactory.configure(term, sort, leftToken, rightToken);
     }
 
     @Override protected void tokenTreeBinding(IToken token, IStrategoTerm term) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizedTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizedTreeImploder.java
@@ -42,7 +42,7 @@ public abstract class TokenizedTreeImploder
         Tokens tokens = new Tokens(input, fileName);
         tokens.makeStartToken();
 
-        Position position = new Position(0, 1, 1);
+        Position position = Position.START_POSITION;
 
         SubTree<Tree> tree = implodeParseNode(topParseNode, messages, tokens, position, tokens.startToken());
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeImploder.java
@@ -107,7 +107,7 @@ public class TreeImploder
 
         Tree contextFreeTerm = createContextFreeTerm(production, childASTs);
         return new SubTree<>(contextFreeTerm, subTrees, production,
-            childASTs.size() > 0 && contextFreeTerm == childASTs.get(0));
+            childASTs.size() == 1 && contextFreeTerm == childASTs.get(0));
     }
 
     protected List<ParseForest> getChildParseForests(Derivation derivation) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
@@ -51,7 +51,7 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
         tokens.makeStartToken();
         tokenTreeBinding(tokens.startToken(), tree.tree);
 
-        SubTree res = tokenizeInternal(tokens, tree, new Position(0, 1, 1));
+        SubTree res = tokenizeInternal(tokens, tree, Position.START_POSITION);
 
         tokens.makeEndToken(res.endPosition);
         tokenTreeBinding(tokens.endToken(), res.tree);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.metaborg.parsetable.productions.IProduction;
+import org.metaborg.parsetable.symbols.ISymbol;
 import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr2.messages.Message;
 import org.spoofax.jsglr2.parser.Position;
@@ -24,9 +25,13 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
             this.leftToken = leftToken;
             this.rightToken = rightToken;
             this.endPosition = endPosition;
-            if(!tree.isInjection && tree.tree != null && leftToken != null && rightToken != null) {
-                String sort = tree.production == null ? null : tree.production.sort();
-                configure(tree.tree, sort, leftToken, rightToken);
+            if(tree.tree != null && leftToken != null && rightToken != null) {
+                if(tree.isInjection) {
+                    configureInjection(tree.production.lhs(), tree.tree, tree.production.isBracket());
+                } else {
+                    String sort = tree.production == null ? null : tree.production.sort();
+                    configure(tree.tree, sort, leftToken, rightToken);
+                }
             }
             this.messages = messages;
         }
@@ -131,6 +136,8 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
     }
 
     protected abstract void configure(Tree term, String sort, IToken leftToken, IToken rightToken);
+
+    protected abstract void configureInjection(ISymbol lhs, Tree term, boolean bracket);
 
     protected abstract void tokenTreeBinding(IToken token, Tree term);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
@@ -53,7 +53,7 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
 
         SubTree res = tokenizeInternal(tokens, tree, new Position(0, 1, 1));
 
-        tokens.makeEndToken(new Position(res.endPosition.offset, res.endPosition.line, res.endPosition.column));
+        tokens.makeEndToken(res.endPosition);
         tokenTreeBinding(tokens.endToken(), res.tree);
 
         return res;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/TokenizedTermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/TokenizedTermTreeFactory.java
@@ -96,10 +96,10 @@ public class TokenizedTermTreeFactory implements ITokenizedTreeFactory<IStratego
     }
 
     private static IStrategoTerm[] toArray(List<IStrategoTerm> children) {
-        return children.toArray(new IStrategoTerm[children.size()]);
+        return children.toArray(new IStrategoTerm[0]);
     }
 
-    protected void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
+    public static void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
         // rightToken can be null, e.g. for an empty string lexical
         rightToken = rightToken != null ? rightToken : leftToken;
         putImploderAttachment(term, false, sort, leftToken, rightToken, false, false, false, false);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/TokenizedTermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/TokenizedTermTreeFactory.java
@@ -83,6 +83,15 @@ public class TokenizedTermTreeFactory implements ITokenizedTreeFactory<IStratego
     }
 
     @Override public IStrategoTerm createInjection(ISymbol symbol, IStrategoTerm injected, boolean isBracket) {
+        configureInjection(symbol, injected, isBracket);
+        return injected;
+    }
+
+    private static IStrategoTerm[] toArray(List<IStrategoTerm> children) {
+        return children.toArray(new IStrategoTerm[0]);
+    }
+
+    public static void configureInjection(ISymbol symbol, IStrategoTerm injected, boolean isBracket) {
         String sort = ISymbol.getSort(symbol);
 
         // Prevent bogus injections from empty sorts, or lexical sorts into themselves
@@ -92,11 +101,6 @@ public class TokenizedTermTreeFactory implements ITokenizedTreeFactory<IStratego
         }
 
         ImploderAttachment.get(injected).setBracket(isBracket);
-        return injected;
-    }
-
-    private static IStrategoTerm[] toArray(List<IStrategoTerm> children) {
-        return children.toArray(new IStrategoTerm[0]);
     }
 
     public static void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {


### PR DESCRIPTION
Ports the behaviours that were added to the combined imploder-tokenizer in #37 and #39 to the separate imploders/tokenizers, plus some minor other changes (see commit log).