### PR TITLE
Tokenizer consistency

### DIFF
--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/Token.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/Token.java
@@ -105,7 +105,7 @@ public class Token implements IToken, Cloneable {
     }
 
     public int getEndColumn() {
-        return column + getEndOffset() - getStartOffset();
+        return column - 1 + tokens.getInput().codePointCount(getStartOffset(), getEndOffset() + 1);
     }
 
     public int getLength() {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeStrategoTermTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeStrategoTermTokenizer.java
@@ -7,7 +7,7 @@ import org.spoofax.jsglr2.imploder.treefactory.TokenizedTermTreeFactory;
 
 public class IterativeStrategoTermTokenizer extends IterativeTreeTokenizer<IStrategoTerm> {
     @Override protected void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
-        TokenizedTermTreeFactory.configure(term, sort, leftToken, rightToken);
+        StrategoTermTokenizer.configureStatic(term, sort, leftToken, rightToken);
     }
 
     @Override protected void configureInjection(ISymbol lhs, IStrategoTerm term, boolean isBracket) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeImploder.java
@@ -113,7 +113,7 @@ public class IterativeTreeImploder
                 if(parseForest instanceof ICharacterNode) {
                     SubTree<Tree> characterSubTree =
                         new SubTree<>(treeFactory.createCharacterTerminal(((ICharacterNode) parseForest).character()),
-                            null, parseForest.width());
+                            null, parseForest.width(), true);
                     currentOut.getLast().add(characterSubTree);
                     pseudoNode.pivotOffset += characterSubTree.width;
                 } else {
@@ -174,7 +174,7 @@ public class IterativeTreeImploder
 
     private SubTree<Tree> createAmbiguousSubTree(ParseNode parseNode, List<SubTree<Tree>> subTrees) {
         return new SubTree<>(treeFactory.createAmb(subTrees.stream().map(t -> t.tree)::iterator), subTrees, null,
-            subTrees.get(0).width, false);
+            subTrees.get(0).width, false, true, false);
     }
 
     private SubTree<Tree> createNonTerminalSubTree(IProduction production, List<SubTree<Tree>> subTrees) {
@@ -189,7 +189,7 @@ public class IterativeTreeImploder
         IProduction production) {
         int width = parseNode.width();
 
-        return new SubTree<>(createLexicalTerm(production, inputString, startOffset, width), production, width);
+        return new SubTree<>(createLexicalTerm(production, inputString, startOffset, width), production, width, false);
     }
 
     @SafeVarargs private static <E> LinkedList<LinkedList<E>> newNestedList(E... elements) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
@@ -66,21 +66,23 @@ public abstract class IterativeTreeTokenizer<Tree> extends TreeTokenizer<Tree> {
                     if(subTree.rightToken != null)
                         pivotToken = subTree.rightToken;
 
-                    // If tree production == null, that means it's an "amb" node; in that case, position is not advanced
-                    if(tree.production != null)
-                        pivotPosition = subTree.endPosition;
+                    pivotPosition = subTree.endPosition;
                 }
 
                 if(leftToken == null)
                     leftToken = currentParentLeftToken;
 
+                // In the case when we're dealing with an ambiguous tree node, position is not advanced
+                //noinspection ConstantConditions (peek can never return `null`, as we check size > 1)
+                if(inputStack.size() > 1 && !inputStack.get(inputStack.size() - 2).peek().isAmbiguous) {
+                    pivotPositionStack.pop();
+                    pivotPositionStack.push(pivotPosition);
+                }
                 // Add processed output to the list that is on top of the stack
