### PR TITLE
Empty tokens

### DIFF
--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/Token.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/Token.java
@@ -105,7 +105,10 @@ public class Token implements IToken, Cloneable {
     }
 
     public int getEndColumn() {
-        return column - 1 + tokens.getInput().codePointCount(getStartOffset(), getEndOffset() + 1);
+        return column - 1
+            + (tokens != null && tokens.getInput() != null && getStartOffset() >= 0
+                && getEndOffset() < tokens.getInput().length() && getStartOffset() <= getEndOffset()
+                    ? tokens.getInput().codePointCount(getStartOffset(), getEndOffset() + 1) : getLength());
     }
 
     public int getLength() {

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/TreeBuilder.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/imploder/TreeBuilder.java
@@ -641,8 +641,8 @@ public class TreeBuilder extends TopdownTreeBuilder {
 
 			if (tokenizer.getTokenCount() - index <= 1) {
 				// Create new empty token
-				// HACK: Assume TK_LAYOUT kind for empty tokens in AST nodes
-				return tokenizer.makeToken(offset - 1, IToken.TK_LAYOUT, true);
+				// HACK: Assume TK_NO_TOKEN_KIND kind for empty tokens in AST nodes
+				return tokenizer.makeToken(offset - 1, IToken.TK_NO_TOKEN_KIND, true);
 			} else {
 				return tokenizer.getTokenAt(index + 1);
 			}

--- a/org.spoofax.jsglr2.integration/src/main/resources/grammars/emoji.sdf3
+++ b/org.spoofax.jsglr2.integration/src/main/resources/grammars/emoji.sdf3
@@ -8,6 +8,7 @@ context-free syntax
 
     Exp.Add = Exp PLUS Exp
     Exp.Var = ID
+    Exp.Empty =
 
 lexical syntax
 

--- a/org.spoofax.jsglr2.integration/src/main/resources/grammars/empty-list-ambiguous.sdf3
+++ b/org.spoofax.jsglr2.integration/src/main/resources/grammars/empty-list-ambiguous.sdf3
@@ -1,0 +1,9 @@
+module empty-list-ambiguous
+
+context-free start-symbols
+    Exp
+
+context-free syntax
+    Exp.List = "[" {Exp ","}* "]"
+    Exp.Term = "x"
+    Exp.Empty =

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -7,9 +7,7 @@ import static org.spoofax.terms.util.TermUtils.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Stack;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -19,6 +17,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.spoofax.interpreter.terms.IStrategoAppl;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.imploder.IToken;
+import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.jsglr2.JSGLR2;
 import org.spoofax.jsglr2.JSGLR2Result;
 import org.spoofax.jsglr2.JSGLR2Success;
@@ -165,8 +164,15 @@ public abstract class BaseTest implements WithParseTable {
 
     private Stream<DynamicTest> testSuccess(String inputString, String expectedOutputAstString, String startSymbol,
         boolean equalityByExpansions) {
+        List<IStrategoTerm> previous = new ArrayList<>(1); // Variable used in lambda should be effectively final
         return testPerVariant(getTestVariants(), variant -> () -> {
             IStrategoTerm actualOutputAst = testSuccess(variant, startSymbol, inputString);
+
+            if(previous.isEmpty())
+                previous.add(actualOutputAst);
+            else
+                assertEqualAST("Variant '" + variant.name() + "' does not have the same AST as the first variant",
+                    previous.get(0), actualOutputAst);
 
             assertEqualAST("Incorrect AST", expectedOutputAstString, actualOutputAst, equalityByExpansions);
         });
@@ -215,6 +221,92 @@ public abstract class BaseTest implements WithParseTable {
                     equalityByExpansions);
             }
         });
+    }
+
+    protected void assertEqualAST(String message, IStrategoTerm expected, IStrategoTerm actual) {
+        assertEqualAST(message, expected, actual, expected, actual);
+    }
+
+    private void assertEqualAST(String message, IStrategoTerm expected, IStrategoTerm actual, IStrategoTerm e,
+        IStrategoTerm a) {
+        compareAttachments(message, e, a);
+
+        IStrategoTerm[] subTermsE = e.getAllSubterms();
+        IStrategoTerm[] subTermsA = a.getAllSubterms();
+        if(isAppl(e) && toAppl(e).getName().equals("amb") && isAppl(a) && toAppl(a).getName().equals("amb")) {
+            // Check the list term that is the first argument of the amb()
+            compareAttachments(message, subTermsE[0], subTermsA[0]);
+
+            IStrategoTerm[] ambTermsE = subTermsE[0].getAllSubterms();
+            IStrategoTerm[] ambTermsA = subTermsA[0].getAllSubterms();
+            // Sort the sub terms of the list term
+            Arrays.sort(ambTermsE, Comparator.comparing(Object::toString));
+            Arrays.sort(ambTermsA, Comparator.comparing(Object::toString));
+
+            compareSubTerms(message, expected, actual, ambTermsE, ambTermsA);
+        } else {
+            compareSubTerms(message, expected, actual, subTermsE, subTermsA);
+        }
+    }
+
+    private void compareSubTerms(String message, IStrategoTerm expected, IStrategoTerm actual,
+        IStrategoTerm[] subTermsE, IStrategoTerm[] subTermsA) {
+        if(subTermsA.length != subTermsE.length)
+            fail(message + "\nExpected: " + expected + "\n  Actual: " + actual);
+        for(int i = 0; i < subTermsA.length; i++) {
+            assertEqualAST(message, expected, actual, subTermsE[i], subTermsA[i]);
+        }
+    }
+
+    private void compareAttachments(String message, IStrategoTerm e, IStrategoTerm a) {
+        if(!Objects.equals(e.getAnnotations(), a.getAnnotations()))
+            fail(message + "\nExpected annotations: " + e.getAnnotations() + "\n  Actual annotations: "
+                + a.getAnnotations() + "\n On tree: " + a);
+
+        ImploderAttachment expectedAttachment = e.getAttachment(ImploderAttachment.TYPE);
+        ImploderAttachment actualAttachment = a.getAttachment(ImploderAttachment.TYPE);
+        if(!equalAttachment(expectedAttachment, actualAttachment)) {
+            fail(message + "\nExpected attachment: " + expectedAttachment + " "
+                + (expectedAttachment == null ? "null"
+                    : printToken(expectedAttachment.getLeftToken()) + " - "
+                        + printToken(expectedAttachment.getRightToken()))
+                + "\n  Actual attachment: " + actualAttachment + " "
+                + (actualAttachment == null ? "null" : printToken(actualAttachment.getLeftToken()) + " - "
+                    + printToken(actualAttachment.getRightToken()))
+                + "\nOn tree: " + a);
+        }
+    }
+
+    private String printToken(IToken token) {
+        if(token == null)
+            return "null";
+        return "<" + token.toString() + ";" + token.getKind() + ";o:" + token.getStartOffset() + " l:" + token.getLine()
+            + " c:" + token.getColumn() + ";o:" + token.getEndOffset() + " l:" + token.getEndLine() + " c:"
+            + token.getEndColumn() + ">";
+    }
+
+    private boolean equalAttachment(ImploderAttachment expectedAttachment, ImploderAttachment actualAttachment) {
+        if(expectedAttachment == null)
+            return actualAttachment == null;
+        if(actualAttachment == null)
+            return false;
+        IToken expectedLeft = expectedAttachment.getLeftToken();
+        IToken expectedRight = expectedAttachment.getRightToken();
+        IToken actualLeft = actualAttachment.getLeftToken();
+        IToken actualRight = actualAttachment.getRightToken();
+        return Objects.equals(expectedAttachment.getSort(), actualAttachment.getSort())
+            && expectedLeft.getKind() == actualLeft.getKind() && expectedRight.getKind() == actualRight.getKind()
+            && expectedLeft.getStartOffset() == actualLeft.getStartOffset()
+            && expectedRight.getStartOffset() == actualRight.getStartOffset()
+            && expectedLeft.getEndOffset() == actualLeft.getEndOffset()
+            && expectedRight.getEndOffset() == actualRight.getEndOffset()
+            && expectedLeft.getLine() == actualLeft.getLine() && expectedRight.getLine() == actualRight.getLine()
+            && expectedLeft.getEndLine() == actualLeft.getEndLine()
+            && expectedRight.getEndLine() == actualRight.getEndLine()
+            && expectedLeft.getColumn() == actualLeft.getColumn()
+            && expectedRight.getColumn() == actualRight.getColumn()
+            && expectedLeft.getEndColumn() == actualLeft.getEndColumn()
+            && expectedRight.getEndColumn() == actualRight.getEndColumn();
     }
 
     protected void assertEqualAST(String message, String expectedOutputAstString, IStrategoTerm actualOutputAst,

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/TokenDescriptor.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/TokenDescriptor.java
@@ -1,10 +1,11 @@
 package org.spoofax.jsglr2.integrationtest;
 
+import static org.spoofax.terms.util.TermUtils.*;
+
 import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import org.spoofax.interpreter.terms.IStrategoAppl;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
@@ -37,8 +38,8 @@ public final class TokenDescriptor {
 
         IStrategoTerm astNode = (IStrategoTerm) token.getAstNode();
         String sort = astNode == null ? null : ImploderAttachment.get(astNode).getSort();
-        String cons = astNode == null ? null
-            : astNode.getTermType() == IStrategoTerm.APPL ? ((IStrategoAppl) astNode).getConstructor().getName() : null;
+        String cons =
+            astNode == null ? null : isAppl(astNode) ? toAppl(astNode).getName() : isList(astNode) ? "[]" : null;
         return new TokenDescriptor(inputPart, token.getKind(), token.getStartOffset(), token.getLine(),
             token.getColumn(), sort, cons);
     }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/disambiguation/EmptyListAmbiguousTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/disambiguation/EmptyListAmbiguousTest.java
@@ -1,0 +1,24 @@
+package org.spoofax.jsglr2.integrationtest.disambiguation;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.spoofax.jsglr2.integrationtest.BaseTestWithSdf3ParseTables;
+import org.spoofax.terms.ParseError;
+
+public class EmptyListAmbiguousTest extends BaseTestWithSdf3ParseTables {
+
+    public EmptyListAmbiguousTest() {
+        super("empty-list-ambiguous.sdf3");
+    }
+
+    @TestFactory public Stream<DynamicTest> emptyList() throws ParseError {
+        return testSuccessByExpansions("[]", "List(amb([[Empty()],[]]))");
+    }
+
+    @TestFactory public Stream<DynamicTest> oneElement() throws ParseError {
+        return testSuccessByExpansions("[x]", "List([Term()])");
+    }
+
+}

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/EmojiTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/EmojiTest.java
@@ -51,9 +51,20 @@ public class EmojiTest extends BaseTestWithSdf3ParseTables {
                 new TokenDescriptor("😄", IToken.TK_IDENTIFIER, 5, 1, 5, "ID", null)));
     }
 
