### PR TITLE
Fixes dangling open stream

### DIFF
--- a/org.spoofax.jsglr/src/org/spoofax/jsglr/client/ParseTable.java
+++ b/org.spoofax.jsglr/src/org/spoofax/jsglr/client/ParseTable.java
@@ -115,18 +115,15 @@ public class ParseTable implements Serializable {
         }
     }
 
-    public ParseTable(IStrategoTerm pt, ITermFactory factory, FileObject persistedTable,
-        IParseTableGenerator ptGenerator) throws Exception {
-        // N.B. This is _not_ code duplication with the InputStream variant constructor, because that
-        //      variant doesn't _close_ the stream. So opening it here and calling the other constructor
-        //      will lead to a dangling open stream!
+    public ParseTable(IStrategoTerm pt, ITermFactory factory, IParseTableGenerator ptGenerator)
+        throws InvalidParseTableException {
         initTransientData(factory);
         parse(pt);
         if(states.length == 0) {
             dynamicPTgeneration = true;
         }
 
-        if(dynamicPTgeneration && persistedTable != null) {
+        if(dynamicPTgeneration) {
             this.ptGenerator = ptGenerator;
             gotoCache = new HashMap<Goto, Goto>();
             shiftCache = new HashMap<Shift, Shift>();
@@ -134,36 +131,6 @@ public class ParseTable implements Serializable {
             rangesCache = new HashMap<RangeList, RangeList>();
         } else {
             this.ptGenerator = null;
-        }
-
-        if(dynamicPTgeneration && persistedTable == null) {
-            throw new InvalidParseTableException(
-                "Parse table does not contain any state and normalized grammar is null");
-        }
-    }
-
-    public ParseTable(IStrategoTerm pt, ITermFactory factory, InputStream persistedTable,
-        IParseTableGenerator ptGenerator) throws Exception {
-        initTransientData(factory);
-        parse(pt);
-        if(states.length == 0) {
-            dynamicPTgeneration = true;
-        }
-
-        if(dynamicPTgeneration && persistedTable != null) {
-            this.ptGenerator = ptGenerator;
-            gotoCache = new HashMap<Goto, Goto>();
-            shiftCache = new HashMap<Shift, Shift>();
-            reduceCache = new HashMap<Reduce, Reduce>();
-            rangesCache = new HashMap<RangeList, RangeList>();
-
-        } else {
-            this.ptGenerator = null;
-        }
-
-        if(dynamicPTgeneration && persistedTable == null) {
-            throw new InvalidParseTableException(
-                "Parse table does not contain any state and normalized grammar is null");
         }
     }
 


### PR DESCRIPTION
Open streams can cause file locking issues on Windows, and other
streams not opening to the file.

The constructors where I made changes don't really make sense to me. I
think maybe some was overzealous in removing code duplication between
two constructors? `FileContent.getInputStream` never returns null anyway.
This change does have a semantic difference in that previously the file
was attempted to be opened, so an Exception from that would previously
be triggered and isn't now. I assumed that wasn't the reason for opening
stream.