### PR TITLE
Unicode diff bug

### DIFF
--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/EmojiTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/EmojiTest.java
@@ -51,4 +51,9 @@ public class EmojiTest extends BaseTestWithSdf3ParseTables {
                 new TokenDescriptor("😄", IToken.TK_IDENTIFIER, 5, 1, 5, "ID", null)));
     }
 
+    @TestFactory public Stream<DynamicTest> testEmojiIncremental() throws ParseError {
+        return testIncrementalSuccessByExpansions(new String[] { "😇 ➕ 😄😄", "😇😇  ➕ 😄" },
+                new String[] { "[Add(Var(\"😇\"),\"➕\",Var(\"😄😄\"))]", "[Add(Var(\"😇😇\"),\"➕\",Var(\"😄\"))]" });
+    }
+
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiff.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/JGitHistogramDiff.java
@@ -14,8 +14,8 @@ public class JGitHistogramDiff implements IStringDiff {
     @Override public List<EditorUpdate> diff(String oldString, String newString) {
         // By default, RawText is split per line.
         // By passing a `lineMap` which is a list that contains all integers from 0 to length, this is avoided.
-        RawText oldText = new RawText(oldString.getBytes(), new IncrementingIntList(oldString.length()));
-        RawText newText = new RawText(newString.getBytes(), new IncrementingIntList(newString.length()));
+        RawText oldText = new RawText(oldString.toCharArray(), new IncrementingIntList(oldString.length()));
+        RawText newText = new RawText(newString.toCharArray(), new IncrementingIntList(newString.length()));
 
         EditList edits = diff.diff(RawTextComparator.DEFAULT, oldText, newText);
         List<EditorUpdate> updates = new ArrayList<>(edits.size());

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdates.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/ProcessUpdates.java
@@ -96,7 +96,7 @@ public class ProcessUpdates
                     return newParseNodeFromChildren(getParseNodeFromString(inserted), currentForest);
                 }
                 // If insert position is NOT begin of string: append to current character
-                if(deletedStartOffset != 0 && currentOffset == deletedStartOffset - 1) {
+                if(deletedStartOffset != 0 && currentOffset == deletedStartOffset - currentForest.width()) {
                     updates.removeFirst();
                     return newParseNodeFromChildren(currentForest, getParseNodeFromString(inserted));
                 }
@@ -105,13 +105,13 @@ public class ProcessUpdates
             }
             // Replace first deleted character with the inserted string (if any)
             if(type == REPLACEMENT && currentOffset == deletedStartOffset) {
-                if(currentOffset == deletedEndOffset - 1)
+                if(currentOffset == deletedEndOffset - currentForest.width())
                     updates.removeFirst();
                 return getParseNodeFromString(inserted);
             }
             // Else: delete all characters within deletion range
             if(deletedStartOffset <= currentOffset && currentOffset < deletedEndOffset) {
-                if(currentOffset == deletedEndOffset - 1)
+                if(currentOffset == deletedEndOffset - currentForest.width())
                     updates.removeFirst();
                 return null;
             }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawCharUtil.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawCharUtil.java
@@ -45,7 +45,7 @@
 package org.spoofax.jsglr2.incremental.diff.jgit;
 
 /**
- * Utility class for character functions on raw bytes
+ * Utility class for character functions on raw chars
  * <p>
  * Characters are assumed to be 8-bit US-ASCII.
  */
@@ -66,24 +66,24 @@ public class RawCharUtil {
      *            the 8-bit US-ASCII encoded character
      * @return true if c represents a whitespace character in 8-bit US-ASCII
      */
-    public static boolean isWhitespace(byte c) {
+    public static boolean isWhitespace(char c) {
         return WHITESPACE[c & 0xff];
     }
 
     /**
-     * Returns the new end point for the byte array passed in after trimming any
+     * Returns the new end point for the char array passed in after trimming any
      * trailing whitespace characters, as determined by the isWhitespace()
      * function. start and end are assumed to be within the bounds of raw.
      *
      * @param raw
-     *            the byte array containing the portion to trim whitespace for
+     *            the char array containing the portion to trim whitespace for
      * @param start
-     *            the start of the section of bytes
+     *            the start of the section of chars
      * @param end
-     *            the end of the section of bytes
+     *            the end of the section of chars
      * @return the new end point
      */
-    public static int trimTrailingWhitespace(byte[] raw, int start, int end) {
+    public static int trimTrailingWhitespace(char[] raw, int start, int end) {
         int ptr = end - 1;
         while (start <= ptr && isWhitespace(raw[ptr]))
             ptr--;
@@ -92,19 +92,19 @@ public class RawCharUtil {
     }
 
     /**
-     * Returns the new start point for the byte array passed in after trimming
+     * Returns the new start point for the char array passed in after trimming
      * any leading whitespace characters, as determined by the isWhitespace()
      * function. start and end are assumed to be within the bounds of raw.
      *
      * @param raw
-     *            the byte array containing the portion to trim whitespace for
+     *            the char array containing the portion to trim whitespace for
      * @param start
-     *            the start of the section of bytes
+     *            the start of the section of chars
      * @param end
-     *            the end of the section of bytes
+     *            the end of the section of chars
      * @return the new start point
      */
-    public static int trimLeadingWhitespace(byte[] raw, int start, int end) {
+    public static int trimLeadingWhitespace(char[] raw, int start, int end) {
         while (start < end && isWhitespace(raw[start]))
             start++;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawText.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawText.java
@@ -37,7 +37,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- * A Sequence supporting UNIX formatted text in byte[] format.
+ * A Sequence supporting UNIX formatted text in char[] format.
  * <p>
  * Elements of the sequence are the lines of the file, as delimited by the UNIX newline character ('\n'). The file
  * content is treated as 8 bit binary text, with no assumptions or requirements on character encoding.
@@ -48,19 +48,19 @@ import java.io.OutputStream;
  */
 public class RawText extends Sequence {
     /** A RawText of length 0 */
-    public static final RawText EMPTY_TEXT = new RawText(new byte[0], new IntList());
+    public static final RawText EMPTY_TEXT = new RawText(new char[0], new IntList());
 
     /** Number of bytes to check for heuristics in {@link #isBinary(byte[])} */
     static final int FIRST_FEW_BYTES = 8000;
 
     /** The file content for this sequence. */
-    protected final byte[] content;
+    protected final char[] content;
 
     /** Map of line number to starting position within {@link #content}. */
     protected final IntList lines;
 
     /**
-     * Create a new sequence from the existing content byte array and the line map indicating line boundaries.
+     * Create a new sequence from the existing content char array and the line map indicating line boundaries.
      *
      * @param input
      *            the content array. The object retains a reference to this array, so it should be immutable.
@@ -69,7 +69,7 @@ public class RawText extends Sequence {
      *            {@link Integer#MIN_VALUE} and an offset one past the end of the last line, respectively.
      * @since 5.0
      */
-    public RawText(byte[] input, IntList lineMap) {
+    public RawText(char[] input, IntList lineMap) {
         content = input;
         lines = lineMap;
     }
@@ -78,7 +78,7 @@ public class RawText extends Sequence {
      * @return the raw, unprocessed content read.
      * @since 4.11
      */
-    public byte[] getRawContent() {
+    public char[] getRawContent() {
         return content;
     }
 
@@ -112,7 +112,7 @@ public class RawText extends Sequence {
         int end = getEnd(i);
         if(content[end - 1] == '\n')
             end--;
-        out.write(content, start, end - start);
+        out.write(new String(content).getBytes(), start, end - start);
     }
 
     /**

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawTextComparator.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/diff/jgit/RawTextComparator.java
@@ -74,7 +74,7 @@ public abstract class RawTextComparator extends SequenceComparator<RawText> {
 		}
 
 		@Override
-		protected int hashRegion(byte[] raw, int ptr, int end) {
+		protected int hashRegion(char[] raw, int ptr, int end) {
 			int hash = 5381;
 			for (; ptr < end; ptr++)
 				hash = ((hash << 5) + hash) + (raw[ptr] & 0xff);
@@ -98,8 +98,8 @@ public abstract class RawTextComparator extends SequenceComparator<RawText> {
 			be = trimTrailingWhitespace(b.content, bs, be);
 
 			while (as < ae && bs < be) {
-				byte ac = a.content[as];
-				byte bc = b.content[bs];
+				char ac = a.content[as];
+				char bc = b.content[bs];
 
 				while (as < ae - 1 && isWhitespace(ac)) {
 					as++;
@@ -122,10 +122,10 @@ public abstract class RawTextComparator extends SequenceComparator<RawText> {
 		}
 
 		@Override
-		protected int hashRegion(byte[] raw, int ptr, int end) {
+		protected int hashRegion(char[] raw, int ptr, int end) {
 			int hash = 5381;
 			for (; ptr < end; ptr++) {
-				byte c = raw[ptr];
+				char c = raw[ptr];
 				if (!isWhitespace(c))
 					hash = ((hash << 5) + hash) + (c & 0xff);
 			}
@@ -161,7 +161,7 @@ public abstract class RawTextComparator extends SequenceComparator<RawText> {
 		}
 
 		@Override
-		protected int hashRegion(byte[] raw, int ptr, int end) {
+		protected int hashRegion(char[] raw, int ptr, int end) {
 			int hash = 5381;
 			ptr = trimLeadingWhitespace(raw, ptr, end);
 			for (; ptr < end; ptr++)
@@ -196,7 +196,7 @@ public abstract class RawTextComparator extends SequenceComparator<RawText> {
 		}
 
 		@Override
-		protected int hashRegion(byte[] raw, int ptr, int end) {
+		protected int hashRegion(char[] raw, int ptr, int end) {
 			int hash = 5381;
 			end = trimTrailingWhitespace(raw, ptr, end);
 			for (; ptr < end; ptr++)
@@ -221,8 +221,8 @@ public abstract class RawTextComparator extends SequenceComparator<RawText> {
 			be = trimTrailingWhitespace(b.content, bs, be);
 
 			while (as < ae && bs < be) {
-				byte ac = a.content[as];
-				byte bc = b.content[bs];
+				char ac = a.content[as];
+				char bc = b.content[bs];
 
 				if (ac != bc)
 					return false;
@@ -241,11 +241,11 @@ public abstract class RawTextComparator extends SequenceComparator<RawText> {
 		}
 
 		@Override
-		protected int hashRegion(byte[] raw, int ptr, int end) {
+		protected int hashRegion(char[] raw, int ptr, int end) {
 			int hash = 5381;
 			end = trimTrailingWhitespace(raw, ptr, end);
 			while (ptr < end) {
-				byte c = raw[ptr];
+				char c = raw[ptr];
 				hash = ((hash << 5) + hash) + (c & 0xff);
 				if (isWhitespace(c))
 					ptr = trimLeadingWhitespace(raw, ptr, end);
@@ -275,8 +275,8 @@ public abstract class RawTextComparator extends SequenceComparator<RawText> {
 		if (e.beginA == e.endA || e.beginB == e.endB)
 			return e;
 
-		byte[] aRaw = a.content;
-		byte[] bRaw = b.content;
+		char[] aRaw = a.content;
+		char[] bRaw = b.content;
 
 		int aPtr = a.lines.get(e.beginA + 1);
 		int bPtr = a.lines.get(e.beginB + 1);
@@ -342,5 +342,5 @@ public abstract class RawTextComparator extends SequenceComparator<RawText> {
 	 *            1 past the last byte of the region.
 	 * @return hash code for the region <code>[ptr, end)</code> of raw.
 	 */
-	protected abstract int hashRegion(byte[] raw, int ptr, int end);
+	protected abstract int hashRegion(char[] raw, int ptr, int end);
 }


### PR DESCRIPTION
This PR fixes some bugs related to the combination of incremental + Unicode:

- The positions reported by the diff algorithm were in terms of offset in the UTF-8-encoded string, instead of offset in the UTF-16. This caused a mismatch in the reported offset when the string contained Unicode chars. This is fixed in 5fd9f1c by changing the diff algorithm to use 16-bit `char` instead of the original 8-bit `byte`.
- Fix `ProcessUpdates` for characters wider than 1 (8c66401). The tree updating algorithm assumed that all characters would have width 1, but this is no longer the case: Unicode chars above value 65535 have a width of 2 (because they are stored in a Java string using two UTF-16 elements).

I ran the full build locally, and it passes :slightly_smiling_face: 