### PR TITLE
Imploder fix: allow character class in kernel syntax

### DIFF
--- a/org.spoofax.jsglr2.integration/src/main/resources/grammars/legacy-cc-in-kernel.sdf3
+++ b/org.spoofax.jsglr2.integration/src/main/resources/grammars/legacy-cc-in-kernel.sdf3
@@ -1,0 +1,11 @@
+module legacy-cc-in-kernel
+
+start-symbols
+
+    Symbol
+
+// Source: https://github.com/webdsl/webdsl/blob/master/src/org/webdsl/dsl/syntax/languages/java-15/lexical/literals/EscapeSequences.sdf#L20
+syntax
+
+    Symbol.Escape = "\\" [btnfr\"\'\\]
+    Symbol.OctEscape = "\\" [0-3] [0-7] [0-7]

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/LegacyCharacterClassInKernelTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/LegacyCharacterClassInKernelTest.java
@@ -1,0 +1,41 @@
+package org.spoofax.jsglr2.integrationtest.features;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.spoofax.jsglr2.integrationtest.BaseTestWithSdf3ParseTables;
+import org.spoofax.jsglr2.integrationtest.BaseTestWithSdf3ParseTablesWithJSGLR1;
+import org.spoofax.terms.ParseError;
+
+public class LegacyCharacterClassInKernelTest extends BaseTestWithSdf3ParseTablesWithJSGLR1 {
+
+    public LegacyCharacterClassInKernelTest() {
+        super("legacy-cc-in-kernel.sdf3");
+    }
+
+    @TestFactory public Stream<DynamicTest> singleEscapeN1() throws ParseError {
+        return testSuccessByJSGLR1("\\n");
+    }
+
+    @TestFactory public Stream<DynamicTest> singleEscapeQuote1() throws ParseError {
+        return testSuccessByJSGLR1("\\\"");
+    }
+
+    @TestFactory public Stream<DynamicTest> octalEscape1() throws ParseError {
+        return testSuccessByJSGLR1("\\123");
+    }
+
+    @TestFactory public Stream<DynamicTest> singleEscapeN2() throws ParseError {
+        return testSuccessByExpansions("\\n", "Escape(110)");
+    }
+
+    @TestFactory public Stream<DynamicTest> singleEscapeQuote2() throws ParseError {
+        return testSuccessByExpansions("\\\"", "Escape(34)");
+    }
+
+    @TestFactory public Stream<DynamicTest> octalEscape2() throws ParseError {
+        return testSuccessByExpansions("\\123", "OctEscape(49,50,51)");
+    }
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variant.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/JSGLR2Variant.java
@@ -8,7 +8,9 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr2.imploder.*;
 import org.spoofax.jsglr2.imploder.incremental.IncrementalStrategoTermImploder;
 import org.spoofax.jsglr2.imploder.incremental.IncrementalTreeImploder;
-import org.spoofax.jsglr2.parseforest.*;
+import org.spoofax.jsglr2.parseforest.IParseForest;
+import org.spoofax.jsglr2.parseforest.ParseForestConstruction;
+import org.spoofax.jsglr2.parseforest.ParseForestRepresentation;
 import org.spoofax.jsglr2.parser.IParser;
 import org.spoofax.jsglr2.parser.ParserVariant;
 import org.spoofax.jsglr2.reducing.Reducing;
@@ -30,7 +32,7 @@ public class JSGLR2Variant {
         this.tokenizer = tokenizerVariant;
     }
 
-    private <ImploderCache extends IncrementalTreeImploder.ResultCache<IParseForest, IParseNode<IParseForest, IDerivation<IParseForest>>, IDerivation<IParseForest>, IStrategoTerm>>
+    private <ImploderCache extends IncrementalTreeImploder.ResultCache<IParseForest, IStrategoTerm>>
         IImploder<IParseForest, TreeImploder.SubTree<IStrategoTerm>, ImploderCache, IStrategoTerm, ImplodeResult<TreeImploder.SubTree<IStrategoTerm>, ImploderCache, IStrategoTerm>>
         getImploder() {
         switch(this.imploder) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizedTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizedTreeImploder.java
@@ -10,6 +10,7 @@ import org.metaborg.parsetable.symbols.IMetaVarSymbol;
 import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr2.imploder.treefactory.ITokenizedTreeFactory;
 import org.spoofax.jsglr2.messages.Message;
+import org.spoofax.jsglr2.parseforest.ICharacterNode;
 import org.spoofax.jsglr2.parseforest.IDerivation;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parseforest.IParseNode;
@@ -184,6 +185,17 @@ public abstract class TokenizedTreeImploder
         IToken pivotToken = parentLeftToken;
 
         for(ParseForest childParseForest : childParseForests) {
+            if(childParseForest instanceof ICharacterNode) {
+                int width = childParseForest.width();
+                Position endPosition = pivotPosition.step(tokens.getInput(), width);
+                IToken token = tokens.makeToken(pivotPosition, endPosition, null);
+                Tree tree = createCharacterTerm(((ICharacterNode) childParseForest).character(), token);
+                childASTs.add(tree);
+                pivotToken = token;
+                pivotPosition = endPosition;
+                continue;
+            }
+
             @SuppressWarnings("unchecked") ParseNode childParseNode = (ParseNode) childParseForest;
 
             IProduction childProduction = childParseNode.production();
@@ -271,6 +283,14 @@ public abstract class TokenizedTreeImploder
             tokenTreeBinding(lexicalToken, lexicalTerm);
 
         return lexicalTerm;
+    }
+
+    protected Tree createCharacterTerm(int character, IToken lexicalToken) {
+        Tree term = treeFactory.createCharacterTerminal(character, lexicalToken);
+
+        tokenTreeBinding(lexicalToken, term);
+
+        return term;
     }
 
     protected abstract void tokenTreeBinding(IToken token, Tree tree);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalStrategoTermImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalStrategoTermImploder.java
@@ -11,7 +11,7 @@ public class IncrementalStrategoTermImploder
    <ParseForest extends IParseForest,
     ParseNode   extends IParseNode<ParseForest, Derivation>,
     Derivation  extends IDerivation<ParseForest>,
-    Cache       extends IncrementalTreeImploder.ResultCache<ParseForest, ParseNode, Derivation, IStrategoTerm>>
+    Cache       extends IncrementalTreeImploder.ResultCache<ParseForest, IStrategoTerm>>
 //@formatter:on
     extends
     IncrementalTreeImploder<ParseForest, ParseNode, Derivation, Cache, IStrategoTerm, IncrementalImplodeInput<ParseNode, Cache, IStrategoTerm>> {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/incremental/IncrementalTreeImploder.java
@@ -16,7 +16,7 @@ public abstract class IncrementalTreeImploder
    <ParseForest extends IParseForest,
     ParseNode   extends IParseNode<ParseForest, Derivation>,
     Derivation  extends IDerivation<ParseForest>,
-    Cache       extends IncrementalTreeImploder.ResultCache<ParseForest, ParseNode, Derivation, Tree>,
+    Cache       extends IncrementalTreeImploder.ResultCache<ParseForest, Tree>,
     Tree,
     Input       extends IncrementalImplodeInput<ParseNode, Cache, Tree>>
 //@formatter:on
@@ -42,14 +42,12 @@ public abstract class IncrementalTreeImploder
             return new ImplodeResult<>(result.intermediateResult, null, result.ast, result.messages);
         }
 
-        @SuppressWarnings("unchecked") ParseNode topParseNode = (ParseNode) parseForest;
-
-        SubTree<Tree> result = implodeParseNode(incrementalInputFactory.get(inputString, resultCache), topParseNode, 0);
+        SubTree<Tree> result = implodeParseNode(incrementalInputFactory.get(inputString, resultCache), parseForest, 0);
 
         return new ImplodeResult<>(result, resultCache, result.tree, Collections.emptyList());
     }
 
-    @Override protected SubTree<Tree> implodeParseNode(Input input, ParseNode parseNode, int startOffset) {
+    @Override protected SubTree<Tree> implodeParseNode(Input input, ParseForest parseNode, int startOffset) {
         if(input.resultCache.cache.containsKey(parseNode))
             return input.resultCache.cache.get(parseNode);
 
@@ -58,8 +56,8 @@ public abstract class IncrementalTreeImploder
         return result;
     }
 
-    public static class ResultCache<ParseForest extends IParseForest, ParseNode extends IParseNode<ParseForest, Derivation>, Derivation extends IDerivation<ParseForest>, Tree> {
-        protected final WeakHashMap<ParseNode, SubTree<Tree>> cache = new WeakHashMap<>();
+    public static class ResultCache<ParseForest extends IParseForest, Tree> {
+        protected final WeakHashMap<ParseForest, SubTree<Tree>> cache = new WeakHashMap<>();
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/ITokenizedTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/ITokenizedTreeFactory.java
@@ -8,6 +8,8 @@ import org.spoofax.jsglr.client.imploder.IToken;
 
 public interface ITokenizedTreeFactory<T> {
 
+    T createCharacterTerminal(int character, IToken token);
+
     T createStringTerminal(ISymbol symbol, String value, IToken token);
 
     T createMetaVar(IMetaVarSymbol symbol, String value, IToken token);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/ITreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/ITreeFactory.java
@@ -5,6 +5,8 @@ import org.metaborg.parsetable.symbols.ISymbol;
 
 public interface ITreeFactory<T> {
 
+    T createCharacterTerminal(int character);
+
     T createStringTerminal(ISymbol symbol, String value);
 
     T createMetaVar(IMetaVarSymbol symbol, String value);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/StrategoTermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/StrategoTermTreeFactory.java
@@ -18,6 +18,10 @@ public class StrategoTermTreeFactory implements ITreeFactory<IStrategoTerm> {
         this.termFactory = new TermFactory();
     }
 
+    @Override public IStrategoTerm createCharacterTerminal(int character) {
+        return termFactory.makeInt(character);
+    }
+
     @Override public IStrategoTerm createStringTerminal(ISymbol symbol, String value) {
         return termFactory.makeString(value);
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/TokenizedTermTreeFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/treefactory/TokenizedTermTreeFactory.java
@@ -25,6 +25,14 @@ public class TokenizedTermTreeFactory implements ITokenizedTreeFactory<IStratego
         this.termFactory = new TermFactory();
     }
 
+    @Override public IStrategoTerm createCharacterTerminal(int character, IToken token) {
+        IStrategoTerm characterTerminalTerm = termFactory.makeInt(character);
+
+        configure(characterTerminalTerm, null, token, token);
+
+        return characterTerminalTerm;
+    }
+
     @Override public IStrategoTerm createStringTerminal(ISymbol symbol, String value, IToken token) {
         IStrategoTerm stringTerminalTerm = termFactory.makeString(value);
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/Tokens.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/Tokens.java
@@ -53,7 +53,9 @@ public class Tokens implements IParseTokens {
     public IToken makeToken(Position startPosition, Position endPosition, IProduction production) {
         int tokenKind;
 
-        if(production.isLayout()) {
+        if(production == null) {
+            tokenKind = IToken.TK_STRING; // indicates a character/int terminal, e.g. 'x'
+        } else if(production.isLayout()) {
             tokenKind = IToken.TK_LAYOUT;
         } else if(production.isLiteral()) {
             if(production.isOperator())


### PR DESCRIPTION
The recursive method `implodeParseNode` now accepts any `ParseForest` (i.e. including `CharacterNode`s), instead of just `ParseNode`s. This fixes the `ClassCastException` that used to be thrown when parsing a grammar production that used "naked" (not wrapped in a lexical rule) character classes in kernel syntax. Examples of such a grammar rule are found [here](https://github.com/webdsl/webdsl/blob/master/src/org/webdsl/dsl/syntax/languages/java-15/lexical/literals/EscapeSequences.sdf#L20).

JSGLR1 handles this by imploding the character to a `StrategoInt` (which IMO is ugly, but hey, legacy code :sweat_smile:). The JSGLR2 imploders now do this as well. This behaviour is verified with an added integration test that tests both versions of JSGLR.