### PR TITLE
TreeSitter benchmark (and some other fixes)

### DIFF
--- a/org.spoofax.jsglr2.benchmark/pom.xml
+++ b/org.spoofax.jsglr2.benchmark/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>antlr4-runtime</artifactId>
             <version>4.7.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.mpsijm</groupId>
+            <artifactId>java-tree-sitter</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -150,6 +156,25 @@
                             <sources>
                                 <source>${basedir}/target/generated-sources/antlr4</source>
                             </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- TreeSitter: Generate language bindings for Java grammar -->
+            <plugin>
+                <groupId>com.github.mpsijm</groupId>
+                <artifactId>tree-sitter-generate-maven-plugin</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>Generate bindings for Java</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <languageRepository>https://github.com/tree-sitter/tree-sitter-java.git</languageRepository>
+                            <languageName>Java</languageName>
                         </configuration>
                     </execution>
                 </executions>

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncremental.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncremental.java
@@ -3,10 +3,7 @@ package org.spoofax.jsglr2.benchmark.jsglr2;
 import static org.spoofax.jsglr2.JSGLR2Variant.Preset.incremental;
 import static org.spoofax.jsglr2.JSGLR2Variant.Preset.standard;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
@@ -65,9 +62,7 @@ public abstract class JSGLR2BenchmarkIncremental extends JSGLR2Benchmark<String[
                 List<String> res = new ArrayList<>();
                 String prev = null;
                 for(String s : input.content) {
-                    if(s.length() == 0)
-                        continue;
-                    if(!s.equals(prev)) {
+                    if(!Objects.equals(prev, s)) {
                         res.add(s);
                         prev = s;
                     }
@@ -78,6 +73,8 @@ public abstract class JSGLR2BenchmarkIncremental extends JSGLR2Benchmark<String[
         if(shouldSetupCache()) {
             for(IncrementalStringInput input : inputs) {
                 String content = input.content[i - 1];
+                if(content == null)
+                    continue;
                 if(!implode()) {
                     prevString.put(input, content);
                     prevParse.put(input, jsglr2.parser.parseUnsafe(content, null));

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncrementalExternal.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncrementalExternal.java
@@ -3,7 +3,6 @@ package org.spoofax.jsglr2.benchmark.jsglr2;
 import java.util.Map;
 
 import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.infra.Blackhole;
 import org.spoofax.jsglr2.benchmark.BenchmarkTestSetWithParseTableReader;
 import org.spoofax.jsglr2.parseforest.IParseForest;
@@ -31,7 +30,7 @@ public class JSGLR2BenchmarkIncrementalExternal extends JSGLR2BenchmarkIncrement
         return implode;
     }
 
-    @Override @Setup public void setupCache() throws ParseException {
+    @Override public void setupCache() throws ParseException {
         // Hack: the original intent of the JSGLR2IncrementalBenchmark was to read in all files upon setup.
         // However, for the external benchmark, only two versions of these files are read.
         // Therefore, we have to overwrite the `setupCache` function, but copy/pasting is bad,

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncrementalExternal.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncrementalExternal.java
@@ -60,15 +60,20 @@ public class JSGLR2BenchmarkIncrementalExternal extends JSGLR2BenchmarkIncrement
             // if (i == -1)
             return jsglr2MultiParser.parse(input.content);
         } else {
-            if(i >= 0)
-                return jsglr2.parser.parseUnsafe(input.content[i > 0 ? 1 : 0], null, prevString.get(input),
-                    prevParse.get(input));
+            if(i >= 0) {
+                String s = input.content[i > 0 ? 1 : 0];
+                if(s == null)
+                    return null;
+                return jsglr2.parser.parseUnsafe(s, null, prevString.get(input), prevParse.get(input));
+            }
 
             String previousInput = null;
             IParseForest previousResult = null;
 
             if(i == -2) {
                 for(String content : uniqueInputs.get(input)) {
+                    if(content == null)
+                        continue;
                     bh.consume(
                         previousResult = jsglr2.parser.parseUnsafe(content, null, previousInput, previousResult));
                     previousInput = content;
@@ -78,6 +83,8 @@ public class JSGLR2BenchmarkIncrementalExternal extends JSGLR2BenchmarkIncrement
 
             // if (i == -1)
             for(String content : input.content) {
+                if(content == null)
+                    continue;
                 bh.consume(previousResult = jsglr2.parser.parseUnsafe(content, null, previousInput, previousResult));
                 previousInput = content;
             }

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncrementalExternal.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncrementalExternal.java
@@ -48,7 +48,7 @@ public class JSGLR2BenchmarkIncrementalExternal extends JSGLR2BenchmarkIncrement
                 return jsglr2MultiParser.parse(input.content[i]);
 
             if(i > 0) {
-                if(parserType.setupCache)
+                if(parserType.setupCache && prevCacheImpl.containsKey(input))
                     return prevCacheImpl.get(input).parse(input.content[1]);
                 else
                     return jsglr2MultiParser.parse(input.content[1]);

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncrementalParsing.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncrementalParsing.java
@@ -12,14 +12,20 @@ public abstract class JSGLR2BenchmarkIncrementalParsing extends JSGLR2BenchmarkI
     }
 
     @Override protected Object action(Blackhole bh, IncrementalStringInput input) throws ParseException {
-        if(i >= 0)
-            return jsglr2.parser.parseUnsafe(input.content[i], null, prevString.get(input), prevParse.get(input));
+        if(i >= 0) {
+            String s = input.content[i];
+            if(s == null)
+                return null;
+            return jsglr2.parser.parseUnsafe(s, null, prevString.get(input), prevParse.get(input));
+        }
 
         String previousInput = null;
         IParseForest previousResult = null;
 
         if(i == -2) {
             for(String content : uniqueInputs.get(input)) {
+                if(content == null)
+                    continue;
                 bh.consume(previousResult = jsglr2.parser.parseUnsafe(content, null, previousInput, previousResult));
                 previousInput = content;
             }
@@ -28,6 +34,8 @@ public abstract class JSGLR2BenchmarkIncrementalParsing extends JSGLR2BenchmarkI
 
         // if (i == -1)
         for(String content : input.content) {
+            if(content == null)
+                continue;
             bh.consume(previousResult = jsglr2.parser.parseUnsafe(content, null, previousInput, previousResult));
             previousInput = content;
         }

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/util/JSGLR2MultiParser.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/util/JSGLR2MultiParser.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.spoofax.jsglr2.JSGLR2;
 import org.spoofax.jsglr2.JSGLR2ImplementationWithCache;
+import org.spoofax.jsglr2.JSGLR2Request;
 import org.spoofax.jsglr2.parser.ParseException;
 
 /**
@@ -28,7 +29,13 @@ public class JSGLR2MultiParser<AbstractSyntaxTree> {
         }
 
         if(jsglr2 instanceof JSGLR2ImplementationWithCache) {
-            ((JSGLR2ImplementationWithCache<?, ?, ?, AbstractSyntaxTree, ?, ?>) this.jsglr2).clearCache();
+            JSGLR2ImplementationWithCache<?, ?, ?, AbstractSyntaxTree, ?, ?> jsglr2 =
+                (JSGLR2ImplementationWithCache<?, ?, ?, AbstractSyntaxTree, ?, ?>) this.jsglr2;
+            JSGLR2Request.CachingKey key = new JSGLR2Request(null, fileName).cachingKey();
+            jsglr2.inputCache.remove(key);
+            jsglr2.parseForestCache.remove(key);
+            jsglr2.imploderCacheCache.remove(key);
+            jsglr2.tokensCache.remove(key);
         }
 
         return res;

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/util/JSGLR2MultiParser.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/util/JSGLR2MultiParser.java
@@ -24,7 +24,7 @@ public class JSGLR2MultiParser<AbstractSyntaxTree> {
         String fileName = "" + System.currentTimeMillis();
 
         for(String input : inputs) {
-            res.add(jsglr2.parseUnsafe(input, fileName, null));
+            res.add(input == null ? null : jsglr2.parseUnsafe(input, fileName, null));
         }
 
         if(jsglr2 instanceof JSGLR2ImplementationWithCache) {

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/util/JSGLR2PersistentCache.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/util/JSGLR2PersistentCache.java
@@ -1,7 +1,6 @@
 package org.spoofax.jsglr2.benchmark.jsglr2.util;
 
 import org.spoofax.jsglr.client.imploder.ITokens;
-import org.spoofax.jsglr2.JSGLR2Implementation;
 import org.spoofax.jsglr2.JSGLR2ImplementationWithCache;
 import org.spoofax.jsglr2.JSGLR2Request;
 import org.spoofax.jsglr2.imploder.IImplodeResult;
@@ -48,6 +47,9 @@ public class JSGLR2PersistentCache
     }
 
     public AbstractSyntaxTree parse(String input) throws ParseException {
+        if(input == null)
+            return null;
+
         JSGLR2Request request = new JSGLR2Request(input, fileName);
         AbstractSyntaxTree res = jsglr2Implementation.parseUnsafe(request);
 

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterBenchmark.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterBenchmark.java
@@ -1,0 +1,47 @@
+package org.spoofax.jsglr2.benchmark.treesitter;
+
+import java.util.Map;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.spoofax.jsglr2.benchmark.BaseBenchmark;
+import org.spoofax.jsglr2.benchmark.BenchmarkTestSetReader;
+import org.spoofax.jsglr2.testset.TestSet;
+import org.spoofax.jsglr2.testset.testinput.StringInput;
+
+import com.github.mpsijm.javatreesitter.java.TreeSitterJavaLibrary;
+
+@State(Scope.Benchmark)
+public class TreeSitterBenchmark extends BaseBenchmark<String, StringInput> {
+
+    private TreeSitterParser parser;
+
+    public TreeSitterBenchmark() {
+        Map<String, String> args = TestSet.parseArgs(System.getProperty("testSet").split(" "));
+
+        if(!args.getOrDefault("language", "").equals("java")) {
+            throw new IllegalStateException("TreeSitter currently only supports Java");
+        }
+
+        TestSet<String, StringInput> testSet = TestSet.fromArgs(args);
+
+        setTestSetReader(new BenchmarkTestSetReader<>(testSet));
+    }
+
+    @Setup public void setup() {
+        parser = new TreeSitterParser(TreeSitterJavaLibrary.tree_sitter_java());
+    }
+
+    @Benchmark public void benchmark(Blackhole bh) {
+        for(StringInput input : inputs)
+            bh.consume(action(bh, input));
+    }
+
+    protected Object action(Blackhole bh, StringInput input) {
+        return parser.parse(input.content);
+    }
+
+}

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterBenchmark.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterBenchmark.java
@@ -32,7 +32,7 @@ public class TreeSitterBenchmark extends BaseBenchmark<String, StringInput> {
     }
 
     @Setup public void setup() {
-        parser = new TreeSitterParser(TreeSitterJavaLibrary.tree_sitter_java());
+        parser = new TreeSitterParser(TreeSitterParser.SupportedLanguage.JAVA);
     }
 
     @Benchmark public void benchmark(Blackhole bh) {

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterBenchmarkIncremental.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterBenchmarkIncremental.java
@@ -1,0 +1,105 @@
+package org.spoofax.jsglr2.benchmark.treesitter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bridj.Pointer;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.spoofax.jsglr2.benchmark.BaseBenchmark;
+import org.spoofax.jsglr2.benchmark.BenchmarkTestSetWithParseTableReader;
+import org.spoofax.jsglr2.testset.TestSet;
+import org.spoofax.jsglr2.testset.TestSetWithParseTable;
+import org.spoofax.jsglr2.testset.testinput.IncrementalStringInput;
+
+import com.github.mpsijm.javatreesitter.JavaTreeSitterLibrary;
+import com.github.mpsijm.javatreesitter.java.TreeSitterJavaLibrary;
+
+@State(Scope.Benchmark)
+public class TreeSitterBenchmarkIncremental extends BaseBenchmark<String[], IncrementalStringInput> {
+
+    private TreeSitterParser parser;
+
+    @Param({ "Incremental", "IncrementalNoCache" }) public ParserType parserType;
+
+    @Param({ "-1" }) public int i;
+
+    public TreeSitterBenchmarkIncremental() {
+        Map<String, String> args = TestSet.parseArgs(System.getProperty("testSet").split(" "));
+
+        if(!args.getOrDefault("language", "").equals("java")) {
+            throw new IllegalStateException("TreeSitter currently only supports Java");
+        }
+
+        TestSetWithParseTable<String[], IncrementalStringInput> testSet =
+            TestSet.fromArgsWithParseTableIncremental(args);
+
+        setTestSetReader(new BenchmarkTestSetWithParseTableReader<>(testSet));
+    }
+
+    public enum ParserType {
+        Incremental(true), IncrementalNoCache(false);
+
+        boolean setupCache;
+
+        ParserType(boolean setupCache) {
+            this.setupCache = setupCache;
+        }
+    }
+
+    Map<IncrementalStringInput, String> prevString = new HashMap<>();
+    Map<IncrementalStringInput, Pointer<JavaTreeSitterLibrary.TSTree>> prevTree = new HashMap<>();
+
+    protected boolean shouldSetupCache() {
+        return parserType.setupCache && i > 0;
+    }
+
+    @Setup public void setup() {
+        parser = new TreeSitterParser(TreeSitterJavaLibrary.tree_sitter_java());
+
+        if(shouldSetupCache()) {
+            // Hack: the original intent of the IncrementalBenchmark was to read in all files upon setup.
+            // However, for the external benchmark, only two versions of these files are read.
+            // Therefore, we have to overwrite the `setupCache` function, but copy/pasting is bad,
+            // so we just pretend that the iteration number (`i`) is temporarily something different. O:)
+            int oldI = i;
+            i = Math.min(i, 1);
+
+            for(IncrementalStringInput input : inputs) {
+                String content = input.content[i - 1];
+                if(content == null)
+                    continue;
+                prevString.put(input, content);
+                prevTree.put(input, parser.parse(content));
+            }
+
+            i = oldI;
+        }
+    }
+
+    @Benchmark public void benchmark(Blackhole bh) {
+        for(IncrementalStringInput input : inputs)
+            bh.consume(action(bh, input));
+    }
+
+    protected Object action(Blackhole bh, IncrementalStringInput input) {
+        if(i >= 0) {
+            String s = input.content[i > 0 ? 1 : 0];
+            if(s == null)
+                return null;
+            return parser.parse(s, prevString.get(input), prevTree.get(input));
+        }
+
+        String previousInput = null;
+        Pointer<JavaTreeSitterLibrary.TSTree> previousResult = null;
+
+        // if (i == -1)
+        for(String content : input.content) {
+            if(content == null)
+                continue;
+            bh.consume(previousResult = parser.parse(content, previousInput, previousResult));
+            previousInput = content;
+        }
+        return null;
+    }
+}

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterBenchmarkIncremental.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterBenchmarkIncremental.java
@@ -55,7 +55,7 @@ public class TreeSitterBenchmarkIncremental extends BaseBenchmark<String[], Incr
     }
 
     @Setup public void setup() {
-        parser = new TreeSitterParser(TreeSitterJavaLibrary.tree_sitter_java());
+        parser = new TreeSitterParser(TreeSitterParser.SupportedLanguage.JAVA);
 
         if(shouldSetupCache()) {
             // Hack: the original intent of the IncrementalBenchmark was to read in all files upon setup.

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterParser.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterParser.java
@@ -1,0 +1,46 @@
+package org.spoofax.jsglr2.benchmark.treesitter;
+
+import static com.github.mpsijm.javatreesitter.JavaTreeSitterLibrary.*;
+
+import org.bridj.Pointer;
+import org.spoofax.jsglr2.incremental.EditorUpdate;
+import org.spoofax.jsglr2.incremental.diff.IStringDiff;
+import org.spoofax.jsglr2.incremental.diff.JGitHistogramDiff;
+
+import com.github.mpsijm.javatreesitter.JavaTreeSitterLibrary;
+import com.github.mpsijm.javatreesitter.TSInputEdit;
+import com.github.mpsijm.javatreesitter.TSLanguage;
+
+public class TreeSitterParser {
+    private final Pointer<JavaTreeSitterLibrary.TSParser> parser;
+    private final IStringDiff diff;
+
+    public TreeSitterParser(Pointer<TSLanguage> language) {
+        parser = ts_parser_new();
+        ts_parser_set_language(parser, language);
+        diff = new JGitHistogramDiff();
+    }
+
+    public Pointer<TSTree> parse(String input) {
+        return parse(input, null, null);
+    }
+
+    public Pointer<TSTree> parse(String input, String previousInput, Pointer<TSTree> previousTree) {
+        Pointer<TSTree> copyOfPrevious =
+            previousInput != null && previousTree != null ? ts_tree_copy(previousTree) : null;
+
+        if(copyOfPrevious != null) {
+            for(EditorUpdate update : diff.diff(previousInput, input)) {
+                Pointer<TSInputEdit> edit = Pointer.allocate(TSInputEdit.class);
+                edit.get().start_byte(update.deletedStart).old_end_byte(update.deletedEnd)
+                    .new_end_byte(update.deletedStart + update.inserted.length());
+
+                ts_tree_edit(copyOfPrevious, edit);
+
+                edit.release();
+            }
+        }
+
+        return ts_parser_parse_string(parser, copyOfPrevious, Pointer.pointerToCString(input), input.length());
+    }
+}

--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterParser.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/treesitter/TreeSitterParser.java
@@ -2,6 +2,8 @@ package org.spoofax.jsglr2.benchmark.treesitter;
 
 import static com.github.mpsijm.javatreesitter.JavaTreeSitterLibrary.*;
 
+import java.util.function.Supplier;
+
 import org.bridj.Pointer;
 import org.spoofax.jsglr2.incremental.EditorUpdate;
 import org.spoofax.jsglr2.incremental.diff.IStringDiff;
@@ -10,8 +12,19 @@ import org.spoofax.jsglr2.incremental.diff.JGitHistogramDiff;
 import com.github.mpsijm.javatreesitter.JavaTreeSitterLibrary;
 import com.github.mpsijm.javatreesitter.TSInputEdit;
 import com.github.mpsijm.javatreesitter.TSLanguage;
+import com.github.mpsijm.javatreesitter.java.TreeSitterJavaLibrary;
 
 public class TreeSitterParser {
+    public enum SupportedLanguage {
+        JAVA(TreeSitterJavaLibrary::tree_sitter_java);
+
+        private final Supplier<Pointer<TSLanguage>> languageSupplier;
+
+        SupportedLanguage(Supplier<Pointer<TSLanguage>> languageSupplier) {
+            this.languageSupplier = languageSupplier;
+        }
+    }
+
     private final Pointer<JavaTreeSitterLibrary.TSParser> parser;
     private final IStringDiff diff;
 
@@ -19,6 +32,10 @@ public class TreeSitterParser {
         parser = ts_parser_new();
         ts_parser_set_language(parser, language);
         diff = new JGitHistogramDiff();
+    }
+
+    public TreeSitterParser(SupportedLanguage language) {
+        this(language.languageSupplier.get());
     }
 
     public Pointer<TSTree> parse(String input) {

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/testset/TestSet.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/testset/TestSet.java
@@ -44,7 +44,7 @@ public class TestSet<ContentType, Input extends TestInput<ContentType>> {
             return new TestSet<>(language, input);
         }
 
-        throw new IllegalStateException("invalid arguments");
+        throw new IllegalStateException("invalid arguments: missing language (" + args + ")");
     }
 
     public static TestSetWithParseTable<String, StringInput> fromArgsWithParseTable(Map<String, String> args) {

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/testset/TestSetIncrementalMultipleInput.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/testset/TestSetIncrementalMultipleInput.java
@@ -15,8 +15,8 @@ public class TestSetIncrementalMultipleInput extends TestSetMultipleInputs<Strin
     public static TestSetIncrementalMultipleInput fromArgsIncremental(Map<String, String> args) {
         String sourcePath = args.get("sourcePath");
         String extension = args.get("extension");
-        int[] versions = args.containsKey("iteration")
-            ? versionsFromIteration(Integer.parseInt(args.get("iteration"))) : args.containsKey("versions")
+        int[] versions = args.containsKey("iteration") ? versionsFromIteration(Integer.parseInt(args.get("iteration")))
+            : args.containsKey("versions")
                 ? Arrays.stream(args.get("versions").split(",")).mapToInt(Integer::parseInt).toArray() : null;
         return new TestSetIncrementalMultipleInput(sourcePath, extension, versions);
     }
@@ -56,7 +56,7 @@ public class TestSetIncrementalMultipleInput extends TestSetMultipleInputs<Strin
                         path + (path.endsWith(File.separator) ? "" : File.separator) + i + File.separator + filename));
                     versionInputs[k++] = input;
                 } catch(NullPointerException | IOException ignored) {
-                    versionInputs[k] = k > 0 ? versionInputs[k - 1] : "";
+                    versionInputs[k] = k > 0 ? versionInputs[k - 1] : null;
                     k++;
                 }
             }

--- a/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/testset/TestSetInput.java
+++ b/org.spoofax.jsglr2.integration/src/main/java/org/spoofax/jsglr2/testset/TestSetInput.java
@@ -28,13 +28,19 @@ public abstract class TestSetInput<ContentType, Input extends TestInput<ContentT
         String sourcePath = args.get("sourcePath");
         String extension = args.get("extension");
 
-        if("multiple".equals(type) && sourcePath != null && extension != null) {
-            return new TestSetMultipleInputs.StringInputSet(sourcePath, extension);
-        } else if("single".equals(type) && sourcePath != null) {
-            return new TestSetSingleInput.StringInputSet(sourcePath, false);
-        }
+        if(sourcePath == null)
+            throw new IllegalStateException("invalid arguments: missing sourcePath (" + args + ")");
 
-        throw new IllegalStateException("invalid arguments");
+        switch(type) {
+            case "multiple":
+                if(extension == null)
+                    throw new IllegalStateException("invalid arguments: missing extension (" + args + ")");
+                return new TestSetMultipleInputs.StringInputSet(sourcePath, extension);
+            case "single":
+                return new TestSetSingleInput.StringInputSet(sourcePath, false);
+            default:
+                throw new IllegalStateException("invalid arguments: missing type=(singular|multiple) (" + args + ")");
+        }
     }
 
     protected abstract Input getInput(String filename, ContentType input);


### PR DESCRIPTION
To be merged together with metaborg/jsglr2evaluation#4.

To run the TreeSitter benchmarks, you'll have to manually run `mvn install` for https://github.com/mpsijm/java-tree-sitter before building the benchmark JAR. Note that I've only tested this on Linux.

Benchmark results with this code are available at https://metaborg.github.io/jsglr2evaluation-site/2020-12-23%2023:59/index.html. Note that only the results for Java are shown, I still have to fix that bug :upside_down_face: 