### PR TITLE
Errors for non-assoc by storing extra data in parse table

### DIFF
--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/ParseTable.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/ParseTable.java
@@ -125,8 +125,8 @@ public class ParseTable implements Serializable {
         }
 
         if(ptGenerator != null) {
-            nonAssocPriorities.putAll(ptGenerator.getNonAssocPriorities());
-            nonNestedPriorities.putAll(ptGenerator.getNonNestedPriorities());
+            nonAssocPriorities.putAll(ptGenerator.getNonAssocProductions());
+            nonNestedPriorities.putAll(ptGenerator.getNonNestedProductions());
         }
 
         if(dynamicPTgeneration && persistedTable != null) {
@@ -158,8 +158,8 @@ public class ParseTable implements Serializable {
         }
 
         if(ptGenerator != null) {
-            nonAssocPriorities.putAll(ptGenerator.getNonAssocPriorities());
-            nonNestedPriorities.putAll(ptGenerator.getNonNestedPriorities());
+            nonAssocPriorities.putAll(ptGenerator.getNonAssocProductions());
+            nonNestedPriorities.putAll(ptGenerator.getNonNestedProductions());
         }
 
         parse(parseTableAterm);

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/ProductionAttributes.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/ProductionAttributes.java
@@ -30,7 +30,6 @@ public class ProductionAttributes implements Serializable {
     private final IStrategoTerm layoutConstraint;
     private final boolean isNewlineEnforced;
     private final boolean isLongestMatch;
-    // TODO add nonAssocWith here somewhere
 
 
     private final transient IStrategoTerm abstractCtor;
@@ -61,15 +60,15 @@ public class ProductionAttributes implements Serializable {
     public boolean isRecoverProduction() {
         return isRecover;
     }
-    
+
     public boolean isIgnoreLayout() {
       return isIgnoreLayout;
     }
-    
+
     public IStrategoTerm getLayoutConstraint() {
       return layoutConstraint;
     }
-    
+
     public boolean isNewlineEnforced() {
       return isNewlineEnforced;
     }
@@ -77,11 +76,11 @@ public class ProductionAttributes implements Serializable {
     public boolean isCompletionProduction() {
         return isCompletion;
     }
-    
+
     public boolean isPlaceholderInsertionProduction() {
         return isPlaceholderInsertion;
     }
-    
+
 
     public boolean isMoreEager(ProductionAttributes other) {
         return type != other.type && (type == PREFER || other.type == AVOID);

--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/ProductionAttributes.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/ProductionAttributes.java
@@ -30,6 +30,7 @@ public class ProductionAttributes implements Serializable {
     private final IStrategoTerm layoutConstraint;
     private final boolean isNewlineEnforced;
     private final boolean isLongestMatch;
+    // TODO add nonAssocWith here somewhere
 
 
     private final transient IStrategoTerm abstractCtor;

--- a/org.spoofax.jsglr2.integration/src/main/resources/grammars/expressions-non-assoc.sdf3
+++ b/org.spoofax.jsglr2.integration/src/main/resources/grammars/expressions-non-assoc.sdf3
@@ -1,0 +1,20 @@
+module expressions
+
+context-free start-symbols
+	Exp
+
+context-free syntax
+	Exp.Var = ID
+	Exp.Add = <<Exp> + <Exp>> {left}
+	Exp.Eq = <<Exp> == <Exp>> {non-assoc}
+	Exp.Gt = [[Exp] > [Exp]] {non-nested}
+
+lexical syntax
+	ID      = [a-zA-Z]+
+	LAYOUT  = [\ \n]
+
+lexical restrictions
+	ID      -/- [a-zA-Z]
+
+context-free restrictions
+	LAYOUT? -/- [\ \n]

--- a/org.spoofax.jsglr2.integration/src/main/resources/grammars/expressions-non-assoc.sdf3
+++ b/org.spoofax.jsglr2.integration/src/main/resources/grammars/expressions-non-assoc.sdf3
@@ -1,20 +1,20 @@
 module expressions
 
 context-free start-symbols
-	Exp
+    Exp
 
 context-free syntax
-	Exp.Var = ID
-	Exp.Add = <<Exp> + <Exp>> {left}
-	Exp.Eq = <<Exp> == <Exp>> {non-assoc}
-	Exp.Gt = [[Exp] > [Exp]] {non-nested}
+    Exp.Var = ID
+    Exp.Add = <<Exp> + <Exp>> {left}
+    Exp.Eq = <<Exp> == <Exp>> {non-assoc}
+    Exp.Gt = [[Exp] > [Exp]] {non-nested}
 
 lexical syntax
-	ID      = [a-zA-Z]+
-	LAYOUT  = [\ \n]
+    ID      = [a-zA-Z]+
+    LAYOUT  = [\ \n]
 
 lexical restrictions
-	ID      -/- [a-zA-Z]
+    ID      -/- [a-zA-Z]
 
 context-free restrictions
-	LAYOUT? -/- [\ \n]
+    LAYOUT? -/- [\ \n]

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/CyclesTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/CyclesTest.java
@@ -30,7 +30,7 @@ public class CyclesTest extends BaseTestWithRecoverySdf3ParseTables {
         // The cycle is _after_ the x, but the input ends after the x and thus the message is reported _on_ the x
         return testMessages("x", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor(ParseFailureCause.Type.Cycle.message, Severity.ERROR, 0, 1, 1)
+            new MessageDescriptor(ParseFailureCause.Type.Cycle.message, Severity.ERROR, 0, 1, 1, 1)
         //@formatter:on
         ));
     }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/NonAssocMessagesTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/NonAssocMessagesTest.java
@@ -21,13 +21,13 @@ public class NonAssocMessagesTest extends BaseTestWithSdf3ParseTables {
     }
 
     @TestFactory public Stream<DynamicTest> testEqNonAssoc() throws ParseError {
-        return testMessages("x == x == x",
-            Collections.singletonList(new MessageDescriptor("Operator is non-associative", Severity.ERROR, 0, 1, 1)));
+        return testMessages("x == x == x", Collections
+            .singletonList(new MessageDescriptor("Operator is non-associative", Severity.ERROR, 0, 1, 1, 11)));
     }
 
     @TestFactory public Stream<DynamicTest> testGtNonNested() throws ParseError {
         return testMessages("x > x > x",
-            Collections.singletonList(new MessageDescriptor("Operator is non-nested", Severity.ERROR, 0, 1, 1)));
+            Collections.singletonList(new MessageDescriptor("Operator is non-nested", Severity.ERROR, 0, 1, 1, 9)));
     }
 
 }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/NonAssocMessagesTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/NonAssocMessagesTest.java
@@ -30,4 +30,13 @@ public class NonAssocMessagesTest extends BaseTestWithSdf3ParseTables {
             Collections.singletonList(new MessageDescriptor("Operator is non-nested", Severity.ERROR, 0, 1, 1, 9)));
     }
 
+    @TestFactory public Stream<DynamicTest> testEqGtMixedNoMessage() throws ParseError {
+        return testMessages("x == x > x", Collections.emptyList());
+    }
+
+    @TestFactory public Stream<DynamicTest> testEqGtMixedAST() throws ParseError {
+        return testSuccessByExpansions("x == x > x",
+            "amb([Eq(Var(\"x\"),Gt(Var(\"x\"),Var(\"x\"))),Gt(Eq(Var(\"x\"),Var(\"x\")),Var(\"x\"))])");
+    }
+
 }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/NonAssocMessagesTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/NonAssocMessagesTest.java
@@ -1,0 +1,33 @@
+package org.spoofax.jsglr2.integrationtest.features;
+
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.spoofax.jsglr2.integrationtest.BaseTestWithSdf3ParseTables;
+import org.spoofax.jsglr2.integrationtest.MessageDescriptor;
+import org.spoofax.jsglr2.messages.Severity;
+import org.spoofax.terms.ParseError;
+
+public class NonAssocMessagesTest extends BaseTestWithSdf3ParseTables {
+
+    public NonAssocMessagesTest() {
+        super("expressions-non-assoc.sdf3");
+    }
+
+    @TestFactory public Stream<DynamicTest> testPlusLeftAssoc() throws ParseError {
+        return testMessages("x + x + x", Collections.emptyList());
+    }
+
+    @TestFactory public Stream<DynamicTest> testEqNonAssoc() throws ParseError {
+        return testMessages("x == x == x",
+            Collections.singletonList(new MessageDescriptor("Operator is non-associative", Severity.ERROR, 0, 1, 1)));
+    }
+
+    @TestFactory public Stream<DynamicTest> testGtNonNested() throws ParseError {
+        return testMessages("x > x > x",
+            Collections.singletonList(new MessageDescriptor("Operator is non-nested", Severity.ERROR, 0, 1, 1)));
+    }
+
+}

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/ParseFailureMessagesTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/features/ParseFailureMessagesTest.java
@@ -36,7 +36,7 @@ public class ParseFailureMessagesTest extends BaseTestWithSdf3ParseTables {
     @TestFactory public Stream<DynamicTest> unexpectedInputoffset0() throws ParseError {
         return testMessages("c", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor(ParseFailureCause.Type.UnexpectedInput.message, Severity.ERROR, 0, 1, 1)
+            new MessageDescriptor(ParseFailureCause.Type.UnexpectedInput.message, Severity.ERROR, 0, 1, 1, 1)
         //@formatter:on
         ));
     }
@@ -44,7 +44,7 @@ public class ParseFailureMessagesTest extends BaseTestWithSdf3ParseTables {
     @TestFactory public Stream<DynamicTest> unexpectedInputoffset1() throws ParseError {
         return testMessages("xc", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor(ParseFailureCause.Type.UnexpectedInput.message, Severity.ERROR, 1, 1, 2)
+            new MessageDescriptor(ParseFailureCause.Type.UnexpectedInput.message, Severity.ERROR, 1, 1, 2, 1)
         //@formatter:on
         ));
     }
@@ -52,7 +52,7 @@ public class ParseFailureMessagesTest extends BaseTestWithSdf3ParseTables {
     @TestFactory public Stream<DynamicTest> unexpectedInputoffset2() throws ParseError {
         return testMessages("xxc", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor(ParseFailureCause.Type.UnexpectedInput.message, Severity.ERROR, 2, 1, 3)
+            new MessageDescriptor(ParseFailureCause.Type.UnexpectedInput.message, Severity.ERROR, 2, 1, 3, 1)
         //@formatter:on
         ));
     }
@@ -71,7 +71,7 @@ public class ParseFailureMessagesTest extends BaseTestWithSdf3ParseTables {
     @TestFactory public Stream<DynamicTest> unexpectedEOFx() throws ParseError {
         return testMessages("x", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor(ParseFailureCause.Type.UnexpectedEOF.message, Severity.ERROR, 0, 1, 1)
+            new MessageDescriptor(ParseFailureCause.Type.UnexpectedEOF.message, Severity.ERROR, 0, 1, 1, 1)
         //@formatter:on
         ));
     }
@@ -79,7 +79,7 @@ public class ParseFailureMessagesTest extends BaseTestWithSdf3ParseTables {
     @TestFactory public Stream<DynamicTest> unexpectedEOFxx() throws ParseError {
         return testMessages("xx", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor(ParseFailureCause.Type.UnexpectedEOF.message, Severity.ERROR, 1, 1, 2)
+            new MessageDescriptor(ParseFailureCause.Type.UnexpectedEOF.message, Severity.ERROR, 1, 1, 2, 1)
         //@formatter:on
         ));
     }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryInsertionMessagesTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryInsertionMessagesTest.java
@@ -19,7 +19,7 @@ public class RecoveryInsertionMessagesTest extends BaseTestWithRecoverySdf3Parse
     @TestFactory public Stream<DynamicTest> testSingleLineYRecovering() throws ParseError {
         return testMessages("xz", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor("Token expected", Severity.ERROR, 1, 1, 2)
+            new MessageDescriptor("Token expected", Severity.ERROR, 1, 1, 2, 1)
         //@formatter:on
         ), getTestVariants(isRecoveryVariant));
     }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryLexicalHiddenInsertionMessagesTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryLexicalHiddenInsertionMessagesTest.java
