### PR TITLE
Correctly store amount of actions in parse table measurements

### DIFF
--- a/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsetable/MeasureStateFactory.java
+++ b/org.spoofax.jsglr2.measure/src/main/java/org/spoofax/jsglr2/measure/parsetable/MeasureStateFactory.java
@@ -60,7 +60,7 @@ public class MeasureStateFactory extends StateFactory {
                 Math.max(actionsPerDisjointSortedRangeMax, actionsForSortedDisjointRange.actions.length);
         }
 
-        actionsCount += actionsCount;
+        this.actionsCount += actionsCount;
 
         gotosPerStateMax = Math.max(gotosPerStateMax, gotos.length);
         actionGroupsPerStateMax = Math.max(actionGroupsPerStateMax, actionsPerCharacterClasses.length);


### PR DESCRIPTION
This PR fixes a bug that caused the amount of actions and max. amount of actions per state to be reported incorrectly by the parse table measurements.

I tested the change on my local machine, before the measurements were as follows:

![measurements-before](https://user-images.githubusercontent.com/25172452/194095833-10137e1e-467a-463b-86a0-1c0feb763c60.png)

And now it is correct:

![measurements-after](https://user-images.githubusercontent.com/25172452/194096193-336c3497-d4e7-46c9-a144-d5784253af66.png)
