### PR TITLE
ISGLR: The final sync

### DIFF
--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/BaseTest.java
@@ -295,7 +295,11 @@ public abstract class BaseTest implements WithParseTable {
 
         String[] expectedOutputAstStrings = new String[inputs.length];
         for(int i = 0; i < inputs.length; i++) {
-            expectedOutputAstStrings[i] = batchJSGLR2.parse(inputs[i]).toString();
+            JSGLR2Result<IStrategoTerm> result = batchJSGLR2.parseResult(inputs[i]);
+            int finalI = i;
+            assertTrue(result.isSuccess(), () -> "Batch parse for version " + finalI + " failed:\n"
+                + ((JSGLR2Failure<IStrategoTerm>) result).parseFailure.exception());
+            expectedOutputAstStrings[i] = ((JSGLR2Success<IStrategoTerm>) result).ast.toString();
         }
 
         return testIncrementalSuccessByExpansions(inputs, expectedOutputAstStrings);

--- a/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/incremental/IncrementalSGLRThesisExampleTest.java
+++ b/org.spoofax.jsglr2.integrationtest/src/test/java/org/spoofax/jsglr2/integrationtest/incremental/IncrementalSGLRThesisExampleTest.java
@@ -202,6 +202,10 @@ public class IncrementalSGLRThesisExampleTest extends BaseTestWithSdf3ParseTable
         if(parseForest instanceof IParseNode) {
             IParseNode<?, ?> parseNode = (IParseNode<?, ?>) parseForest;
             IProduction production = parseNode.production();
+            IParseForest parent = ids.keySet().stream()
+                .filter(n -> n instanceof IParseNode && Arrays
+                    .stream(((IParseNode<?, ?>) n).getFirstDerivation().parseForests()).anyMatch(c -> c == parseForest))
+                .findFirst().orElse(null);
             System.out.print("node" + (id > originalSize ? "[new]" : "") + " (" + id + ") {"
                 + (production == null ? ""
                     : ((ParseTableProduction) production).getProduction().leftHand() + (production.constructor() == null
@@ -214,8 +218,8 @@ public class IncrementalSGLRThesisExampleTest extends BaseTestWithSdf3ParseTable
                 System.out.print(" ");
             for(IParseForest child : children) {
                 printIndent(indent);
-                String opt = isExp(child) ? "[level distance=6em]"
-                    : (isExp(parseForest)) ? "[level distance=3em]" : id == 50 ? "[sibling distance=4em]" : "";
+                String opt = isExp(parseForest) ? "[level distance=6em]"
+                    : isExp(parent) ? "[level distance=3em]" : id == 50 ? "[sibling distance=4em]" : "";
                 System.out.print("child" + opt + " { ");
                 printLaTeX(child, ids, originalSize, indent + 8);
                 System.out.println("}");
@@ -365,7 +369,7 @@ public class IncrementalSGLRThesisExampleTest extends BaseTestWithSdf3ParseTable
         System.out.println();
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     static class ShiftReduceBreakdownObserver implements IParserObserver {
         @Override public void forActorStacks(IForActorStacks forActorStacks) {
             System.out.println("Starting parse round with stacks\n[" + Iterables2.stream(forActorStacks)

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurement.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurement.java
@@ -7,5 +7,5 @@ public enum IncrementalParsingMeasurement {
     characterNodes, characterNodesReused,
 
     createCharacterNode, createParseNode, shiftCharacterNode, shiftParseNode, //
-    breakDowns, breakDownIrreusable, breakDownNoActions, breakDownTemporary, breakDownWrongState
+    breakDowns, breakDownHasChange, breakDownIrreusable, breakDownNoActions, breakDownTemporary, breakDownWrongState
 }

--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/incremental/IncrementalParsingMeasurements.java
@@ -1,6 +1,7 @@
 package org.spoofax.jsglr2.measure.incremental;
 
 import static org.spoofax.jsglr2.measure.incremental.IncrementalParsingMeasurement.*;
+import static org.spoofax.jsglr2.parser.observing.IParserObserver.BreakdownReason;
 
 import java.io.IOException;
 import java.util.*;
@@ -27,7 +28,6 @@ import org.spoofax.jsglr2.parseforest.IParseNode;
 import org.spoofax.jsglr2.parser.AbstractParseState;
 import org.spoofax.jsglr2.parser.IObservableParser;
 import org.spoofax.jsglr2.parser.ParserVariant;
-import org.spoofax.jsglr2.parser.observing.IParserObserver;
 import org.spoofax.jsglr2.parser.result.ParseFailure;
 import org.spoofax.jsglr2.parser.result.ParseResult;
 import org.spoofax.jsglr2.parser.result.ParseSuccess;
@@ -131,14 +131,16 @@ public class IncrementalParsingMeasurements extends Measurements<String[], Incre
                         return measureObserver.shiftNode;
                     case breakDowns:
                         return measureObserver.breakdown.values().stream().mapToLong(l -> l).sum();
+                    case breakDownHasChange:
+                        return measureObserver.breakdown.getOrDefault(BreakdownReason.HAS_CHANGE, 0L);
                     case breakDownIrreusable:
-                        return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.IRREUSABLE, 0L);
+                        return measureObserver.breakdown.getOrDefault(BreakdownReason.IRREUSABLE, 0L);
                     case breakDownNoActions:
-                        return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.NO_ACTIONS, 0L);
+                        return measureObserver.breakdown.getOrDefault(BreakdownReason.NO_ACTIONS, 0L);
                     case breakDownTemporary:
-                        return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.TEMPORARY, 0L);
+                        return measureObserver.breakdown.getOrDefault(BreakdownReason.TEMPORARY, 0L);
                     case breakDownWrongState:
-                        return measureObserver.breakdown.getOrDefault(IParserObserver.BreakdownReason.WRONG_STATE, 0L);
+                        return measureObserver.breakdown.getOrDefault(BreakdownReason.WRONG_STATE, 0L);
                     default:
                         return -1L;
                 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/AbstractIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/AbstractIncrementalInputStack.java
@@ -57,19 +57,17 @@ public abstract class AbstractIncrementalInputStack extends AbstractPreprocessin
     static IncrementalInputStackFactory<IIncrementalInputStack> factoryBuilder(IStringDiff diff,
         Function4<String, String, IncrementalParseForest, List<EditorUpdate>, IIncrementalInputStack> constructor) {
         return (inputString, previousInput, previousResult) -> {
-            if(previousInput != null && previousResult != null) {
-                List<EditorUpdate> editorUpdates = diff.diff(previousInput, inputString);
+            if(previousInput == null || previousResult == null)
+                return new StringIncrementalInputStack(inputString);
 
-                // Optimization: if everything is deleted/replaced, then start a batch parse
-                if(editorUpdates.size() == 1 && editorUpdates.get(0).deletedStart == 0
-                    && editorUpdates.get(0).deletedEnd == previousResult.width()) {
-                    return new StringIncrementalInputStack(inputString);
-                }
+            List<EditorUpdate> editorUpdates = diff.diff(previousInput, inputString);
 
-                return constructor.apply(inputString, previousInput, previousResult, editorUpdates);
-            }
+            // Optimization: if everything is deleted/replaced, then start a batch parse
+            if(editorUpdates.size() == 1 && editorUpdates.get(0).deletedStart == 0
+                && editorUpdates.get(0).deletedEnd == previousResult.width())
+                return new StringIncrementalInputStack(inputString);
 
-            return new StringIncrementalInputStack(inputString);
+            return constructor.apply(inputString, previousInput, previousResult, editorUpdates);
         };
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/AbstractPreprocessingIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/AbstractPreprocessingIncrementalInputStack.java
@@ -64,18 +64,17 @@ public abstract class AbstractPreprocessingIncrementalInputStack extends Abstrac
         if(current.isTerminal())
             return;
 
+        stack.pop(); // always pop last lookahead, whether it has children or not
+
         if(current instanceof IncrementalSkippedNode) {
             // Break down a skipped node by explicitly instantiating character nodes for the skipped part
-            stack.pop();
             pushCharactersToStack(inputString.substring(currentOffset, currentOffset + current.width()));
-            return;
-        }
-
-        stack.pop(); // always pop last lookahead, whether it has children or not
-        IncrementalParseForest[] children = ((IncrementalParseNode) current).getFirstDerivation().parseForests();
-        // Push all children to stack in reverse order
-        for(int i = children.length - 1; i >= 0; i--) {
-            stack.push(children[i]);
+        } else {
+            IncrementalParseForest[] children = ((IncrementalParseNode) current).getFirstDerivation().parseForests();
+            // Push all children to stack in reverse order
+            for(int i = children.length - 1; i >= 0; i--) {
+                stack.push(children[i]);
+            }
         }
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/AbstractPreprocessingIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/AbstractPreprocessingIncrementalInputStack.java
@@ -10,6 +10,7 @@ import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalSkippedNode;
 import org.spoofax.jsglr2.parser.AbstractParseState;
+import org.spoofax.jsglr2.parser.observing.IParserObserver.BreakdownReason;
 import org.spoofax.jsglr2.stack.IStackNode;
 
 /**
@@ -56,7 +57,7 @@ public abstract class AbstractPreprocessingIncrementalInputStack extends Abstrac
 
     @Override public abstract AbstractPreprocessingIncrementalInputStack clone();
 
-    @Override public void breakDown() {
+    @Override public void breakDown(BreakdownReason breakdownReason) {
         if(stack.isEmpty())
             return;
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/EagerPreprocessingIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/EagerPreprocessingIncrementalInputStack.java
@@ -20,7 +20,7 @@ public class EagerPreprocessingIncrementalInputStack extends AbstractPreprocessi
     public static <StackNode extends IStackNode, ParseState extends AbstractParseState<IIncrementalInputStack, StackNode> & IIncrementalParseState>
         IncrementalInputStackFactory<IIncrementalInputStack>
         factory(IStringDiff diff, ProcessUpdates<StackNode, ParseState> processUpdates) {
-        return (inputString, previousInput, previousResult) -> new EagerPreprocessingIncrementalInputStack(
+        return (inputString, previousInput, previousResult, observing) -> new EagerPreprocessingIncrementalInputStack(
             preProcessParseForest(processUpdates, diff, inputString, previousInput, previousResult), inputString);
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/IIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/IIncrementalInputStack.java
@@ -2,11 +2,12 @@ package org.spoofax.jsglr2.inputstack.incremental;
 
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
 import org.spoofax.jsglr2.inputstack.IInputStack;
+import org.spoofax.jsglr2.parser.observing.IParserObserver.BreakdownReason;
 
 public interface IIncrementalInputStack extends IInputStack {
     IncrementalParseForest getNode();
 
-    void breakDown();
+    void breakDown(BreakdownReason breakdownReason);
 
     /** Returns whether the lookahead of the node returned by {@link #getNode()} is unchanged. */
     boolean lookaheadIsUnchanged();

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/IncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/IncrementalInputStack.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.spoofax.jsglr2.incremental.EditorUpdate;
 import org.spoofax.jsglr2.incremental.diff.IStringDiff;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.parser.observing.ParserObserving;
 
 public class IncrementalInputStack extends AbstractIncrementalInputStack {
 
@@ -13,8 +14,8 @@ public class IncrementalInputStack extends AbstractIncrementalInputStack {
     }
 
     public IncrementalInputStack(String input, String previousInput, IncrementalParseForest previousResult,
-        List<EditorUpdate> editorUpdates) {
-        super(input, previousInput, previousResult, editorUpdates);
+        List<EditorUpdate> editorUpdates, ParserObserving<?, ?, ?, ?, ?> observing) {
+        super(input, previousInput, previousResult, editorUpdates, observing);
     }
 
     public static IncrementalInputStackFactory<IIncrementalInputStack> factory(IStringDiff diff) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/IncrementalInputStackFactory.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/IncrementalInputStackFactory.java
@@ -1,9 +1,11 @@
 package org.spoofax.jsglr2.inputstack.incremental;
 
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.parser.observing.ParserObserving;
 
 public interface IncrementalInputStackFactory<InputStack extends IIncrementalInputStack> {
 
-    InputStack get(String inputString, String previousInput, IncrementalParseForest previousResult);
+    InputStack get(String inputString, String previousInput, IncrementalParseForest previousResult,
+        ParserObserving observing);
 
 }

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LazyPreprocessingIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LazyPreprocessingIncrementalInputStack.java
@@ -10,6 +10,7 @@ import org.spoofax.jsglr2.incremental.diff.IStringDiff;
 import org.spoofax.jsglr2.incremental.diff.ProcessUpdates;
 import org.spoofax.jsglr2.incremental.parseforest.*;
 import org.spoofax.jsglr2.parser.AbstractParseState;
+import org.spoofax.jsglr2.parser.observing.IParserObserver.BreakdownReason;
 import org.spoofax.jsglr2.stack.IStackNode;
 
 public class LazyPreprocessingIncrementalInputStack extends AbstractInputStack implements IIncrementalInputStack {
@@ -35,7 +36,7 @@ public class LazyPreprocessingIncrementalInputStack extends AbstractInputStack i
     public static <StackNode extends IStackNode, ParseState extends AbstractParseState<IIncrementalInputStack, StackNode> & IIncrementalParseState>
         IncrementalInputStackFactory<IIncrementalInputStack>
         factory(IStringDiff diff, ProcessUpdates<StackNode, ParseState> processUpdates) {
-        return (inputString, previousInput, previousResult) -> new LazyPreprocessingIncrementalInputStack(
+        return (inputString, previousInput, previousResult, observing) -> new LazyPreprocessingIncrementalInputStack(
             preProcessParseForest(processUpdates, diff, inputString, previousInput, previousResult), inputString);
     }
 
@@ -55,7 +56,7 @@ public class LazyPreprocessingIncrementalInputStack extends AbstractInputStack i
         return last;
     }
 
-    @Override public void breakDown() {
+    @Override public void breakDown(BreakdownReason breakdownReason) {
         if(stack.isEmpty())
             last = null;
         if(last == null || last.isTerminal())

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LinkedIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LinkedIncrementalInputStack.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.spoofax.jsglr2.incremental.EditorUpdate;
 import org.spoofax.jsglr2.incremental.diff.IStringDiff;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.parser.observing.ParserObserving;
 
 public class LinkedIncrementalInputStack extends AbstractIncrementalInputStack {
 
@@ -13,8 +14,8 @@ public class LinkedIncrementalInputStack extends AbstractIncrementalInputStack {
     }
 
     public LinkedIncrementalInputStack(String input, String previousInput, IncrementalParseForest previousResult,
-        List<EditorUpdate> editorUpdates) {
-        super(input, previousInput, previousResult, editorUpdates);
+        List<EditorUpdate> editorUpdates, ParserObserving<?, ?, ?, ?, ?> observing) {
+        super(input, previousInput, previousResult, editorUpdates, observing);
     }
 
     public static IncrementalInputStackFactory<IIncrementalInputStack> factory(IStringDiff diff) {

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LinkedPreprocessingIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/LinkedPreprocessingIncrementalInputStack.java
@@ -4,7 +4,6 @@ import org.spoofax.jsglr2.incremental.IIncrementalParseState;
 import org.spoofax.jsglr2.incremental.diff.IStringDiff;
 import org.spoofax.jsglr2.incremental.diff.ProcessUpdates;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
-import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 import org.spoofax.jsglr2.parser.AbstractParseState;
 import org.spoofax.jsglr2.stack.IStackNode;
 
@@ -25,7 +24,7 @@ public class LinkedPreprocessingIncrementalInputStack extends AbstractPreprocess
     public static <StackNode extends IStackNode, ParseState extends AbstractParseState<IIncrementalInputStack, StackNode> & IIncrementalParseState>
         IncrementalInputStackFactory<IIncrementalInputStack>
         factory(IStringDiff diff, ProcessUpdates<StackNode, ParseState> processUpdates) {
-        return (inputString, previousInput, previousResult) -> new LinkedPreprocessingIncrementalInputStack(
+        return (inputString, previousInput, previousResult, observing) -> new LinkedPreprocessingIncrementalInputStack(
             preProcessParseForest(processUpdates, diff, inputString, previousInput, previousResult), inputString);
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/StringIncrementalInputStack.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/inputstack/incremental/StringIncrementalInputStack.java
@@ -2,6 +2,7 @@ package org.spoofax.jsglr2.inputstack.incremental;
 
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
+import org.spoofax.jsglr2.parser.observing.IParserObserver.BreakdownReason;
 
 /**
  * An incremental input stack that does not have a previous parse tree, but just an input string.<br>
@@ -35,7 +36,7 @@ public class StringIncrementalInputStack extends AbstractInputStack implements I
         return currentNode;
     }
 
-    @Override public void breakDown() {
+    @Override public void breakDown(BreakdownReason breakdownReason) {
         // Nothing to do, character nodes cannot be broken down
     }
 

--- a/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/IParserObserver.java
+++ b/org.spoofax.jsglr2/src/main/java/org/spoofax/jsglr2/parser/observing/IParserObserver.java
@@ -70,9 +70,10 @@ public interface IParserObserver
     }
 
     enum BreakdownReason {
+        /** The parse node is broken down because it contains a change from the diff. */
+        HAS_CHANGE("parse node contains a change"),
         /**
-         * The parse node is broken down because it is irreusable.
-         * A parse node is irreusable when it stores no state,
+         * The parse node is broken down because it is irreusable. A parse node is irreusable when it stores no state,
          * which happens when it is created during a non-deterministic phase of parsing.
          */
         IRREUSABLE("parse node was irreusable, i.e., created while parse was non-deterministic"),

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/AbstractPreprocessingIncrementalInputStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/AbstractPreprocessingIncrementalInputStackTest.java
@@ -12,6 +12,7 @@ import org.spoofax.jsglr2.incremental.parseforest.IncrementalCharacterNode;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseForest;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalSkippedNode;
+import org.spoofax.jsglr2.parser.observing.IParserObserver.BreakdownReason;
 
 public abstract class AbstractPreprocessingIncrementalInputStackTest {
 
@@ -167,17 +168,17 @@ public abstract class AbstractPreprocessingIncrementalInputStackTest {
         IncrementalParseNode parseNode2 = new IncrementalParseNode(node3, node4);
         IncrementalParseNode root = new IncrementalParseNode(parseNode1, parseNode2);
 
-        TestTuple[] actions =
-            new TestTuple[] { new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, parseNode1),
-                new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node1),
-                new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node1),
-                new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertPopLookahead, node2),
-                new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node2),
-                new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertPopLookahead, parseNode2),
-                new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node3),
-                new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node3),
-                new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertPopLookahead, node4),
-                new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node4) };
+        TestTuple[] actions = new TestTuple[] {
+            new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, parseNode1),
+            new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node1),
+            new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node1),
+            new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertPopLookahead, node2),
+            new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node2),
+            new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertPopLookahead, parseNode2),
+            new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node3),
+            new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node3),
+            new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertPopLookahead, node4),
+            new TestTuple(AbstractPreprocessingIncrementalInputStackTest::assertLeftBreakdown, node4) };
 
         IIncrementalInputStack original = getStack(root);
         IIncrementalInputStack[] clones = new IIncrementalInputStack[actions.length];
