### PR TITLE
Origin Tracking Bugfix

### DIFF
--- a/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/origin/OriginSublistTermPrimitive.java
+++ b/org.spoofax.interpreter.library.jsglr/src/main/java/org/spoofax/interpreter/library/jsglr/origin/OriginSublistTermPrimitive.java
@@ -57,6 +57,9 @@ public class OriginSublistTermPrimitive extends AbstractPrimitive {
 				break;
 			}
 		}
+		if (startIndex < 0) {
+			return false;
+		}
 		for (int i = 0; i < list.size(); i++) {
 			if(childNodes.size()<=i+startIndex)
 				return false;


### PR DESCRIPTION
This bug was discovered when using the `construct-textual-change` strategy, to perform a layout-preserving transformation (renaming). It'ts likely this simply has never been used with a current language project, as the code is like 15 years old.

Here's the strategy that failed before this bugfix:
```    	
  rename-action-2 :
    (selected-term, _, ast, path, project-path) -> (filename, result)
    where
    	analysis := <nabl2-get-ast-analysis> ast;
        <not(nabl2-analysis-has-errors)> analysis
    with
        new-name := <read-new-name> path
	; renamed-ast := <rename(|selected-term, new-name, path)
	; filename := <compose-filename> path
	; (_, _, result) := <construct-textual-change> (ast, renamed-ast)
```