### PR TITLE
Allow 0-width tokens on lexical AST nodes

### DIFF
--- a/org.spoofax.jsglr2.integration/src/main/resources/grammars/kernel-string.sdf3
+++ b/org.spoofax.jsglr2.integration/src/main/resources/grammars/kernel-string.sdf3
@@ -1,0 +1,11 @@
+module kernel-string
+
+context-free start-symbols
+	Start
+
+context-free syntax
+    Start = {String "\n"}+
+
+syntax
+    String-CF.String = "\"" InnerString-LEX "\""
+    InnerString-LEX = ~[\"]*

--- a/org.spoofax.jsglr2.integration/src/main/resources/grammars/kernel-syntax.sdf3
+++ b/org.spoofax.jsglr2.integration/src/main/resources/grammars/kernel-syntax.sdf3
@@ -1,0 +1,8 @@
+module kernel-syntax
+
+start-symbols
+	Exp
+
+syntax
+	Exp.Add = Exp "+" Exp {left}
+	Exp.Id = [a-z]

--- a/org.spoofax.jsglr2.integration/src/main/resources/grammars/sdf-syntax.sdf3
+++ b/org.spoofax.jsglr2.integration/src/main/resources/grammars/sdf-syntax.sdf3
@@ -1,8 +1,0 @@
-module sdf-syntax
-
-start-symbols
-	Exp
-
-syntax
-	Exp.Add = Exp [\+] Exp {left}
-	Exp.Id = [a-z]

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/KernelStringTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/KernelStringTest.java
@@ -1,0 +1,49 @@
+package org.spoofax.jsglr2.integrationtest.features;
+
+import static org.spoofax.jsglr.client.imploder.IToken.Kind.TK_NO_TOKEN_KIND;
+import static org.spoofax.jsglr.client.imploder.IToken.Kind.TK_OPERATOR;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.spoofax.jsglr2.integrationtest.BaseTestWithSdf3ParseTables;
+import org.spoofax.jsglr2.integrationtest.TokenDescriptor;
+import org.spoofax.terms.ParseError;
+
+public class KernelStringTest extends BaseTestWithSdf3ParseTables {
+
+    public KernelStringTest() {
+        super("kernel-string.sdf3");
+    }
+
+    @TestFactory public Stream<DynamicTest> emptyString() throws ParseError {
+        return testSuccessByExpansions("\"\"", "[String(\"\")]");
+    }
+
+    @TestFactory public Stream<DynamicTest> nonEmptyString() throws ParseError {
+        return testSuccessByExpansions("\"Hello World!\"", "[String(\"Hello World!\")]");
+    }
+
+    @TestFactory public Stream<DynamicTest> emptyAndNonEmptyStrings() throws ParseError {
+        return testSuccessByExpansions("\"\"\n\"Hello World!\"", "[String(\"\"),String(\"Hello World!\")]");
+    }
+
+    @TestFactory public Stream<DynamicTest> emptyStringTokens() throws ParseError {
+        return testTokens("\"\"", Arrays.asList(
+        //@formatter:off
+            new TokenDescriptor("\"", TK_OPERATOR,      0, 1, 1, "String", "String"),
+            new TokenDescriptor("\"", TK_OPERATOR,      1, 1, 2, "String", "String")
+        //@formatter:on
+        ), Arrays.asList(
+        //@formatter:off
+            new TokenDescriptor("\"", TK_OPERATOR,      0, 1, 1, "String", "String"),
+            new TokenDescriptor("",   TK_NO_TOKEN_KIND, 1, 1, 2, "InnerString", null),
+            new TokenDescriptor("\"", TK_OPERATOR,      1, 1, 2, "String", "String")
+        //@formatter:on
+        ));
+    }
+
+
+}

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/KernelSyntaxTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/KernelSyntaxTest.java
@@ -7,14 +7,18 @@ import org.junit.jupiter.api.TestFactory;
 import org.spoofax.jsglr2.integrationtest.BaseTestWithSdf3ParseTables;
 import org.spoofax.terms.ParseError;
 
-public class SdfSyntaxTest extends BaseTestWithSdf3ParseTables {
+public class KernelSyntaxTest extends BaseTestWithSdf3ParseTables {
 
-    public SdfSyntaxTest() {
-        super("sdf-syntax.sdf3");
+    public KernelSyntaxTest() {
+        super("kernel-syntax.sdf3");
     }
 
     @TestFactory public Stream<DynamicTest> identifier() throws ParseError {
         return testSuccessByExpansions("x", "\"x\"");
+    }
+
+    @TestFactory public Stream<DynamicTest> addition() throws ParseError {
+        return testSuccessByExpansions("x+x", "Add(\"x\",\"x\")");
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/IterativeTreeTokenizer.java
@@ -82,7 +82,7 @@ public abstract class IterativeTreeTokenizer<Tree> extends TreeTokenizer<Tree> {
             } else {
                 TreeImploder.SubTree<Tree> tree = currentIn.getFirst(); // Process the next input
                 if(tree.production != null && !tree.production.isContextFree() || tree.isCharacterTerminal) {
-                    if(tree.width > 0) {
+                    if(tree.width > 0 || tree.tree != null) {
                         Position endPosition = currentPos.step(tokens.getInput(), tree.width);
                         IToken token = tokens.makeToken(currentPos, endPosition, tree.production);
                         tokenTreeBinding(token, tree.tree);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizedTreeImploder.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TokenizedTreeImploder.java
@@ -118,7 +118,8 @@ public abstract class TokenizedTreeImploder
 
             Position endPosition = startPosition.step(tokens.getInput(), width);
 
-            IToken token = width > 0 ? tokens.makeToken(startPosition, endPosition, production) : null;
+            IToken token =
+                width > 0 || production.isLexical() ? tokens.makeToken(startPosition, endPosition, production) : null;
 
             Tree tree;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/imploder/TreeTokenizer.java
@@ -30,7 +30,6 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
                 }
             }
         }
-
     }
 
     @Override public TokenizeResult<ITokens> tokenize(JSGLR2Request request,
@@ -54,7 +53,7 @@ public abstract class TreeTokenizer<Tree> implements ITokenizer<TreeImploder.Sub
 
     private SubTree tokenizeInternal(Tokens tokens, TreeImploder.SubTree<Tree> tree, Position startPosition) {
         if(tree.production != null && !tree.production.isContextFree() || tree.isCharacterTerminal) {
-            if(tree.width > 0) {
+            if(tree.width > 0 || tree.tree != null) {
                 Position endPosition = startPosition.step(tokens.getInput(), tree.width);
                 IToken token = tokens.makeToken(startPosition, endPosition, tree.production);
                 tokenTreeBinding(token, tree.tree);

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/treeshaped/AbstractTreeShapedTokenizer.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/tokens/treeshaped/AbstractTreeShapedTokenizer.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.tokens.treeshaped;
 
 import static org.spoofax.jsglr.client.imploder.IToken.Kind.TK_NO_TOKEN_KIND;
+import static org.spoofax.jsglr2.tokens.treeshaped.TreeTokens.EMPTY_RANGE;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,7 +45,8 @@ public abstract class AbstractTreeShapedTokenizer<TokensResult extends TreeToken
                 return new TokenTree(tree,
                     new TreeToken(tokens, positionRange, IToken.getTokenKind(tree.production), tree.tree));
             } else
-                return new TokenTree(tree, null);
+                return new TokenTree(tree,
+                    tree.tree == null ? null : new TreeToken(tokens, EMPTY_RANGE, TK_NO_TOKEN_KIND, tree.tree));
         } else {
             List<TokenTree> children = new ArrayList<>(tree.children.size());
             TreeToken leftToken = null;
@@ -79,11 +81,11 @@ public abstract class AbstractTreeShapedTokenizer<TokensResult extends TreeToken
             // In this case, create an empty token to associate with this AST node.
             if(leftToken == null) {
                 assert rightToken == null;
-                return new TokenTree(tree, new TreeToken(tokens, TreeTokens.EMPTY_RANGE, TK_NO_TOKEN_KIND, tree.tree));
+                return new TokenTree(tree, new TreeToken(tokens, EMPTY_RANGE, TK_NO_TOKEN_KIND, tree.tree));
             }
 
-            Position positionRange = tree.isAmbiguous ? children.get(0).positionRange : children.stream()
-                .map(child -> child.positionRange).reduce(TreeTokens.EMPTY_RANGE, TreeTokens::addPosition);
+            Position positionRange = tree.isAmbiguous ? children.get(0).positionRange
+                : children.stream().map(child -> child.positionRange).reduce(EMPTY_RANGE, TreeTokens::addPosition);
             TokenTree res = new TokenTree(tree, children, leftToken, rightToken, positionRange);
             for(TokenTree child : children) {
                 child.parent = res;


### PR DESCRIPTION
Figured out that this was broken while I was writing down the tokenization algorithm in my thesis report. I realized that it was silly that empty (i.e. `tree.width == 0`), non-context-free parse nodes would always result in `null` tokens. After all, empty tokens are considered supported since #77, and I could come up with a scenario where an empty token would be required for lexical parse node.

I created a test with this scenario, see `KernelStringTest.java` and `kernel-string.sdf3`. Basically, the Stratego term `""` requires a token, and the most logical thing to do in this case is to create an empty token, just like we did for empty lists in #77. Note that the tokens for the quotation marks (before and after the empty token) are already attached to the context-free `String(...)` AST node, so the term `""` really only corresponds to the lexical production.

The fix is applied differently for the different Tokenizer variants, but should make sense (and let me know if it doesn't) :slightly_smiling_face: 