@@ -231,12 +232,12 @@ public abstract class AbstractPreprocessingIncrementalInputStackTest {
     }
 
     protected static void assertLeftBreakdown(IncrementalParseForest forest, IIncrementalInputStack stack) {
-        stack.breakDown();
+        stack.breakDown(BreakdownReason.HAS_CHANGE);
         assertSame(forest, stack.getNode());
     }
 
     protected static void assertLeftBreakdown(int character, IIncrementalInputStack stack) {
-        stack.breakDown();
+        stack.breakDown(BreakdownReason.HAS_CHANGE);
         assertEquals(character, ((IncrementalCharacterNode) stack.getNode()).character());
     }
 

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/IncrementalInputStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/IncrementalInputStackTest.java
@@ -4,12 +4,14 @@ import java.util.Arrays;
 
 import org.spoofax.jsglr2.incremental.EditorUpdate;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.parser.observing.ParserObserving;
 
 public class IncrementalInputStackTest extends AbstractIncrementalInputStackTest {
 
     @Override protected IIncrementalInputStack getStack(String inputString, String previousInput,
         IncrementalParseNode previousResult, EditorUpdate... editorUpdates) {
-        return new IncrementalInputStack(inputString, previousInput, previousResult, Arrays.asList(editorUpdates));
+        return new IncrementalInputStack(inputString, previousInput, previousResult, Arrays.asList(editorUpdates),
+            new ParserObserving<>());
     }
 
 }

