### PR TITLE
Fix imploder attachments for injections on empty trees

### DIFF
--- a/org.spoofax.jsglr2.integration/src/main/resources/grammars/tokenization.sdf3
+++ b/org.spoofax.jsglr2.integration/src/main/resources/grammars/tokenization.sdf3
@@ -22,3 +22,6 @@ context-free syntax
 	Exp.AddOperator = <<Exp> + <Exp>>
 	Exp.AddKeyword  = <<Exp> add <Exp>>
 	Exp.Add2Keyword = <<Exp> add2 <Exp>>
+	Exp             = "[" List "]"
+
+	List.List = {Exp ","}*

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/TokenizationTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/TokenizationTest.java
@@ -92,6 +92,39 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
         ));
     }
 
+    @TestFactory public Stream<DynamicTest> emptyList() throws ParseError {
+        return testTokens("[]", Arrays.asList(
+        //@formatter:off
+            new TokenDescriptor("[", IToken.TK_OPERATOR, 0, 1, 1, "List", "List"),
+            new TokenDescriptor("]", IToken.TK_OPERATOR, 1, 1, 2, "List", "List")
+        //@formatter:on
+        ));
+    }
+
+    @TestFactory public Stream<DynamicTest> singletonList() throws ParseError {
+        return testTokens("[x]", Arrays.asList(
+        //@formatter:off
+            new TokenDescriptor("[", IToken.TK_OPERATOR,    0, 1, 1, "List", "List"),
+            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 1, 1, 2, "ID", null),
+            new TokenDescriptor("]", IToken.TK_OPERATOR,    2, 1, 3, "List", "List")
+        //@formatter:on
+        ));
+    }
+
+    @TestFactory public Stream<DynamicTest> longList() throws ParseError {
+        return testTokens("[x,x,x]", Arrays.asList(
+        //@formatter:off
+            new TokenDescriptor("[", IToken.TK_OPERATOR,    0, 1, 1, "List", "List"),
+            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 1, 1, 2, "ID", null),
+            new TokenDescriptor(",", IToken.TK_OPERATOR,    2, 1, 3, null, null),
+            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 3, 1, 4, "ID", null),
+            new TokenDescriptor(",", IToken.TK_OPERATOR,    4, 1, 5, null, null),
+            new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 5, 1, 6, "ID", null),
+            new TokenDescriptor("]", IToken.TK_OPERATOR,    6, 1, 7, "List", "List")
+        //@formatter:on
+        ));
+    }
+
     @TestFactory public Stream<DynamicTest> multipleLines() throws ParseError {
         return testTokens("x;\nx", Arrays.asList(
         //@formatter:off


### PR DESCRIPTION
In the added test for an empty list, the separated imploders/tokenizers would throw `NullPointerException`s in `configureInjection` because there would be `null` tokens on their subtrees, or in other words, there would be no `ImploderAttachment` to configure the injection for.

This commit makes sure that every context-free subtree has tokens.
For empty subtrees, the `parentLeftToken` is used.

This behaviour matches the changes in 130eef6484c04aa05e4f04be968eb06f9f0f4c3d.