@@ -19,7 +19,7 @@ public class RecoveryLexicalHiddenInsertionMessagesTest extends BaseTestWithReco
     @TestFactory public Stream<DynamicTest> testHiddenYRecovering() throws ParseError {
         return testMessages("xz", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor("Invalid syntax", Severity.ERROR, 1, 1, 2)
+            new MessageDescriptor("Invalid syntax", Severity.ERROR, 1, 1, 2, 1)
         //@formatter:on
         ), getTestVariants(isRecoveryVariant));
     }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryLexicalInsertionMessagesTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryLexicalInsertionMessagesTest.java
@@ -19,7 +19,7 @@ public class RecoveryLexicalInsertionMessagesTest extends BaseTestWithRecoverySd
     @TestFactory public Stream<DynamicTest> testSingleLineYRecovering() throws ParseError {
         return testMessages("xz", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor("y expected", Severity.ERROR, 1, 1, 2)
+            new MessageDescriptor("y expected", Severity.ERROR, 1, 1, 2, 1)
         //@formatter:on
         ), getTestVariants(isRecoveryVariant));
     }
@@ -30,7 +30,7 @@ public class RecoveryLexicalInsertionMessagesTest extends BaseTestWithRecoverySd
     @TestFactory public Stream<DynamicTest> testSingleLineWithWhiteSpaceYRecovering() throws ParseError {
         return testMessages("x   z", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor("y expected", Severity.ERROR, 1, 1, 2)
+            new MessageDescriptor("y expected", Severity.ERROR, 1, 1, 2, 3)
         //@formatter:on
         ), getTestVariants(isRecoveryVariant));
     }