--- a/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/LinkedIncrementalInputStackTest.java
+++ b/org.spoofax.jsglr2/src/test/java/org/spoofax/jsglr2/inputstack/incremental/LinkedIncrementalInputStackTest.java
@@ -4,13 +4,14 @@ import java.util.Arrays;
 
 import org.spoofax.jsglr2.incremental.EditorUpdate;
 import org.spoofax.jsglr2.incremental.parseforest.IncrementalParseNode;
+import org.spoofax.jsglr2.parser.observing.ParserObserving;
 
 public class LinkedIncrementalInputStackTest extends AbstractIncrementalInputStackTest {
 
     @Override protected IIncrementalInputStack getStack(String inputString, String previousInput,
         IncrementalParseNode previousResult, EditorUpdate... editorUpdates) {
-        return new LinkedIncrementalInputStack(inputString, previousInput, previousResult,
-            Arrays.asList(editorUpdates));
+        return new LinkedIncrementalInputStack(inputString, previousInput, previousResult, Arrays.asList(editorUpdates),
+            new ParserObserving<>());
     }
 
 }


### PR DESCRIPTION
To be merged together with metaborg/jsglr2evaluation#12.

I already had these commits ready before my graduation, but the evaluation scripts still needed to be cleaned up after that. But this is done now :smile: 

The commits should be reviewable one-by-one. Most changes are in the tests and measurements, with the only real change in the parser itself being the addition of a `breakdownReason` parameter to the `*InputStack.breakDown` method and the reordering of some statements. All in all, no algorithmic changes :slightly_smiling_face: 