### PR TITLE
Incremental Parsing Measurements

### DIFF
--- a/org.spoofax.jsglr2.measure/pom.xml
+++ b/org.spoofax.jsglr2.measure/pom.xml
@@ -36,14 +36,24 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>batch</id>
                         <goals>
                             <goal>java</goal>
                         </goals>
+                        <configuration>
+                            <mainClass>org.spoofax.jsglr2.measure.JSGLR2Measurements</mainClass>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>incremental</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.spoofax.jsglr2.measure.JSGLR2MeasurementsIncremental</mainClass>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <mainClass>org.spoofax.jsglr2.measure.JSGLR2Measurements</mainClass>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/CSV.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/CSV.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CSV<T> {
 
@@ -37,15 +38,15 @@ public class CSV<T> {
     }
 
     private void writeHeader(PrintWriter out) {
-        writeLine(out, columns.stream().map(T::toString).collect(Collectors.toList()));
+        writeLine(out, columns.stream().map(T::toString));
     }
 
     private void writeRow(PrintWriter out, Map<T, String> row) {
-        writeLine(out, columns.stream().map(column -> row.getOrDefault(column, "")).collect(Collectors.toList()));
+        writeLine(out, columns.stream().map(column -> row.getOrDefault(column, "")));
     }
 
-    private void writeLine(PrintWriter out, List<String> row) {
-        out.println(String.join(",", row));
+    private void writeLine(PrintWriter out, Stream<String> row) {
+        out.println(row.collect(Collectors.joining(",")));
     }
 
 }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/Config.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/Config.java
@@ -1,0 +1,24 @@
+package org.spoofax.jsglr2.measure;
+
+import org.spoofax.jsglr2.testset.TestSet;
+import org.spoofax.jsglr2.testset.TestSetWithParseTable;
+import org.spoofax.jsglr2.testset.testinput.TestInput;
+
+public class Config<ContentType, Input extends TestInput<ContentType>> {
+
+    final Iterable<TestSetWithParseTable<ContentType, Input>> testSets;
+    final boolean prefix;
+
+    Config(Iterable<TestSetWithParseTable<ContentType, Input>> testSets, boolean prefix) {
+        this.testSets = testSets;
+        this.prefix = prefix;
+    }
+
+    public String prefix(TestSet<ContentType, Input> testSet) {
+        if (prefix)
+            return JSGLR2Measurements.REPORT_PATH + "/" + testSet.name + "_";
+        else
+            return JSGLR2Measurements.REPORT_PATH + "/";
+    }
+
+}

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/JSGLR2Measurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/JSGLR2Measurements.java
@@ -13,16 +13,19 @@ import org.spoofax.jsglr2.testset.testinput.StringInput;
 
 public class JSGLR2Measurements {
 
-    private static String REPORT_PATH = System.getProperty("reportPath", "~/jsglr2measurements");
-
-    public static void main(String[] args) throws ParseTableReadException, IOException {
-        if(REPORT_PATH.startsWith("~" + File.separator)) {
-            REPORT_PATH = System.getProperty("user.home") + REPORT_PATH.substring(1);
+    static final String REPORT_PATH;
+    static {
+        String reportPath = System.getProperty("reportPath", "~/jsglr2measurements");
+        if(reportPath.startsWith("~" + File.separator)) {
+            reportPath = System.getProperty("user.home") + reportPath.substring(1);
         }
+        REPORT_PATH = reportPath;
 
         new File(REPORT_PATH).mkdirs();
+    }
 
-        Config config = getConfig(args);
+    public static void main(String[] args) throws ParseTableReadException, IOException {
+        Config<String, StringInput> config = getConfig(args);
 
         for(TestSetWithParseTable<String, StringInput> testSet : config.testSets) {
             if(config.prefix)
@@ -33,35 +36,14 @@ public class JSGLR2Measurements {
         }
     }
 
-    private static Config getConfig(String[] arg) {
-        if(arg.length == 0)
-            return new Config(TestSet.all, true);
-        else if(arg.length == 1) {
-            String[] args = arg[0].split(" ");
-
-            return new Config(Collections.singleton(TestSet.fromArgsWithParseTable(TestSet.parseArgs(args))), false);
-        }
+    private static Config<String, StringInput> getConfig(String[] args) {
+        if(args.length == 0)
+            return new Config<>(TestSet.all, true);
+        else if(args.length == 1)
+            return new Config<>(
+                Collections.singleton(TestSet.fromArgsWithParseTable(TestSet.parseArgs(args[0].split(" ")))), false);
 
         throw new IllegalStateException("invalid arguments");
-    }
-
-    public static class Config {
-
-        final Iterable<TestSetWithParseTable<String, StringInput>> testSets;
-        final boolean prefix;
-
-        Config(Iterable<TestSetWithParseTable<String, StringInput>> testSets, boolean prefix) {
-            this.testSets = testSets;
-            this.prefix = prefix;
-        }
-
-        public String prefix(TestSet testSet) {
-            if(prefix)
-                return JSGLR2Measurements.REPORT_PATH + "/" + testSet.name + "_";
-            else
-                return JSGLR2Measurements.REPORT_PATH + "/";
-        }
-
     }
 
 }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/JSGLR2MeasurementsIncremental.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/JSGLR2MeasurementsIncremental.java
@@ -1,0 +1,63 @@
+package org.spoofax.jsglr2.measure;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.metaborg.parsetable.ParseTableReadException;
+import org.metaborg.util.iterators.Iterables2;
+import org.spoofax.jsglr2.measure.incremental.IncrementalParsingMeasurements;
+import org.spoofax.jsglr2.measure.parsetable.ParseTableMeasurements;
+import org.spoofax.jsglr2.measure.parsing.ParsingMeasurements;
+import org.spoofax.jsglr2.testset.TestSet;
+import org.spoofax.jsglr2.testset.TestSetInput;
+import org.spoofax.jsglr2.testset.TestSetWithParseTable;
+import org.spoofax.jsglr2.testset.testinput.IncrementalStringInput;
+import org.spoofax.jsglr2.testset.testinput.StringInput;
+
+public class JSGLR2MeasurementsIncremental {
+
+    public static void main(String[] args) throws ParseTableReadException, IOException {
+        if(args.length != 1) {
+            throw new IllegalStateException("invalid arguments");
+        }
+
+        Config<String[], IncrementalStringInput> config = new Config<>(
+            Collections.singleton(TestSet.fromArgsWithParseTableIncremental(TestSet.parseArgs(args[0].split(" ")))),
+            false);
+        Config<String, StringInput> configBatch = configFromLastVersion(config);
+
+        for(TestSetWithParseTable<String[], IncrementalStringInput> testSet : config.testSets) {
+            if(config.prefix)
+                System.out.println(testSet.name);
+
+            new ParseTableMeasurements(testSetFromLastVersion(testSet)).measure(configBatch);
+            new ParsingMeasurements(testSetFromLastVersion(testSet)).measure(configBatch);
+            new IncrementalParsingMeasurements(testSet).measure(config);
+        }
+    }
+
+    private static Config<String, StringInput> configFromLastVersion(Config<String[], IncrementalStringInput> config) {
+        return new Config<>(Iterables2.stream(config.testSets)
+            .map(JSGLR2MeasurementsIncremental::testSetFromLastVersion).collect(Collectors.toList()), config.prefix);
+    }
+
+    private static TestSetWithParseTable<String, StringInput>
+        testSetFromLastVersion(TestSetWithParseTable<String[], IncrementalStringInput> testSet) {
+        return new TestSetWithParseTable<>(testSet.name, testSet.parseTable,
+            new TestSetInput<String, StringInput>(TestSetInput.Type.MULTIPLE, false) {
+                @Override protected StringInput getInput(String filename, String input) {
+                    return new StringInput(filename, input);
+                }
+
+                @Override public List<StringInput> getInputs() throws IOException {
+                    return testSet.input.getInputs().stream()
+                        .map(incrementalInput -> getInput(incrementalInput.fileName,
+                            incrementalInput.content[incrementalInput.content.length - 1]))
+                        .collect(Collectors.toList());
+                }
+            });
+    }
+
+}

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/Measurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/Measurements.java
@@ -4,18 +4,18 @@ import java.io.IOException;
 
 import org.metaborg.parsetable.ParseTableReadException;
 import org.spoofax.jsglr2.testset.TestSetWithParseTable;
-import org.spoofax.jsglr2.testset.testinput.StringInput;
+import org.spoofax.jsglr2.testset.testinput.TestInput;
 
-public abstract class Measurements {
+public abstract class Measurements<ContentType, Input extends TestInput<ContentType>> {
 
-    protected TestSetWithParseTable<String, StringInput> testSet;
-    protected MeasureTestSetWithParseTableReader<String, StringInput> testSetReader;
+    protected TestSetWithParseTable<ContentType, Input> testSet;
+    protected MeasureTestSetWithParseTableReader<ContentType, Input> testSetReader;
 
-    public Measurements(TestSetWithParseTable<String, StringInput> testSet) {
+    public Measurements(TestSetWithParseTable<ContentType, Input> testSet) {
         this.testSet = testSet;
         this.testSetReader = new MeasureTestSetWithParseTableReader<>(testSet);
     }
 
-    protected abstract void measure(JSGLR2Measurements.Config config) throws ParseTableReadException, IOException;
+    protected abstract void measure(Config<ContentType, Input> config) throws ParseTableReadException, IOException;
 
 }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParserMeasureObserver.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParserMeasureObserver.java
@@ -1,0 +1,55 @@
+package org.spoofax.jsglr2.measure.incremental;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+
+import org.metaborg.parsetable.productions.IProduction;
+import org.spoofax.jsglr2.incremental.IIncrementalParseState;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalDerivation;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.inputstack.incremental.IIncrementalInputStack;
+import org.spoofax.jsglr2.parser.AbstractParseState;
+import org.spoofax.jsglr2.parser.ForShifterElement;
+import org.spoofax.jsglr2.parser.observing.IParserObserver;
+import org.spoofax.jsglr2.stack.IStackNode;
+
+public class IncrementalParserMeasureObserver
+//@formatter:off
+   <StackNode     extends IStackNode,
+    ParseState    extends AbstractParseState<IIncrementalInputStack, StackNode> & IIncrementalParseState>
+//@formatter:on
+    implements
+    IParserObserver<IncrementalParseForest, IncrementalDerivation, IncrementalParseNode, StackNode, ParseState> {
+
+    long createChar, createNode, shiftChar, shiftNode;
+    Map<IParserObserver.BreakdownReason, Long> breakdown = new HashMap<>();
+
+    @Override public void parseStart(ParseState parse) {
+        breakdown.clear();
+        createChar = 0;
+        createNode = 0;
+        shiftChar = 0;
+        shiftNode = 0;
+    }
+
+    @Override public void createParseNode(IncrementalParseNode parseNode, IProduction production) {
+        createNode++;
+    }
+
+    @Override public void createCharacterNode(IncrementalParseForest characterNode, int character) {
+        createChar++;
+    }
+
+    @Override public void shifter(IncrementalParseForest termNode, Queue<ForShifterElement<StackNode>> forShifter) {
+        if(termNode instanceof IncrementalParseNode)
+            shiftNode++;
+        else
+            shiftChar++;
+    }
+
+    @Override public void breakDown(IIncrementalInputStack inputStack, IParserObserver.BreakdownReason reason) {
+        breakdown.merge(reason, 1L, Long::sum);
+    }
+}

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurement.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurement.java
@@ -1,0 +1,11 @@
+package org.spoofax.jsglr2.measure.incremental;
+
+public enum IncrementalParsingMeasurement {
+    version,
+
+    parseNodes, parseNodesAmbiguous, parseNodesNonDeterministic, parseNodesReused, parseNodesRebuilt, //
+    characterNodes, characterNodesReused,
+
+    createCharacterNode, createParseNode, shiftCharacterNode, shiftParseNode, //
+    breakDownNoActions, breakDownNonDeterministic, breakDownWrongState
+}

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurement.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurement.java
@@ -7,5 +7,5 @@ public enum IncrementalParsingMeasurement {
     characterNodes, characterNodesReused,
 
     createCharacterNode, createParseNode, shiftCharacterNode, shiftParseNode, //
-    breakDowns, breakDownNoActions, breakDownNonDeterministic, breakDownTemporary, breakDownWrongState
+    breakDowns, breakDownIrreusable, breakDownNoActions, breakDownTemporary, breakDownWrongState
 }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurement.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurement.java
@@ -7,5 +7,5 @@ public enum IncrementalParsingMeasurement {
     characterNodes, characterNodesReused,
 
     createCharacterNode, createParseNode, shiftCharacterNode, shiftParseNode, //
-    breakDownNoActions, breakDownNonDeterministic, breakDownWrongState
+    breakDowns, breakDownNoActions, breakDownNonDeterministic, breakDownWrongState
 }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurement.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurement.java
@@ -7,5 +7,5 @@ public enum IncrementalParsingMeasurement {
     characterNodes, characterNodesReused,
 
     createCharacterNode, createParseNode, shiftCharacterNode, shiftParseNode, //
-    breakDowns, breakDownNoActions, breakDownNonDeterministic, breakDownWrongState
+    breakDowns, breakDownNoActions, breakDownNonDeterministic, breakDownTemporary, breakDownWrongState
 }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
@@ -127,11 +127,10 @@ public class IncrementalParsingMeasurements extends Measurements<String[], Incre
                         return measureObserver.shiftNode;
                     case breakDowns:
                         return measureObserver.breakdown.values().stream().mapToLong(l -> l).sum();
+                    case breakDownIrreusable:
+                        return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.IRREUSABLE, 0L);
                     case breakDownNoActions:
                         return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.NO_ACTIONS, 0L);
-                    case breakDownNonDeterministic:
-                        return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.NON_DETERMINISTIC,
-                            0L);
                     case breakDownTemporary:
                         return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.TEMPORARY, 0L);
                     case breakDownWrongState:
@@ -196,7 +195,7 @@ public class IncrementalParsingMeasurements extends Measurements<String[], Incre
                         rebuilt++;
                         rebuiltSet.add(parent);
                         parent = parents.get(parent);
-                        if (parent == null) // At this point, we reached the root node
+                        if(parent == null) // At this point, we reached the root node
                             break;
                     }
                 }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
@@ -78,6 +78,8 @@ public class IncrementalParsingMeasurements extends Measurements<String[], Incre
                 IncrementalParseForest previousResult = null;
                 for(int i = 0; i < input.content.length; i++) {
                     String content = input.content[i];
+                    if(content == null)
+                        continue;
                     IncrementalParseForest result;
                     try {
                         result = ((ParseSuccess<IncrementalParseForest>) parser.parse(
@@ -145,20 +147,22 @@ public class IncrementalParsingMeasurements extends Measurements<String[], Incre
         long nodes = 0, leaves = 0, ambs = 0, nondets = 0, reusedNodes = 0, reusedLeaves = 0, rebuilt = 0;
         Set<IParseForest> nodeSet = new HashSet<>(), leafSet = new HashSet<>();
 
-        Stack<IParseForest> todo1 = new Stack<>();
-        todo1.add(parse1);
-        while(!todo1.isEmpty()) {
-            IParseForest t1 = todo1.pop();
-            if(t1 instanceof IParseNode) {
-                nodeSet.add(t1);
-                if(!(t1 instanceof IncrementalSkippedNode)) {
-                    IParseForest[] sub1 = ((IParseNode<?, ?>) t1).getFirstDerivation().parseForests();
-                    for(int i = sub1.length - 1; i >= 0; i--) {
-                        todo1.add(sub1[i]);
+        if(parse1 != null) {
+            Stack<IParseForest> todo1 = new Stack<>();
+            todo1.add(parse1);
+            while(!todo1.isEmpty()) {
+                IParseForest t1 = todo1.pop();
+                if(t1 instanceof IParseNode) {
+                    nodeSet.add(t1);
+                    if(!(t1 instanceof IncrementalSkippedNode)) {
+                        IParseForest[] sub1 = ((IParseNode<?, ?>) t1).getFirstDerivation().parseForests();
+                        for(int i = sub1.length - 1; i >= 0; i--) {
+                            todo1.add(sub1[i]);
+                        }
                     }
+                } else {
+                    leafSet.add(t1);
                 }
-            } else {
-                leafSet.add(t1);
             }
         }
 

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
@@ -132,6 +132,8 @@ public class IncrementalParsingMeasurements extends Measurements<String[], Incre
                     case breakDownNonDeterministic:
                         return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.NON_DETERMINISTIC,
                             0L);
+                    case breakDownTemporary:
+                        return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.TEMPORARY, 0L);
                     case breakDownWrongState:
                         return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.WRONG_STATE, 0L);
                     default:

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
@@ -1,0 +1,211 @@
+package org.spoofax.jsglr2.measure.incremental;
+
+import static org.spoofax.jsglr2.measure.incremental.IncrementalParsingMeasurement.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.metaborg.parsetable.IParseTable;
+import org.metaborg.parsetable.ParseTableReadException;
+import org.metaborg.parsetable.ParseTableReader;
+import org.spoofax.jsglr2.JSGLR2Request;
+import org.spoofax.jsglr2.JSGLR2Variant;
+import org.spoofax.jsglr2.incremental.IIncrementalParseState;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalDerivation;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.incremental.parseforest.IncrementalSkippedNode;
+import org.spoofax.jsglr2.inputstack.incremental.IIncrementalInputStack;
+import org.spoofax.jsglr2.measure.CSV;
+import org.spoofax.jsglr2.measure.Config;
+import org.spoofax.jsglr2.measure.Measurements;
+import org.spoofax.jsglr2.parseforest.IParseForest;
+import org.spoofax.jsglr2.parseforest.IParseNode;
+import org.spoofax.jsglr2.parser.AbstractParseState;
+import org.spoofax.jsglr2.parser.IObservableParser;
+import org.spoofax.jsglr2.parser.ParserVariant;
+import org.spoofax.jsglr2.parser.observing.IParserObserver;
+import org.spoofax.jsglr2.parser.result.ParseSuccess;
+import org.spoofax.jsglr2.stack.IStackNode;
+import org.spoofax.jsglr2.testset.TestSetWithParseTable;
+import org.spoofax.jsglr2.testset.testinput.IncrementalStringInput;
+
+public class IncrementalParsingMeasurements extends Measurements<String[], IncrementalStringInput> {
+
+    public IncrementalParsingMeasurements(TestSetWithParseTable<String[], IncrementalStringInput> testSet) {
+        super(testSet);
+    }
+
+    @Override public void measure(Config<String[], IncrementalStringInput> config)
+        throws ParseTableReadException, IOException {
+        CSV<IncrementalParsingMeasurement> output = new CSV<>(IncrementalParsingMeasurement.values());
+
+        IParseTable parseTable = new ParseTableReader().read(testSetReader.getParseTableTerm());
+
+        ParserVariant variantIncremental = JSGLR2Variant.Preset.incremental.variant.parser;
+
+        output.addRows(measure(variantIncremental, parseTable, new IncrementalParserMeasureObserver<>()));
+
+        output.write(config.prefix(testSet) + "parsing-incremental.csv");
+    }
+
+    private
+//@formatter:off
+   <StackNode  extends IStackNode,
+    ParseState extends AbstractParseState<IIncrementalInputStack, StackNode> & IIncrementalParseState>
+//@formatter:on
+    List<Map<IncrementalParsingMeasurement, String>> measure(ParserVariant variant, IParseTable parseTable,
+        IncrementalParserMeasureObserver<StackNode, ParseState> measureObserver) throws IOException {
+        return testSetReader.getInputBatches().flatMap(inputBatch -> {
+            @SuppressWarnings("unchecked") IObservableParser<IncrementalParseForest, IncrementalDerivation, IncrementalParseNode, StackNode, ParseState> parser =
+                (IObservableParser<IncrementalParseForest, IncrementalDerivation, IncrementalParseNode, StackNode, ParseState>) variant
+                    .getParser(parseTable);
+
+            parser.observing().attachObserver(measureObserver);
+
+            int versionCount = inputBatch.inputs.iterator().next().content.length;
+
+            List<Map<IncrementalParsingMeasurement, Long>> output = new ArrayList<>();
+            for(int i = 0; i < versionCount; i++) {
+                output.add(new HashMap<>());
+            }
+
+            for(IncrementalStringInput input : inputBatch.inputs) {
+                String previousInput = null;
+                IncrementalParseForest previousResult = null;
+                for(int i = 0; i < input.content.length; i++) {
+                    String content = input.content[i];
+                    IncrementalParseForest result;
+                    try {
+                        result = ((ParseSuccess<IncrementalParseForest>) parser.parse(
+                            new JSGLR2Request(content, input.fileName, null), previousInput,
+                            previousResult)).parseResult;
+                    } catch(Exception e) {
+                        throw new IllegalStateException("Parsing failed with variant " + variant.name() + ": "
+                            + e.getClass().getSimpleName() + ": " + e.getMessage());
+                    }
+                    output.set(i, addToOutput(output.get(i), previousResult, result, measureObserver));
+                    previousInput = content;
+                    previousResult = result;
+                }
+            }
+
+            return IntStream.range(0, versionCount).mapToObj(i -> {
+                Map<IncrementalParsingMeasurement, String> stringMap = output.get(i).entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+                stringMap.put(IncrementalParsingMeasurement.version, Integer.toString(i));
+                return stringMap;
+            });
+        }).collect(Collectors.toList());
+    }
+
+    private
+//@formatter:off
+   <StackNode  extends IStackNode,
+    ParseState extends AbstractParseState<IIncrementalInputStack, StackNode> & IIncrementalParseState>
+//@formatter:on
+    Map<IncrementalParsingMeasurement, Long> addToOutput(Map<IncrementalParsingMeasurement, Long> output,
+        IncrementalParseForest previousResult, IncrementalParseForest result,
+        IncrementalParserMeasureObserver<StackNode, ParseState> measureObserver) {
+
+        calculateReuse(previousResult, result).forEach((k, v) -> output.merge(k, v, Long::sum));
+
+        Arrays.stream(IncrementalParsingMeasurement.values())
+            .collect(Collectors.toMap(Function.identity(), measurement -> {
+                switch(measurement) {
+                    case createCharacterNode:
+                        return measureObserver.createChar;
+                    case createParseNode:
+                        return measureObserver.createNode;
+                    case shiftCharacterNode:
+                        return measureObserver.shiftChar;
+                    case shiftParseNode:
+                        return measureObserver.shiftNode;
+                    case breakDownNoActions:
+                        return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.NO_ACTIONS, 0L);
+                    case breakDownNonDeterministic:
+                        return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.NON_DETERMINISTIC,
+                            0L);
+                    case breakDownWrongState:
+                        return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.WRONG_STATE, 0L);
+                    default:
+                        return -1L;
+                }
+            })).forEach((k, v) -> {
+                if(v >= 0)
+                    output.merge(k, v, Long::sum);
+            });
+        return output;
+    }
+
+    private static Map<IncrementalParsingMeasurement, Long> calculateReuse(IParseForest parse1, IParseForest parse2) {
+        long nodes = 0, leaves = 0, ambs = 0, nondets = 0, reusedNodes = 0, reusedLeaves = 0, rebuilt = 0;
+        Set<IParseForest> nodeSet = new HashSet<>(), leafSet = new HashSet<>();
+
+        Stack<IParseForest> todo1 = new Stack<>();
+        todo1.add(parse1);
+        while(!todo1.isEmpty()) {
+            IParseForest t1 = todo1.pop();
+            if(t1 instanceof IParseNode) {
+                nodeSet.add(t1);
+                if(!(t1 instanceof IncrementalSkippedNode)) {
+                    IParseForest[] sub1 = ((IParseNode<?, ?>) t1).getFirstDerivation().parseForests();
+                    for(int i = sub1.length - 1; i >= 0; i--) {
+                        todo1.add(sub1[i]);
+                    }
+                }
+            } else {
+                leafSet.add(t1);
+            }
+        }
+
+        Map<IParseForest, IParseNode<?, ?>> parents = new HashMap<>();
+        Stack<IParseForest> todo2 = new Stack<>();
+        todo2.add(parse2);
+        while(!todo2.isEmpty()) {
+            IParseForest t2 = todo2.pop();
+            if(t2 instanceof IParseNode) {
+                nodes++;
+                if(nodeSet.contains(t2))
+                    reusedNodes++;
+                IParseNode<?, ?> t2Node = (IParseNode<?, ?>) t2;
+                if(t2Node.isAmbiguous())
+                    ambs++;
+                if(!((IncrementalParseForest) t2Node).isReusable())
+                    nondets++;
+                if(!(t2 instanceof IncrementalSkippedNode)) {
+                    IParseForest[] sub2 = t2Node.getFirstDerivation().parseForests();
+                    for(int i = sub2.length - 1; i >= 0; i--) {
+                        parents.put(sub2[i], t2Node);
+                        todo2.add(sub2[i]);
+                    }
+                    IParseNode<?, ?> parent = t2Node;
+                    while(!nodeSet.contains(parent) && parent.getFirstDerivation().parseForests().length > 0
+                        && Arrays.stream(parent.getFirstDerivation().parseForests()).allMatch(nodeSet::contains)) {
+                        rebuilt++;
+                        nodeSet.add(parent);
+                        parent = parents.get(parent);
+                    }
+                }
+            } else {
+                leaves++;
+                if(leafSet.contains(t2))
+                    reusedLeaves++;
+            }
+        }
+
+        Map<IncrementalParsingMeasurement, Long> output = new HashMap<>();
+        output.put(parseNodesAmbiguous, ambs);
+        output.put(parseNodesNonDeterministic, nondets);
+        output.put(parseNodes, nodes);
+        output.put(parseNodesReused, reusedNodes);
+        output.put(parseNodesRebuilt, rebuilt);
+        output.put(characterNodes, leaves);
+        output.put(characterNodesReused, reusedLeaves);
+        return output;
+    }
+
+}

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
@@ -12,7 +12,6 @@ import org.metaborg.parsetable.IParseTable;
 import org.metaborg.parsetable.ParseTableReadException;
 import org.metaborg.parsetable.ParseTableReader;
 import org.spoofax.jsglr2.JSGLR2Request;
-import org.spoofax.jsglr2.JSGLR2Variant;
 import org.spoofax.jsglr2.incremental.IIncrementalParseState;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalDerivation;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
@@ -22,6 +21,7 @@ import org.spoofax.jsglr2.inputstack.incremental.IIncrementalInputStack;
 import org.spoofax.jsglr2.measure.CSV;
 import org.spoofax.jsglr2.measure.Config;
 import org.spoofax.jsglr2.measure.Measurements;
+import org.spoofax.jsglr2.measure.parsing.ParsingMeasurements;
 import org.spoofax.jsglr2.parseforest.IParseForest;
 import org.spoofax.jsglr2.parseforest.IParseNode;
 import org.spoofax.jsglr2.parser.AbstractParseState;
@@ -45,9 +45,8 @@ public class IncrementalParsingMeasurements extends Measurements<String[], Incre
 
         IParseTable parseTable = new ParseTableReader().read(testSetReader.getParseTableTerm());
 
-        ParserVariant variantIncremental = JSGLR2Variant.Preset.incremental.variant.parser;
-
-        output.addRows(measure(variantIncremental, parseTable, new IncrementalParserMeasureObserver<>()));
+        output.addRows(
+            measure(ParsingMeasurements.variantIncremental, parseTable, new IncrementalParserMeasureObserver<>()));
 
         output.write(config.prefix(testSet) + "parsing-incremental.csv");
     }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
@@ -125,6 +125,8 @@ public class IncrementalParsingMeasurements extends Measurements<String[], Incre
                         return measureObserver.shiftChar;
                     case shiftParseNode:
                         return measureObserver.shiftNode;
+                    case breakDowns:
+                        return measureObserver.breakdown.values().stream().mapToLong(l -> l).sum();
                     case breakDownNoActions:
                         return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.NO_ACTIONS, 0L);
                     case breakDownNonDeterministic:

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
@@ -148,7 +148,7 @@ public class IncrementalParsingMeasurements extends Measurements<String[], Incre
 
     private static Map<IncrementalParsingMeasurement, Long> calculateReuse(IParseForest parse1, IParseForest parse2) {
         long nodes = 0, leaves = 0, ambs = 0, nondets = 0, reusedNodes = 0, reusedLeaves = 0, rebuilt = 0;
-        Set<IParseForest> nodeSet = new HashSet<>(), leafSet = new HashSet<>();
+        Set<IParseForest> nodeSet = new HashSet<>(), leafSet = new HashSet<>(), rebuiltSet = new HashSet<>();
 
         if(parse1 != null) {
             Stack<IParseForest> todo1 = new Stack<>();
@@ -191,10 +191,13 @@ public class IncrementalParsingMeasurements extends Measurements<String[], Incre
                     }
                     IParseNode<?, ?> parent = t2Node;
                     while(!nodeSet.contains(parent) && parent.getFirstDerivation().parseForests().length > 0
-                        && Arrays.stream(parent.getFirstDerivation().parseForests()).allMatch(nodeSet::contains)) {
+                        && Arrays.stream(parent.getFirstDerivation().parseForests()).allMatch(c -> nodeSet.contains(c)
+                            || leafSet.contains(c) || rebuiltSet.contains(c) || c.width() == 0)) {
                         rebuilt++;
-                        nodeSet.add(parent);
+                        rebuiltSet.add(parent);
                         parent = parents.get(parent);
+                        if (parent == null) // At this point, we reached the root node
+                            break;
                     }
                 }
             } else {

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsetable/ParseTableMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsetable/ParseTableMeasurements.java
@@ -11,18 +11,18 @@ import org.metaborg.parsetable.ParseTableReader;
 import org.metaborg.parsetable.actions.ActionsFactory;
 import org.metaborg.parsetable.actions.IActionsFactory;
 import org.spoofax.jsglr2.measure.CSV;
-import org.spoofax.jsglr2.measure.JSGLR2Measurements;
+import org.spoofax.jsglr2.measure.Config;
 import org.spoofax.jsglr2.measure.Measurements;
 import org.spoofax.jsglr2.testset.TestSetWithParseTable;
 import org.spoofax.jsglr2.testset.testinput.StringInput;
 
-public class ParseTableMeasurements extends Measurements {
+public class ParseTableMeasurements extends Measurements<String, StringInput> {
 
     public ParseTableMeasurements(TestSetWithParseTable<String, StringInput> testSet) {
         super(testSet);
     }
 
-    @Override public void measure(JSGLR2Measurements.Config config)
+    @Override public void measure(Config<String, StringInput> config)
         throws FileNotFoundException, ParseTableReadException {
         CSV<ParseTableMeasurement> output = new CSV<>(ParseTableMeasurement.values());
 

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParserMeasureObserver.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParserMeasureObserver.java
@@ -113,7 +113,8 @@ abstract class ParserMeasureObserver
     }
 
     @Override public void createParseNode(ParseNode parseNode, IProduction production) {
-        parseNodes_.add(parseNode);
+        if(parseNode.production() != null) // Do not record temporary parse nodes created by the incremental parser
+            parseNodes_.add(parseNode);
     }
 
     @Override public void createCharacterNode(ParseForest characterNode, int character) {

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParsingMeasurements.java
@@ -110,8 +110,8 @@ public class ParsingMeasurements extends Measurements<String, StringInput> {
                 for(StringInput input : inputBatch.inputs)
                     parser.parse(new JSGLR2Request(input.content, input.fileName, null), null, null);
             } catch(Exception e) {
-                throw new IllegalStateException(
-                    "Parsing failed with variant " + variant.name() + ": " + e.getMessage());
+                throw new IllegalStateException("Parsing failed with variant " + variant.name() + ": "
+                    + e.getClass().getSimpleName() + ": " + e.getMessage());
             }
 
             return toOutput(name, inputBatch, measureActiveStacksFactory, measureForActorStacksFactory,

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParsingMeasurements.java
@@ -11,8 +11,9 @@ import org.metaborg.parsetable.IParseTable;
 import org.metaborg.parsetable.ParseTableReadException;
 import org.metaborg.parsetable.ParseTableReader;
 import org.spoofax.jsglr2.JSGLR2Request;
+import org.spoofax.jsglr2.JSGLR2Variant;
 import org.spoofax.jsglr2.measure.CSV;
-import org.spoofax.jsglr2.measure.JSGLR2Measurements;
+import org.spoofax.jsglr2.measure.Config;
 import org.spoofax.jsglr2.measure.MeasureTestSetWithParseTableReader;
 import org.spoofax.jsglr2.measure.Measurements;
 import org.spoofax.jsglr2.parseforest.*;
@@ -27,13 +28,13 @@ import org.spoofax.jsglr2.stack.collections.ForActorStacksRepresentation;
 import org.spoofax.jsglr2.testset.TestSetWithParseTable;
 import org.spoofax.jsglr2.testset.testinput.StringInput;
 
-public class ParsingMeasurements extends Measurements {
+public class ParsingMeasurements extends Measurements<String, StringInput> {
 
     public ParsingMeasurements(TestSetWithParseTable<String, StringInput> testSet) {
         super(testSet);
     }
 
-    @Override public void measure(JSGLR2Measurements.Config config) throws ParseTableReadException, IOException {
+    @Override public void measure(Config<String, StringInput> config) throws ParseTableReadException, IOException {
         CSV<ParsingMeasurement> output = new CSV<>(ParsingMeasurement.values());
 
         IParseTable parseTable = new ParseTableReader().read(testSetReader.getParseTableTerm());
@@ -126,7 +127,8 @@ public class ParsingMeasurements extends Measurements {
     StackNode   extends IStackNode,
     ParseState  extends AbstractParseState<?, StackNode>>
 //@formatter:on
-    Map<ParsingMeasurement, String> toOutput(String name, MeasureTestSetWithParseTableReader.InputBatch inputBatch,
+    Map<ParsingMeasurement, String> toOutput(String name,
+        MeasureTestSetWithParseTableReader<String, StringInput>.InputBatch inputBatch,
         MeasureActiveStacksFactory measureActiveStacksFactory,
         MeasureForActorStacksFactory measureForActorStacksFactory,
         ParserMeasureObserver<ParseForest, Derivation, ParseNode, StackNode, ParseState> measureObserver) {

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParsingMeasurements.java
@@ -78,9 +78,14 @@ public class ParsingMeasurements extends Measurements<String, StringInput> {
             );
         //@formatter:on
 
+        ParserVariant variantIncremental = JSGLR2Variant.Preset.incremental.variant.parser;
+
+        //@formatter:off
         output.addRows(measure("standard",     variantStandard,      parseTable, new StandardParserMeasureObserver<>()));
         output.addRows(measure("optimized-pf", optimizedParseForest, parseTable, new StandardParserMeasureObserver<>()));
         output.addRows(measure("elkhound",     variantElkhound,      parseTable, new ElkhoundParserMeasureObserver<>()));
+        output.addRows(measure("incremental",  variantIncremental,   parseTable, new StandardParserMeasureObserver<>()));
+        //@formatter:on
 
         output.write(config.prefix(testSet) + "parsing.csv");
     }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsing/ParsingMeasurements.java
@@ -11,7 +11,6 @@ import org.metaborg.parsetable.IParseTable;
 import org.metaborg.parsetable.ParseTableReadException;
 import org.metaborg.parsetable.ParseTableReader;
 import org.spoofax.jsglr2.JSGLR2Request;
-import org.spoofax.jsglr2.JSGLR2Variant;
 import org.spoofax.jsglr2.measure.CSV;
 import org.spoofax.jsglr2.measure.Config;
 import org.spoofax.jsglr2.measure.MeasureTestSetWithParseTableReader;
@@ -30,6 +29,58 @@ import org.spoofax.jsglr2.testset.testinput.StringInput;
 
 public class ParsingMeasurements extends Measurements<String, StringInput> {
 
+    public static final ParserVariant variantStandard =
+    //@formatter:off
+        new ParserVariant(
+            ActiveStacksRepresentation.ArrayList,
+            ForActorStacksRepresentation.ArrayDeque,
+            ParseForestRepresentation.Hybrid,
+            ParseForestConstruction.Full,
+            StackRepresentation.Hybrid,
+            Reducing.Basic,
+            false
+        );
+        //@formatter:on
+
+    public static final ParserVariant optimizedParseForest =
+    //@formatter:off
+        new ParserVariant(
+            ActiveStacksRepresentation.ArrayList,
+            ForActorStacksRepresentation.ArrayDeque,
+            ParseForestRepresentation.Hybrid,
+            ParseForestConstruction.Optimized,
+            StackRepresentation.Hybrid,
+            Reducing.Basic,
+            false
+        );
+        //@formatter:on
+
+    public static final ParserVariant variantElkhound =
+    //@formatter:off
+        new ParserVariant(
+            ActiveStacksRepresentation.ArrayList,
+            ForActorStacksRepresentation.ArrayDeque,
+            ParseForestRepresentation.Hybrid,
+            ParseForestConstruction.Full,
+            StackRepresentation.HybridElkhound,
+            Reducing.Elkhound,
+            false
+        );
+    //@formatter:on
+
+    public static final ParserVariant variantIncremental =
+    //@formatter:off
+        new ParserVariant(
+            ActiveStacksRepresentation.ArrayList,
+            ForActorStacksRepresentation.ArrayDeque,
+            ParseForestRepresentation.Incremental,
+            ParseForestConstruction.Full,
+            StackRepresentation.Hybrid,
+            Reducing.Incremental,
+            false
+        );
+    //@formatter:on
+
     public ParsingMeasurements(TestSetWithParseTable<String, StringInput> testSet) {
         super(testSet);
     }
@@ -38,47 +89,6 @@ public class ParsingMeasurements extends Measurements<String, StringInput> {
         CSV<ParsingMeasurement> output = new CSV<>(ParsingMeasurement.values());
 
         IParseTable parseTable = new ParseTableReader().read(testSetReader.getParseTableTerm());
-
-        ParserVariant variantStandard =
-        //@formatter:off
-            new ParserVariant(
-                ActiveStacksRepresentation.ArrayList,
-                ForActorStacksRepresentation.ArrayDeque,
-                ParseForestRepresentation.Hybrid,
-                ParseForestConstruction.Full,
-                StackRepresentation.Hybrid,
-                Reducing.Basic,
-                false
-            );
-            //@formatter:on
-
-        ParserVariant optimizedParseForest =
-        //@formatter:off
-            new ParserVariant(
-                ActiveStacksRepresentation.ArrayList,
-                ForActorStacksRepresentation.ArrayDeque,
-                ParseForestRepresentation.Hybrid,
-                ParseForestConstruction.Optimized,
-                StackRepresentation.Hybrid,
-                Reducing.Basic,
-                false
-            );
-            //@formatter:on
-
-        ParserVariant variantElkhound =
-        //@formatter:off
-            new ParserVariant(
-                ActiveStacksRepresentation.ArrayList,
-                ForActorStacksRepresentation.ArrayDeque,
-                ParseForestRepresentation.Hybrid,
-                ParseForestConstruction.Full,
-                StackRepresentation.HybridElkhound,
-                Reducing.Elkhound,
-                false
-            );
-        //@formatter:on
-
-        ParserVariant variantIncremental = JSGLR2Variant.Preset.incremental.variant.parser;
 
         //@formatter:off
         output.addRows(measure("standard",     variantStandard,      parseTable, new StandardParserMeasureObserver<>()));

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParser.java
@@ -25,6 +25,7 @@ import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 import org.spoofax.jsglr2.inputstack.incremental.IIncrementalInputStack;
 import org.spoofax.jsglr2.inputstack.incremental.IncrementalInputStackFactory;
 import org.spoofax.jsglr2.parseforest.Disambiguator;
+import org.spoofax.jsglr2.parseforest.IParseNode;
 import org.spoofax.jsglr2.parseforest.ParseForestManagerFactory;
 import org.spoofax.jsglr2.parser.AbstractParseState;
 import org.spoofax.jsglr2.parser.ParseReporterFactory;
@@ -113,7 +114,9 @@ public class IncrementalParser
             observing.notify(observer -> {
                 IncrementalParseForest node = parseState.inputStack.getNode();
                 observer.breakDown(parseState.inputStack,
-                    node.isReusable() ? node.isReusable(stack.state()) ? NO_ACTIONS : WRONG_STATE : NON_DETERMINISTIC);
+                    node instanceof IParseNode && ((IParseNode<?, ?>) node).production() == null ? TEMPORARY
+                        : node.isReusable() ? node.isReusable(stack.state()) ? NO_ACTIONS : WRONG_STATE
+                            : NON_DETERMINISTIC);
             });
             parseState.inputStack.breakDown();
             observing.notify(observer -> observer.parseRound(parseState, parseState.activeStacks));

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParser.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/IncrementalParser.java
@@ -116,7 +116,7 @@ public class IncrementalParser
                 observer.breakDown(parseState.inputStack,
                     node instanceof IParseNode && ((IParseNode<?, ?>) node).production() == null ? TEMPORARY
                         : node.isReusable() ? node.isReusable(stack.state()) ? NO_ACTIONS : WRONG_STATE
-                            : NON_DETERMINISTIC);
+                            : IRREUSABLE);
             });
             parseState.inputStack.breakDown();
             observing.notify(observer -> observer.parseRound(parseState, parseState.activeStacks));

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseNode.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/incremental/parseforest/IncrementalParseNode.java
@@ -107,7 +107,7 @@ public class IncrementalParseNode extends IncrementalParseForest
         if(production == null)
             printer.println("p null {");
         else
-            printer.println("p" + production.id() + " : " + production.sort() + " { (s" + state.id() + ")");
+            printer.println("p" + production.id() + " : " + production.lhs() + " { (s" + state.id() + ")");
         if(isAmbiguous()) {
             printer.indent(1);
             printer.println("amb[");

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/IParserObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/IParserObserver.java
@@ -73,10 +73,15 @@ public interface IParserObserver
         /** The parse node is broken down because no actions are available for the grammar production of this node. */
         NO_ACTIONS("no actions for this parse node"),
         /**
-         * The parse node is broken down because it stores no state, i.e. it was created during a non-deterministic
+         * The parse node is broken down because it stores no state, i.e., it was created during a non-deterministic
          * phase of parsing.
          */
         NON_DETERMINISTIC("parse node was created while parse was non-deterministic"),
+        /**
+         * The parse node is broken down because it was temporary, i.e., it was created during ProcessUpdates to store
+         * changed children.
+         */
+        TEMPORARY("parse node was created as temporary node in ProcessUpdates"),
         /** The parse node is broken down because it stores a different state than the current top of the stack. */
         WRONG_STATE("parse node was created in a different parse state");
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/IParserObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/IParserObserver.java
@@ -70,13 +70,14 @@ public interface IParserObserver
     }
 
     enum BreakdownReason {
+        /**
+         * The parse node is broken down because it is irreusable.
+         * A parse node is irreusable when it stores no state,
+         * which happens when it is created during a non-deterministic phase of parsing.
+         */
+        IRREUSABLE("parse node was irreusable, i.e., created while parse was non-deterministic"),
         /** The parse node is broken down because no actions are available for the grammar production of this node. */
         NO_ACTIONS("no actions for this parse node"),
-        /**
-         * The parse node is broken down because it stores no state, i.e., it was created during a non-deterministic
-         * phase of parsing.
-         */
-        NON_DETERMINISTIC("parse node was created while parse was non-deterministic"),
         /**
          * The parse node is broken down because it was temporary, i.e., it was created during ProcessUpdates to store
          * changed children.


### PR DESCRIPTION
In order to make the incremental parsing measurements fit in the framework of the existing measurements, I had to add type parameters to several classes, similar to the benchmark classes.
To make things a bit cleaner, I lifted `JSGLR2Measurements.Config` to its own class file.

Besides the incremental parsing measurements, I also made some small changes, which you can find back in the commit log and the diff.

The results of the measurements are displayed on the [evaluation website](https://www.spoofax.dev/jsglr2evaluation-site/2021-03-02%2015:51/index.html) and converted to LaTeX tables in metaborg/jsglr2evaluation#7. 