### PR TITLE
Improve messages

### DIFF
--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -64,8 +64,8 @@ public abstract class BaseTest implements WithParseTable {
 
     protected static class TestVariant {
 
-        public IntegrationVariant variant;
-        public ParseTableWithOrigin parseTableWithOrigin;
+        public final IntegrationVariant variant;
+        public final ParseTableWithOrigin parseTableWithOrigin;
 
         TestVariant(IntegrationVariant variant, ParseTableWithOrigin parseTableWithOrigin) {
             this.variant = variant;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/messages/Category.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/messages/Category.java
@@ -1,5 +1,14 @@
 package org.spoofax.jsglr2.messages;
 
+import static org.spoofax.jsglr2.messages.Severity.ERROR;
+import static org.spoofax.jsglr2.messages.Severity.WARNING;
+
 public enum Category {
-    PARSING, RECOVERY, CYCLE, AMBIGUITY, NON_ASSOC
+    PARSING(ERROR), RECOVERY(ERROR), CYCLE(ERROR), AMBIGUITY(WARNING), NON_ASSOC(ERROR);
+
+    public final Severity severity;
+
+    Category(Severity severity) {
+        this.severity = severity;
+    }
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/messages/Category.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/messages/Category.java
@@ -1,5 +1,5 @@
 package org.spoofax.jsglr2.messages;
 
 public enum Category {
-    PARSING, RECOVERY, CYCLE, AMBIGUITY, NONASSOC
+    PARSING, RECOVERY, CYCLE, AMBIGUITY, NON_ASSOC
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/messages/Message.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/messages/Message.java
@@ -1,57 +1,40 @@
 package org.spoofax.jsglr2.messages;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.spoofax.jsglr2.parser.Position;
 
 public class Message {
 
     public final String message;
-    public final Severity severity;
     public final Category category;
+    public final Severity severity;
+    /** If the region of a message is null, it should be displayed at the top of the program. */
     public final SourceRegion region;
 
-    public Message(String message, Severity severity, Category category, SourceRegion region) {
+    public Message(@Nonnull String message, @Nonnull Category category, @Nullable SourceRegion region) {
         this.message = message;
-        this.severity = severity;
         this.category = category;
+        this.severity = category.severity;
         this.region = region;
     }
 
+    public Message(@Nonnull String message, @Nonnull Category category, @Nonnull Position startPosition,
+        @Nonnull Position endPosition) {
+        this(message, category, new SourceRegion(startPosition, endPosition));
+    }
+
+    public Message(@Nonnull String message, @Nonnull Category category, @Nullable Position position) {
+        this(message, category, position == null ? null : new SourceRegion(position, position));
+    }
+
     public Message atRegion(SourceRegion otherRegion) {
-        return new Message(message, severity, category, otherRegion);
+        return new Message(message, category, otherRegion);
     }
 
     @Override public String toString() {
         return "\"" + message + "\" " + severity + " @ " + region;
-    }
-
-    public static Message error(String message, Category category, Position position) {
-        if(position == null)
-            return errorAtTop(message, category);
-        else {
-            SourceRegion region = new SourceRegion(position);
-
-            return new Message(message, Severity.ERROR, category, region);
-        }
-    }
-
-    public static Message error(String message, Category category, Position startPosition, Position endPosition) {
-        return new Message(message, Severity.ERROR, category, new SourceRegion(startPosition, endPosition));
-    }
-
-    public static Message error(String message, Category category, SourceRegion region) {
-        return new Message(message, Severity.ERROR, category, region);
-    }
-
-    public static Message atTop(String message, Severity severity, Category category) {
-        return new Message(message, severity, category, null);
-    }
-
-    public static Message errorAtTop(String message, Category category) {
-        return atTop(message, Severity.ERROR, category);
-    }
-
-    public static Message warning(String message, Category category, Position startPosition, Position endPosition) {
-        return new Message(message, Severity.WARNING, category, new SourceRegion(startPosition, endPosition));
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/AmbiguityDetector.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/AmbiguityDetector.java
@@ -27,7 +27,7 @@ public class AmbiguityDetector
         if(parseNode.isAmbiguous()) {
             String message;
 
-            if (parseNode.production().isContextFree() && parseNode.getPreferredAvoidedDerivations().size() == 1)
+            if(parseNode.production().isContextFree() && parseNode.getPreferredAvoidedDerivations().size() == 1)
                 return;
 
             switch(parseNode.production().concreteSyntaxContext()) {
@@ -44,7 +44,7 @@ public class AmbiguityDetector
                     break;
             }
 
-            messages.add(Message.warning(message, Category.AMBIGUITY, startPosition, endPosition));
+            messages.add(new Message(message, Category.AMBIGUITY, startPosition, endPosition));
         }
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/CycleDetector.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/CycleDetector.java
@@ -31,7 +31,7 @@ public class CycleDetector
     @Override public boolean preVisit(ParseNode parseNode, Position startPosition) {
         if(spine.contains(parseNode)) {
             cycleDetected = true;
-            messages.add(Message.error(ParseFailureCause.Type.Cycle.message, Category.CYCLE, startPosition));
+            messages.add(new Message(ParseFailureCause.Type.Cycle.message, Category.CYCLE, startPosition));
 
             return false;
         } else {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/NonAssocDetector.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/NonAssocDetector.java
@@ -45,7 +45,7 @@ public class NonAssocDetector
 
     @Override public void postVisit(ParseNode parseNode, Position startPosition, Position endPosition) {
         if(failure != null) {
-            messages.add(Message.error(failure.message, Category.NONASSOC, startPosition, endPosition));
+            messages.add(Message.error(failure.message, Category.NON_ASSOC, startPosition, endPosition));
             failure = null;
         }
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/NonAssocDetector.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/NonAssocDetector.java
@@ -45,7 +45,7 @@ public class NonAssocDetector
 
     @Override public void postVisit(ParseNode parseNode, Position startPosition, Position endPosition) {
         if(failure != null) {
-            messages.add(Message.error(failure.message, Category.NON_ASSOC, startPosition, endPosition));
+            messages.add(new Message(failure.message, Category.NON_ASSOC, startPosition, endPosition));
             failure = null;
         }
     }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseFailureCause.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseFailureCause.java
@@ -11,8 +11,8 @@ public class ParseFailureCause {
         UnexpectedEOF("Unexpected end of input", Category.PARSING),
         UnexpectedInput("Unexpected input", Category.PARSING),
         InvalidStartSymbol("Invalid start symbol", Category.PARSING), Cycle("Cycle in parse forest", Category.CYCLE),
-        NonAssoc("Operator is non-associative", Category.NONASSOC),
-        NonNested("Operator is non-nested", Category.NONASSOC);
+        NonAssoc("Operator is non-associative", Category.NON_ASSOC),
+        NonNested("Operator is non-nested", Category.NON_ASSOC);
 
         public final String message;
         public final Category category;

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseFailureCause.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseFailureCause.java
@@ -6,38 +6,38 @@ import org.spoofax.jsglr2.parser.Position;
 
 public class ParseFailureCause {
 
-	public enum Type {
+    public enum Type {
 
-		UnexpectedEOF("Unexpected end of input", Category.PARSING),
-		UnexpectedInput("Unexpected input", Category.PARSING),
-		InvalidStartSymbol("Invalid start symbol", Category.PARSING), Cycle("Cycle in parse forest", Category.CYCLE),
-		NonAssoc("Operator is non-associative", Category.NONASSOC),
-		NonNested("Operator is non-nested", Category.NONASSOC);
+        UnexpectedEOF("Unexpected end of input", Category.PARSING),
+        UnexpectedInput("Unexpected input", Category.PARSING),
+        InvalidStartSymbol("Invalid start symbol", Category.PARSING), Cycle("Cycle in parse forest", Category.CYCLE),
+        NonAssoc("Operator is non-associative", Category.NONASSOC),
+        NonNested("Operator is non-nested", Category.NONASSOC);
 
-		public final String message;
-		public final Category category;
+        public final String message;
+        public final Category category;
 
-		Type(String message, Category category) {
-			this.message = message;
-			this.category = category;
-		}
+        Type(String message, Category category) {
+            this.message = message;
+            this.category = category;
+        }
 
-	}
+    }
 
-	public final Type type;
-	public final Position position;
+    public final Type type;
+    public final Position position;
 
-	public ParseFailureCause(Type type, Position position) {
-		this.type = type;
-		this.position = position;
-	}
+    public ParseFailureCause(Type type, Position position) {
+        this.type = type;
+        this.position = position;
+    }
 
-	public ParseFailureCause(Type type) {
-		this(type, null);
-	}
+    public ParseFailureCause(Type type) {
+        this(type, null);
+    }
 
-	public Message toMessage() {
-		return Message.error(type.message, type.category, position);
-	}
+    public Message toMessage() {
+        return Message.error(type.message, type.category, position);
+    }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseFailureCause.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/result/ParseFailureCause.java
@@ -10,7 +10,8 @@ public class ParseFailureCause {
 
         UnexpectedEOF("Unexpected end of input", Category.PARSING),
         UnexpectedInput("Unexpected input", Category.PARSING),
-        InvalidStartSymbol("Invalid start symbol", Category.PARSING), Cycle("Cycle in parse forest", Category.CYCLE),
+        InvalidStartSymbol("Invalid start symbol", Category.PARSING),
+        Cycle("Parse forest contains a cycle", Category.CYCLE),
         NonAssoc("Operator is non-associative", Category.NON_ASSOC),
         NonNested("Operator is non-nested", Category.NON_ASSOC);
 
@@ -37,7 +38,7 @@ public class ParseFailureCause {
     }
 
     public Message toMessage() {
-        return Message.error(type.message, type.category, position);
+        return new Message(type.message, type.category, position);
     }
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/recovery/RecoveryMessages.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/recovery/RecoveryMessages.java
@@ -28,7 +28,7 @@ public class RecoveryMessages {
         } else
             message = "Invalid syntax";
 
-        return Message.error(message, Category.RECOVERY, region);
+        return new Message(message, Category.RECOVERY, region);
     }
 
 }


### PR DESCRIPTION
When message categories were added in a41a71741a1d052326431284675ce8ea3b801c2f, I noticed that the severity of messages contains a strong link with their category. I therefore decided to add the severity of a category as a field to the `Category` enum. This simplifies the creation of messages.

This is all under the assumption that every message category always has exactly one severity. If you think there could be a case where this is not true, please discuss :slightly_smiling_face: 