-                pivotPositionStack.pop();
-                pivotPositionStack.push(pivotPosition);
                 outputStack.peek().add(new SubTree(tree, leftToken, pivotToken, pivotPosition));
             } else {
                 TreeImploder.SubTree<Tree> tree = currentIn.getFirst(); // Process the next input
-                if(tree.production != null && !tree.production.isContextFree()) {
+                if(tree.production != null && !tree.production.isContextFree() || tree.isCharacterTerminal) {
                     if(tree.width > 0) {
                         Position endPosition = currentPos.step(tokens.getInput(), tree.width);
                         lastToken = tokens.makeToken(currentPos, endPosition, tree.production);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/StrategoTermTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/StrategoTermTokenizer.java
@@ -4,10 +4,24 @@ import org.metaborg.parsetable.symbols.ISymbol;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr2.imploder.treefactory.TokenizedTermTreeFactory;
+import org.spoofax.terms.util.TermUtils;
 
 public class StrategoTermTokenizer extends TreeTokenizer<IStrategoTerm> {
     @Override protected void configure(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
+        configureStatic(term, sort, leftToken, rightToken);
+    }
+
+    public static void configureStatic(IStrategoTerm term, String sort, IToken leftToken, IToken rightToken) {
         TokenizedTermTreeFactory.configure(term, sort, leftToken, rightToken);
+        if (TermUtils.isAppl(term)) {
+            String name = TermUtils.toAppl(term).getName();
+            if ("amb".equals(name)) {
+                TokenizedTermTreeFactory.configure(term.getSubterm(0), null, leftToken, rightToken);
+            }
+            if ("meta-var".equals(name) || "meta-listvar".equals(name)) {
+                TokenizedTermTreeFactory.configure(term.getSubterm(0), sort, leftToken, rightToken);
+            }
+        }
     }
 
     @Override protected void configureInjection(ISymbol lhs, IStrategoTerm term, boolean isBracket) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizedTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizedTreeImploder.java
@@ -219,7 +219,9 @@ public abstract class TokenizedTreeImploder
             }
 
             // Set the parent tree left and right token from the outermost non-layout left and right child tokens
-            if(childProduction != null && !childProduction.isLayout()) {
+            if(childProduction != null && !childProduction.isLayout()
+                // Also do this for character nodes
+                || childParseNode == null) {
                 if(result.leftToken == null)
                     result.leftToken = subTree.leftToken;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeImploder.java
@@ -43,7 +43,7 @@ public class TreeImploder
     protected SubTree<Tree> implodeParseNode(Input input, ParseForest parseForest, int startOffset) {
         if(parseForest instanceof ICharacterNode) {
             return new SubTree<>(treeFactory.createCharacterTerminal(((ICharacterNode) parseForest).character()), null,
-                parseForest.width());
+                parseForest.width(), true);
         }
 
         @SuppressWarnings("unchecked") ParseNode parseNode = (ParseNode) parseForest;
@@ -74,14 +74,15 @@ public class TreeImploder
                     }
                 }
 
-                return new SubTree<>(treeFactory.createAmb(trees), subTrees, null, subTrees.get(0).width, false);
+                return new SubTree<>(treeFactory.createAmb(trees), subTrees, null, subTrees.get(0).width, false, true,
+                    false);
             } else
                 return implodeDerivation(input, filteredDerivations.get(0), startOffset);
         } else {
             int width = parseNode.width();
 
             return new SubTree<>(createLexicalTerm(production, input.inputString, startOffset, width), production,
-                width);
+                width, false);
         }
     }
 
@@ -201,24 +202,28 @@ public class TreeImploder
          * </code>
          */
         public final boolean isInjection;
+        public final boolean isAmbiguous;
+        public final boolean isCharacterTerminal;
 
-        public SubTree(Tree tree, List<SubTree<Tree>> children, IProduction production, int width,
-            boolean isInjection) {
+        public SubTree(Tree tree, List<SubTree<Tree>> children, IProduction production, int width, boolean isInjection,
+            boolean isAmbiguous, boolean isCharacterTerminal) {
             this.tree = tree;
             this.children = children;
             this.production = production;
             this.width = width;
             this.isInjection = isInjection;
+            this.isAmbiguous = isAmbiguous;
+            this.isCharacterTerminal = isCharacterTerminal;
         }
 
         /** This constructor infers the width from the sum of widths of its children. */
         public SubTree(Tree tree, List<SubTree<Tree>> children, IProduction production, boolean isInjection) {
-            this(tree, children, production, sumWidth(children), isInjection);
+            this(tree, children, production, sumWidth(children), isInjection, false, false);
         }
 
         /** This constructor corresponds to a terminal/lexical node without children. */
-        public SubTree(Tree tree, IProduction production, int width) {
-            this(tree, Collections.emptyList(), production, width, false);
+        public SubTree(Tree tree, IProduction production, int width, boolean isCharacterTerminal) {
+            this(tree, Collections.emptyList(), production, width, false, false, isCharacterTerminal);
         }
 
         private static <Tree> int sumWidth(List<SubTree<Tree>> children) {


### PR DESCRIPTION
This fixes the following bugs related to consistent tokenization between the different variants

- Make `Token`s calculate `getEndColumn` correctly with wide Unicode characters (all tokenizer variants)
- Recursive/iterative tokenizers: add attachments to children of `amb`/`meta-var` (for recursive and iterative tokenizer variants)
- Reset `pivotPosition` when moving to next child of ambiguous subtree (for recursive and iterative tokenizer variants)
- Set `leftToken` and `rightToken` for character nodes (all tokenizer variants)