@@ -38,7 +38,7 @@ public class RecoveryLexicalInsertionMessagesTest extends BaseTestWithRecoverySd
     @TestFactory public Stream<DynamicTest> testMultiLineWithWhiteSpaceYRecovering() throws ParseError {
         return testMessages("x \n z", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor("y expected", Severity.ERROR, 1, 1, 2)
+            new MessageDescriptor("y expected", Severity.ERROR, 1, 1, 2, 3)
         //@formatter:on
         ), getTestVariants(isRecoveryVariant));
     }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryMessagesTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryMessagesTest.java
@@ -19,7 +19,7 @@ public class RecoveryMessagesTest extends BaseTestWithRecoverySdf3ParseTables {
     @TestFactory public Stream<DynamicTest> testSingleLineYRecovering() throws ParseError {
         return testMessages("y", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor("Invalid syntax", Severity.ERROR, 0, 1, 1)
+            new MessageDescriptor("Invalid syntax", Severity.ERROR, 0, 1, 1, 1)
         //@formatter:on
         ), getTestVariants(isRecoveryVariant));
     }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryPermissiveLiteralTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryPermissiveLiteralTest.java
@@ -29,7 +29,7 @@ public class RecoveryPermissiveLiteralTest extends BaseTestWithRecoverySdf3Parse
     @TestFactory public Stream<DynamicTest> testClosingLiteralExpected() throws ParseError {
         return testMessages("{", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor("} expected", Severity.ERROR, 0, 1, 1)
+            new MessageDescriptor("} expected", Severity.ERROR, 0, 1, 1, 1)
         //@formatter:on
         ), getTestVariants(isRecoveryVariant));
     }

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryWaterMessagesTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/recovery/RecoveryWaterMessagesTest.java
@@ -19,7 +19,7 @@ public class RecoveryWaterMessagesTest extends BaseTestWithRecoverySdf3ParseTabl
     @TestFactory public Stream<DynamicTest> testSingleLineYRecovering() throws ParseError {
         return testMessages("xwz", Arrays.asList(
         //@formatter:off
-            new MessageDescriptor("Not expected", Severity.ERROR, 1, 1, 2)
+            new MessageDescriptor("Not expected", Severity.ERROR, 1, 1, 2, 2)
         //@formatter:on
         ), getTestVariants(isRecoveryVariant));
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/messages/Message.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/messages/Message.java
@@ -32,6 +32,10 @@ public class Message {
         }
     }
 