+    @TestFactory public Stream<DynamicTest> tokenizationTestMultilineWithEmpty() throws ParseError {
+        return testTokens("😇 \n\n 😄",
+            Arrays.asList(new TokenDescriptor("😇", IToken.TK_IDENTIFIER, 0, 1, 1, "ID", null),
+                new TokenDescriptor(" ", IToken.TK_LAYOUT, 2, 1, 2, null, "[]"),
+                new TokenDescriptor("\n", IToken.TK_KEYWORD, 3, 1, 3, null, "[]"),
+                new TokenDescriptor("", IToken.TK_NO_TOKEN_KIND, 4, 2, 1, "Exp", "Empty"),
+                new TokenDescriptor("\n", IToken.TK_KEYWORD, 4, 2, 1, null, "[]"),
+                new TokenDescriptor(" ", IToken.TK_LAYOUT, 5, 3, 1, null, "[]"),
+                new TokenDescriptor("😄", IToken.TK_IDENTIFIER, 6, 3, 2, "ID", null)));
+    }
+
     @TestFactory public Stream<DynamicTest> testEmojiIncremental() throws ParseError {
         return testIncrementalSuccessByExpansions(new String[] { "😇 ➕ 😄😄", "😇😇  ➕ 😄" },
-                new String[] { "[Add(Var(\"😇\"),\"➕\",Var(\"😄😄\"))]", "[Add(Var(\"😇😇\"),\"➕\",Var(\"😄\"))]" });
+            new String[] { "[Add(Var(\"😇\"),\"➕\",Var(\"😄😄\"))]", "[Add(Var(\"😇😇\"),\"➕\",Var(\"😄\"))]" });
     }
 
 }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/OptionalsTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/OptionalsTest.java
