### PR TITLE
Add Elkhound to incremental benchmarks

### DIFF
--- a/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncremental.java
+++ b/org.spoofax.jsglr2.benchmark/src/main/java/org/spoofax/jsglr2/benchmark/jsglr2/JSGLR2BenchmarkIncremental.java
@@ -1,8 +1,5 @@
 package org.spoofax.jsglr2.benchmark.jsglr2;
 
-import static org.spoofax.jsglr2.JSGLR2Variant.Preset.incremental;
-import static org.spoofax.jsglr2.JSGLR2Variant.Preset.standard;
-
 import java.util.*;
 
 import org.openjdk.jmh.annotations.Param;
@@ -15,10 +12,13 @@ import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parser.ParseException;
 import org.spoofax.jsglr2.testset.testinput.IncrementalStringInput;
 
+import static org.spoofax.jsglr2.JSGLR2Variant.Preset.*;
+
 public abstract class JSGLR2BenchmarkIncremental extends JSGLR2Benchmark<String[], IncrementalStringInput> {
 
     public enum ParserType {
         Batch(false, new IntegrationVariant(standard.variant)),
+        Elkhound(false, new IntegrationVariant(elkhound.variant)),
         Incremental(true, new IntegrationVariant(incremental.variant)),
         IncrementalNoCache(false, new IntegrationVariant(incremental.variant));
 
@@ -31,7 +31,7 @@ public abstract class JSGLR2BenchmarkIncremental extends JSGLR2Benchmark<String[
         }
     }
 
-    @Param({ "Batch", "Incremental", "IncrementalNoCache" }) public ParserType parserType;
+    @Param({ "Batch", "Elkhound", "Incremental", "IncrementalNoCache" }) public ParserType parserType;
 
     @Param({ "-1" }) public int i;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/ParseException.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/ParseException.java
@@ -28,10 +28,11 @@ public class ParseException extends Exception {
 
         if(position != null)
             message.append(
-                " at offset " + position.offset + "(line " + position.line + ", column " + position.column + ")");
+                " at offset " + position.offset + " (line " + position.line + ", column " + position.column + ")");
 
         if(character != null)
-            message.append(" at character " + CharacterClassFactory.intToString(character));
+            message.append(
+                String.format(" at character %s (U+%04X)", CharacterClassFactory.intToString(character), character));
 
         return message.toString();
     }


### PR DESCRIPTION
Two small updates that accompany the changes in metaborg/jsglr2evaluation#6. The don't necessarily depend on each other, though :slightly_smiling_face: 

- I've added the Elkhound parser to the incremental benchmarks.
- While debugging the encoding issue described in metaborg/jsglr2evaluation#6, it seemed like a good idea to print the Unicode value of the current character in the message of a `ParseException`. I left this in, who knows when it comes in handy again :stuck_out_tongue: The value is printed as `U+XXXX`, e.g. the letter `J` is `U+004A`.