+    public static Message error(String message, Position startPosition, Position endPosition) {
+        return new Message(message, Severity.ERROR, new SourceRegion(startPosition, endPosition));
+    }
+
     public static Message error(String message, SourceRegion region) {
         return new Message(message, Severity.ERROR, region);
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/messages/SourceRegion.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/messages/SourceRegion.java
@@ -5,12 +5,9 @@ import org.spoofax.jsglr2.parser.Position;
 
 public class SourceRegion {
 
-    public final int startOffset;
-    public final int startRow;
-    public final int startColumn;
-    public final int endOffset;
-    public final int endRow;
-    public final int endColumn;
+    public final int startOffset, startRow, startColumn;
+    /** Inclusive. */
+    public final int endOffset, endRow, endColumn;
 
     public SourceRegion(int startOffset, int startRow, int startColumn, int endOffset, int endRow, int endColumn) {
         this.startOffset = startOffset;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/NonAssocDetector.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/NonAssocDetector.java
@@ -49,7 +49,7 @@ public class NonAssocDetector
                 continue;
             ParseForest firstChild = children[0];
             if(firstChild instanceof IParseNode
-                && parseNode.production().isNonAssocWith(((IParseNode<?, ?>) firstChild).production()))
+                && derivation.production().isNonAssocWith(((IParseNode<?, ?>) firstChild).production()))
                 return true;
         }
         return false;
@@ -62,7 +62,7 @@ public class NonAssocDetector
                 continue;
             ParseForest lastChild = children[children.length - 1];
             if(lastChild instanceof IParseNode
-                && parseNode.production().isNonNestedWith(((IParseNode<?, ?>) lastChild).production()))
+                && derivation.production().isNonNestedWith(((IParseNode<?, ?>) lastChild).production()))
                 return true;
         }
         return false;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/NonAssocDetector.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/NonAssocDetector.java