@@ -1,10 +1,13 @@
 package org.spoofax.jsglr2.integrationtest.features;
 
+import java.util.Collections;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
+import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr2.integrationtest.BaseTestWithSdf3ParseTables;
+import org.spoofax.jsglr2.integrationtest.TokenDescriptor;
 import org.spoofax.terms.ParseError;
 
 public class OptionalsTest extends BaseTestWithSdf3ParseTables {
@@ -15,6 +18,11 @@ public class OptionalsTest extends BaseTestWithSdf3ParseTables {
 
     @TestFactory public Stream<DynamicTest> testEmpty() throws ParseError {
         return testSuccessByExpansions("", "None");
+    }
+
+    @TestFactory public Stream<DynamicTest> testEmptyToken() throws ParseError {
+        return testTokens("",
+            Collections.singletonList(new TokenDescriptor("", IToken.TK_NO_TOKEN_KIND, 0, 1, 1, null, "None")));
     }
 
     @TestFactory public Stream<DynamicTest> testSingleX() throws ParseError {

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/TokenizationTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/TokenizationTest.java
@@ -57,13 +57,13 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     @TestFactory public Stream<DynamicTest> operatorWithLayout2() throws ParseError {
         return testTokens(" x + x ", Arrays.asList(
         //@formatter:off
-            new TokenDescriptor(" ", IToken.TK_LAYOUT,     0, 1, 1, null, null),
+            new TokenDescriptor(" ", IToken.TK_LAYOUT,     0, 1, 1, null, "[]"),
             new TokenDescriptor("x", IToken.TK_IDENTIFIER, 1, 1, 2, "ID", null),
             new TokenDescriptor(" ", IToken.TK_LAYOUT,     2, 1, 3, "Exp", "AddOperator"),
             new TokenDescriptor("+", IToken.TK_OPERATOR,   3, 1, 4, "Exp", "AddOperator"),
             new TokenDescriptor(" ", IToken.TK_LAYOUT,     4, 1, 5, "Exp", "AddOperator"),
             new TokenDescriptor("x", IToken.TK_IDENTIFIER, 5, 1, 6, "ID", null),
-            new TokenDescriptor(" ", IToken.TK_LAYOUT,     6, 1, 7, null, null)
+            new TokenDescriptor(" ", IToken.TK_LAYOUT,     6, 1, 7, null, "[]")
         //@formatter:on
         ));
     }
@@ -93,10 +93,11 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
     }
 
     @TestFactory public Stream<DynamicTest> emptyList() throws ParseError {
-        return testTokens("[]", Arrays.asList(
+        return testTokens("[]", Arrays.asList( // The AST of this input is "[List([])]"
         //@formatter:off
-            new TokenDescriptor("[", IToken.TK_OPERATOR, 0, 1, 1, "List", "List"),
-            new TokenDescriptor("]", IToken.TK_OPERATOR, 1, 1, 2, "List", "List")
+            new TokenDescriptor("[", IToken.TK_OPERATOR,      0, 1, 1, "List", "List"),
+            new TokenDescriptor("",  IToken.TK_NO_TOKEN_KIND, 1, 1, 2, null, "[]"), // belonging to AST "[]"
+            new TokenDescriptor("]", IToken.TK_OPERATOR,      1, 1, 2, "List", "List")
         //@formatter:on
         ));
     }
@@ -116,9 +117,9 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
         //@formatter:off
             new TokenDescriptor("[", IToken.TK_OPERATOR,    0, 1, 1, "List", "List"),
             new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 1, 1, 2, "ID", null),
-            new TokenDescriptor(",", IToken.TK_OPERATOR,    2, 1, 3, null, null),
+            new TokenDescriptor(",", IToken.TK_OPERATOR,    2, 1, 3, null, "[]"),
             new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 3, 1, 4, "ID", null),
-            new TokenDescriptor(",", IToken.TK_OPERATOR,    4, 1, 5, null, null),
+            new TokenDescriptor(",", IToken.TK_OPERATOR,    4, 1, 5, null, "[]"),
             new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 5, 1, 6, "ID", null),
             new TokenDescriptor("]", IToken.TK_OPERATOR,    6, 1, 7, "List", "List")
         //@formatter:on
@@ -129,8 +130,8 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
         return testTokens("x;\nx", Arrays.asList(
         //@formatter:off
             new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 0, 1, 1, "ID", null),
-            new TokenDescriptor(";",  IToken.TK_OPERATOR,   1, 1, 2, null, null),
-            new TokenDescriptor("\n", IToken.TK_LAYOUT,     2, 1, 3, null, null),
+            new TokenDescriptor(";",  IToken.TK_OPERATOR,   1, 1, 2, null, "[]"),
+            new TokenDescriptor("\n", IToken.TK_LAYOUT,     2, 1, 3, null, "[]"),
             new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 3, 2, 1, "ID", null)
         //@formatter:on
         ));
@@ -140,10 +141,10 @@ public class TokenizationTest extends BaseTestWithSdf3ParseTables {
         return testTokens("x;\nx\n", Arrays.asList(
         //@formatter:off
             new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 0, 1, 1, "ID", null),
-            new TokenDescriptor(";",  IToken.TK_OPERATOR,   1, 1, 2, null, null),
-            new TokenDescriptor("\n", IToken.TK_LAYOUT,     2, 1, 3, null, null),
+            new TokenDescriptor(";",  IToken.TK_OPERATOR,   1, 1, 2, null, "[]"),
+            new TokenDescriptor("\n", IToken.TK_LAYOUT,     2, 1, 3, null, "[]"),
             new TokenDescriptor("x",  IToken.TK_IDENTIFIER, 3, 2, 1, "ID", null),
-            new TokenDescriptor("\n", IToken.TK_LAYOUT,     4, 2, 2, null, null)
+            new TokenDescriptor("\n", IToken.TK_LAYOUT,     4, 2, 2, null, "[]")
         //@formatter:on
         ));
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/AbstractTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/AbstractTreeImploder.java
@@ -27,12 +27,15 @@ public abstract class AbstractTreeImploder
         List<List<ParseForest>> alternatives = new ArrayList<>();
 
         for(Derivation derivation : derivations) {
-            if(derivation.parseForests().length == 1) {
-                alternatives.add(Arrays.asList(derivation.parseForests()[0]));
+            ParseForest[] children = derivation.parseForests();
+            if(children.length == 0) {
+                alternatives.add(Collections.emptyList());
+            } else if(children.length == 1) {
+                alternatives.add(Collections.singletonList(children[0]));
             } else {
-                List<ParseForest> subTrees = Arrays.asList(derivation.parseForests());
+                List<ParseForest> subTrees = Arrays.asList(children);
 
-                ParseNode head = (ParseNode) subTrees.get(0);
+                ParseNode head = (ParseNode) children[0];
 
                 if(head.production().isList() && head.getPreferredAvoidedDerivations().size() > 1) {
                     List<ParseForest> tail = subTrees.subList(1, subTrees.size());

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
@@ -14,25 +14,20 @@ public abstract class IterativeTreeTokenizer<Tree> extends TreeTokenizer<Tree> {
         tokens.makeStartToken();
         tokenTreeBinding(tokens.startToken(), rootTree.tree);
 
-        IToken lastToken = tokens.startToken();
-
         Stack<LinkedList<TreeImploder.SubTree<Tree>>> inputStack = new Stack<>();
         Stack<Position> pivotPositionStack = new Stack<>();
         Stack<Position> startPositionStack = new Stack<>();
-        Stack<IToken> parentLeftTokenStack = new Stack<>();
         Stack<LinkedList<SubTree>> outputStack = new Stack<>();
 
         inputStack.add(new LinkedList<>(Collections.singletonList(rootTree)));
         pivotPositionStack.add(Position.START_POSITION);
         startPositionStack.add(Position.START_POSITION);
-        parentLeftTokenStack.add(tokens.startToken());
         outputStack.add(new LinkedList<>());
 
         while(true) {
             LinkedList<TreeImploder.SubTree<Tree>> currentIn = inputStack.peek();
             Position currentPos = pivotPositionStack.peek();
             Position currentStart = startPositionStack.peek();
-            IToken currentParentLeftToken = parentLeftTokenStack.peek();
             LinkedList<SubTree> currentOut = outputStack.peek();
             if(currentIn.isEmpty()) { // If we're finished with the current children
                 inputStack.pop(); // That means it's done, so remove it from the stack
@@ -40,13 +35,12 @@ public abstract class IterativeTreeTokenizer<Tree> extends TreeTokenizer<Tree> {
                     break;
                 pivotPositionStack.pop(); // Also remove `currentPos` from stack
                 startPositionStack.pop(); // Also remove `currentStart` from stack
-                parentLeftTokenStack.pop(); // Also remove `currentParentLeftToken` from stack
                 outputStack.pop(); // Also remove `currentOut` from stack
 
                 // Process current output in the way we're used to
                 TreeImploder.SubTree<Tree> tree = inputStack.peek().removeFirst();
                 IToken leftToken = null;
-                IToken pivotToken = currentParentLeftToken;
+                IToken rightToken = null;
                 Position pivotPosition = currentPos;
                 for(SubTree subTree : currentOut) {
                     // If child tree had tokens that were not yet bound, bind them
@@ -64,31 +58,36 @@ public abstract class IterativeTreeTokenizer<Tree> extends TreeTokenizer<Tree> {
 
                     // The right-most token of this tree is the last non-null rightToken of a subTree
                     if(subTree.rightToken != null)
-                        pivotToken = subTree.rightToken;
+                        rightToken = subTree.rightToken;
 
                     pivotPosition = subTree.endPosition;
                 }
 
-                if(leftToken == null)
-                    leftToken = currentParentLeftToken;
+                // If is no token, this means that this AST has no characters in the input.
+                // In this case, create an empty token to associate with this AST node.
+                if(leftToken == null) {
+                    assert rightToken == null;
+                    leftToken = rightToken = tokens.makeToken(currentStart, pivotPosition, tree.production);
+                    tokenTreeBinding(leftToken, tree.tree);
+                }
 
                 // In the case when we're dealing with an ambiguous tree node, position is not advanced
-                //noinspection ConstantConditions (peek can never return `null`, as we check size > 1)
+                // noinspection ConstantConditions (peek can never return `null`, as we check size > 1)
                 if(inputStack.size() > 1 && !inputStack.get(inputStack.size() - 2).peek().isAmbiguous) {
                     pivotPositionStack.pop();
                     pivotPositionStack.push(pivotPosition);
                 }
                 // Add processed output to the list that is on top of the stack
-                outputStack.peek().add(new SubTree(tree, leftToken, pivotToken, pivotPosition));
+                outputStack.peek().add(new SubTree(tree, leftToken, rightToken, pivotPosition));
             } else {
                 TreeImploder.SubTree<Tree> tree = currentIn.getFirst(); // Process the next input
                 if(tree.production != null && !tree.production.isContextFree() || tree.isCharacterTerminal) {
                     if(tree.width > 0) {
                         Position endPosition = currentPos.step(tokens.getInput(), tree.width);
-                        lastToken = tokens.makeToken(currentPos, endPosition, tree.production);
-                        tokenTreeBinding(lastToken, tree.tree);
+                        IToken token = tokens.makeToken(currentPos, endPosition, tree.production);
+                        tokenTreeBinding(token, tree.tree);
 
-                        currentOut.add(new SubTree(tree, lastToken, lastToken, endPosition));
+                        currentOut.add(new SubTree(tree, token, token, endPosition));
                         pivotPositionStack.pop();
                         pivotPositionStack.push(endPosition);
                     } else
@@ -98,7 +97,6 @@ public abstract class IterativeTreeTokenizer<Tree> extends TreeTokenizer<Tree> {
                     inputStack.add(new LinkedList<>(tree.children));
                     pivotPositionStack.add(currentPos);
                     startPositionStack.add(currentPos);
-                    parentLeftTokenStack.add(lastToken);
                     outputStack.add(new LinkedList<>());
                 }
             }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
@@ -63,7 +63,7 @@ public abstract class IterativeTreeTokenizer<Tree> extends TreeTokenizer<Tree> {
                     pivotPosition = subTree.endPosition;
                 }
 
-                // If is no token, this means that this AST has no characters in the input.
+                // If there is no token, this means that this AST has no characters in the input.
                 // In this case, create an empty token to associate with this AST node.
                 if(leftToken == null) {
                     assert rightToken == null;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
@@ -18,7 +18,9 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
             this.leftToken = leftToken;
             this.rightToken = rightToken;
             this.endPosition = endPosition;
-            if(tree.tree != null && leftToken != null && rightToken != null) {
+            assert leftToken != null ^ rightToken == null : "Both tokens should be either null, or not null";
+            if(tree.tree != null) {
+                assert leftToken != null && rightToken != null : "All AST nodes should have tokens, even if it's empty";
                 if(tree.isInjection) {
                     configureInjection(tree.production.lhs(), tree.tree, tree.production.isBracket());
                 } else {
@@ -43,14 +45,13 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
         tokens.makeStartToken();
         tokenTreeBinding(tokens.startToken(), tree.tree);
 
-        SubTree res = tokenizeInternal(tokens, tree, Position.START_POSITION, tokens.startToken());
+        SubTree res = tokenizeInternal(tokens, tree, Position.START_POSITION);
 
         tokens.makeEndToken(res.endPosition);
         tokenTreeBinding(tokens.endToken(), res.tree);
     }
 
-    private SubTree tokenizeInternal(Tokens tokens, TreeImploder.SubTree<Tree> tree, Position startPosition,
-        IToken parentLeftToken) {
+    private SubTree tokenizeInternal(Tokens tokens, TreeImploder.SubTree<Tree> tree, Position startPosition) {
         if(tree.production != null && !tree.production.isContextFree() || tree.isCharacterTerminal) {
             if(tree.width > 0) {
                 Position endPosition = startPosition.step(tokens.getInput(), tree.width);
@@ -62,14 +63,14 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
                 return new SubTree(tree, null, null, startPosition);
         } else {
             IToken leftToken = null;
-            IToken pivotToken = parentLeftToken;
+            IToken rightToken = null;
             Position pivotPosition = startPosition;
             for(TreeImploder.SubTree<Tree> child : tree.children) {
                 // In the case when we're dealing with an ambiguous tree node, position is not advanced
                 if(tree.isAmbiguous)
                     pivotPosition = startPosition;
 
-                SubTree subTree = tokenizeInternal(tokens, child, pivotPosition, pivotToken);
+                SubTree subTree = tokenizeInternal(tokens, child, pivotPosition);
 
                 // If child tree had tokens that were not yet bound, bind them
                 if(subTree.tree == null) {
@@ -86,15 +87,20 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
 
                 // The right-most token of this tree is the last non-null rightToken of a subTree
                 if(subTree.rightToken != null)
-                    pivotToken = subTree.rightToken;
+                    rightToken = subTree.rightToken;
 
                 pivotPosition = subTree.endPosition;
             }
 
-            if(leftToken == null)
-                leftToken = parentLeftToken;
+            // If is no token, this means that this AST has no characters in the input.
+            // In this case, create an empty token to associate with this AST node.
+            if(leftToken == null) {
+                assert rightToken == null;
+                leftToken = rightToken = tokens.makeToken(startPosition, pivotPosition, tree.production);
+                tokenTreeBinding(leftToken, tree.tree);
+            }
 
-            return new SubTree(tree, leftToken, pivotToken, pivotPosition);
+            return new SubTree(tree, leftToken, rightToken, pivotPosition);
         }
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
@@ -92,7 +92,7 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
                 pivotPosition = subTree.endPosition;
             }
 
-            // If is no token, this means that this AST has no characters in the input.
+            // If there is no token, this means that this AST has no characters in the input.
             // In this case, create an empty token to associate with this AST node.
             if(leftToken == null) {
                 assert rightToken == null;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/Tokens.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/Tokens.java
@@ -53,7 +53,9 @@ public class Tokens implements IParseTokens {
     public IToken makeToken(Position startPosition, Position endPosition, IProduction production) {
         int tokenKind;
 
-        if(production == null) {
+        if(startPosition.equals(endPosition)) {
+            tokenKind = IToken.TK_NO_TOKEN_KIND;
+        } else if(production == null) {
             tokenKind = IToken.TK_STRING; // indicates a character/int terminal, e.g. 'x'
         } else if(production.isLayout()) {
             tokenKind = IToken.TK_LAYOUT;


### PR DESCRIPTION
The tokenizers will now create empty (i.e. start offset == end ofset) tokens for AST nodes that have no corresponding region in the input string, instead of (ab)using the `parentLeftToken` for this. This causes the token stream to contain empty tokens, which can be safely ignored. Since these empty tokens have kind `TK_NO_TOKEN_KIND`, they are already ignored the `CategorizerService` that facilitates syntax highlighting. Also, error messages displayed on these empty tokens seem to work out:
<details>
<summary>Warning displayed on a `None` AST node that has no corresponding region in the input</summary>

![image](https://user-images.githubusercontent.com/9739541/81943548-d0c32000-95fb-11ea-817f-a02cb936d783.png)
</details>

To make sure that all tokenizer variants produce the same imploder attachments and tokens, I've extended `BaseTest.testSuccess` with a check that walks over the entire AST to compare the imploder attachments. All variants are compared to the first variant.

Miscellaneous other fixes:
- `IToken.getEndColumn()` would throw an `IndexOutOfBoundsException` for invalid tokens or a `NullPointerException` if either `tokens` or `tokens.getInput()` was `null`. This was triggered in some other projects in the full build (e.g. `org.metaborg.lang.coq`), that's why I didn't find out earlier because I only ran the integration tests. [This fix](https://github.com/metaborg/jsglr/commit/3ecbe5f712561bda006651fda2eed8adc31bbe8b) double-checks whether calling `codePointCount` could cause any problems. In the case of problems, we revert to the old behaviour of returning `column + getEndOffset() - getStartOffset()`.
- The tokenization tests would always assume that the start/end token would have constructor `null`, but this was only the case when the root node was a list. I made two changes because of this:
  - The constructor of the start/end token is fetched from the AST before creating their `TokenDescriptor`s, instead of blindly using `null`.
  - The "constructor" of a `TokenDescriptor` will be set to `"[]"` when the associated AST node is a list.
- **EDIT**: [Fix `IndexOutOfBounds` when imploding an empty ambiguous list](https://github.com/metaborg/jsglr/pull/77/commits/34d981acad13e7171b6b32affdea1afc76915609). I figured out this was broken while trying to test all this in Eclipse, so I added a test case for this :slightly_smiling_face: 