@@ -1,0 +1,71 @@
+package org.spoofax.jsglr2.parser;
+
+import java.util.Collection;
+
+import org.spoofax.jsglr2.messages.Message;
+import org.spoofax.jsglr2.parseforest.IDerivation;
+import org.spoofax.jsglr2.parseforest.IParseForest;
+import org.spoofax.jsglr2.parseforest.IParseNode;
+import org.spoofax.jsglr2.parseforest.ParseNodeVisitor;
+import org.spoofax.jsglr2.parser.result.ParseFailureCause;
+
+public class NonAssocDetector
+//@formatter:off
+   <ParseForest extends IParseForest,
+    Derivation  extends IDerivation<ParseForest>,
+    ParseNode   extends IParseNode<ParseForest, Derivation>>
+//@formatter:on
+    implements ParseNodeVisitor<ParseForest, Derivation, ParseNode> {
+
+    Collection<Message> messages;
+
+    NonAssocDetector(Collection<Message> messages) {
+        this.messages = messages;
+    }
+
+    @Override public boolean preVisit(ParseNode parseNode, Position startPosition) {
+        if(hasNonAssoc(parseNode)) {
+            return false;
+        } else if(hasNonNested(parseNode)) {
+            return false;
+        } else {
+            return parseNode.production().isContextFree();
+        }
+    }
+
+
+    @Override public void postVisit(ParseNode parseNode, Position startPosition, Position endPosition) {
+        if(hasNonAssoc(parseNode)) {
+            messages.add(Message.error(ParseFailureCause.Type.NonAssoc.message, startPosition, endPosition));
+        } else if(hasNonNested(parseNode)) {
+            messages.add(Message.error(ParseFailureCause.Type.NonNested.message, startPosition, endPosition));
+        }
+    }
+
+    private boolean hasNonAssoc(ParseNode parseNode) {
+        for(Derivation derivation : parseNode.getDerivations()) {
+            ParseForest[] children = derivation.parseForests();
+            if(children.length == 0)
+                continue;
+            ParseForest firstChild = children[0];
+            if(firstChild instanceof IParseNode
+                && parseNode.production().isNonAssocWith(((IParseNode<?, ?>) firstChild).production()))
+                return true;
+        }
+        return false;
+    }
+
+    private boolean hasNonNested(ParseNode parseNode) {
+        for(Derivation derivation : parseNode.getDerivations()) {
+            ParseForest[] children = derivation.parseForests();
+            if(children.length == 0)
+                continue;
+            ParseForest lastChild = children[children.length - 1];
+            if(lastChild instanceof IParseNode
+                && parseNode.production().isNonNestedWith(((IParseNode<?, ?>) lastChild).production()))
+                return true;
+        }
+        return false;
+    }
+
+}

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/Parser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/Parser.java
@@ -123,6 +123,9 @@ public class Parser
         } else {
             reporter.report(parseState, parseForest, messages);
 
+            // Generate errors for non-assoc or non-nested productions that are used associatively
+            parseForestManager.visit(parseState.request, parseForest, new NonAssocDetector(messages));
+
             ParseSuccess<ParseForest> success = new ParseSuccess<>(parseState, parseForest, messages);
 
             observing.notify(observer -> observer.success(success));

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseFailureCause.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseFailureCause.java
@@ -8,7 +8,8 @@ public class ParseFailureCause {
     public enum Type {
 
         UnexpectedEOF("Unexpected end of input"), UnexpectedInput("Unexpected input"),
-        InvalidStartSymbol("Invalid start symbol"), Cycle("Cycle in parse forest");
+        InvalidStartSymbol("Invalid start symbol"), Cycle("Cycle in parse forest"),
+        NonAssoc("Operator is non-associative"), NonNested("Operator is non-nested");
 
         public final String message;
 


### PR DESCRIPTION
To be merged together with metaborg/sdf#50 and metaborg/spoofax#73. Recommended order of reading: SDF, JSGLR, Spoofax.

### For JSGLR1:

The parse table reader has been adapted to recognize the new `assoc-with` attributes on productions in the ATerm parse table format, see [ParseTable.java:404-422](https://github.com/metaborg/jsglr/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-e18e1a7cb4a99fd9061082e6b2a315e4R404-R422). The option to retrieve the global list of non-associative pairs from the parse table generator has been removed.

Because I didn't want to change how non-assoc error messages are generated in `JSGLR1I` (see metaborg/spoofax#73), I decided to rewrite the "for each production, a list of production labels" approach back into the "global table with mutually non-associative pairs of productions" approach that has to be used in `JSGLR1I`. The keys/values of the map are `<Sort>.<Cons>` strings, just like it used to be. This all happens in [ParseTable.java:302-314](https://github.com/metaborg/jsglr/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-e18e1a7cb4a99fd9061082e6b2a315e4R302-R314).

### For JSGLR2:

This is the part that makes me happy. :relaxed: 

To generate the non-assoc error messages, I've added a [NonAssocDetector](https://github.com/metaborg/jsglr/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-f7794d1b5ce08b0613137891ca8b8f45) that is implemented as a `ParseForestVisitor`. :sparkles: This detector is called in [Parser.java:127](https://github.com/metaborg/jsglr/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-f4f3219c5f7234fce51c7a2e7d5b010bR127), after (and only if) the cycle detector has concluded that the parse forest is valid. I decided to not make this a hard failure (much like how error recovery works), because that means we still get an AST in the end, but the parse will be considered as "failed" by SPT.

I've also added a [NonAssocMessagesTest](https://github.com/metaborg/jsglr/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-e601b569fd479a62c9b0aed70f0437e1) that verifies that the messages are actually generated.

One note about the messages: they're generated over the entire non-associative production, for example, all of `a > a < a` will be underlined in red. However, it's not possible to verify this in the test, currently; only the message start position is verified. @jasperdenkers Do we want to add this? 